### PR TITLE
1.5.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
       - name: Build and test
         run: ./gradlew check --console=plain

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
 
       - name: Build and test

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -28,6 +28,7 @@ jobs:
           echo "value=$(./gradlew -q properties | grep ^version: | awk '{print $2}')" >> $GITHUB_OUTPUT
 
       - name: Publish snapshot to Maven Central
+        if: endsWith(steps.version.outputs.value, '-SNAPSHOT')
         run: |
           echo "${{ secrets.GPG_SECRET_KEY }}" | base64 -d | gpg --batch --import
           ASCII_KEY=$(gpg --batch --yes --pinentry-mode loopback \

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,37 @@
+name: Snapshot
+
+on:
+  push:
+    branches: [ 'release/**' ]
+
+permissions:
+  contents: read
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: 11
+          distribution: temurin
+
+      - name: Build and test
+        run: ./gradlew check --console=plain
+
+      - name: Publish snapshot to Maven Central
+        run: |
+          echo "${{ secrets.GPG_SECRET_KEY }}" | base64 -d | gpg --batch --import
+          ASCII_KEY=$(gpg --batch --yes --pinentry-mode loopback \
+            --passphrase "${{ secrets.GPG_PASSPHRASE }}" \
+            --armor --export-secret-keys "${{ secrets.GPG_KEY_ID }}")
+          export ORG_GRADLE_PROJECT_signingInMemoryKey="$ASCII_KEY"
+          ./gradlew publishToMavenCentral --console=plain
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.GPG_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
 
       - name: Build and test

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -22,6 +22,11 @@ jobs:
       - name: Build and test
         run: ./gradlew check --console=plain
 
+      - name: Read version
+        id: version
+        run: |
+          echo "value=$(./gradlew -q properties | grep ^version: | awk '{print $2}')" >> $GITHUB_OUTPUT
+
       - name: Publish snapshot to Maven Central
         run: |
           echo "${{ secrets.GPG_SECRET_KEY }}" | base64 -d | gpg --batch --import

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -14,7 +14,7 @@
 
 | Library | Version |
 |---------|---------|
-| jackson-dataformat-spreadsheet | 1.4.1 |
+| jackson-dataformat-spreadsheet | 1.5.0 |
 | Apache POI | 5.5.1 |
 | FastExcel | 0.20.0 |
 | Fesod | 2.0.1-incubating |

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -57,13 +57,13 @@ But this is not a POI replacement. POI types (`Sheet`, `Workbook`) are first-cla
 <dependency>
     <groupId>io.github.scndry</groupId>
     <artifactId>jackson-dataformat-spreadsheet</artifactId>
-    <version>1.4.1</version>
+    <version>1.5.0</version>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-implementation "io.github.scndry:jackson-dataformat-spreadsheet:1.4.1"
+implementation "io.github.scndry:jackson-dataformat-spreadsheet:1.5.0"
 ```
 
 ## Quick Start

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -656,11 +656,34 @@ Operators accept typed values (numeric, boolean, string, date) or `Formula` for 
 
 Operators: `greaterThan`, `greaterThanOrEqual`, `lessThan`, `lessThanOrEqual`, `equalTo`, `notEqualTo`, `between`, `notBetween`. Equality also accepts `boolean` and `String`.
 
-Operand types: `Number` (long, double, int, BigDecimal — autoboxed), `boolean`, `String` (equality only — auto-escaped), `LocalDate`, `LocalDateTime`, `Date`, `Calendar`, `Formula`.
+Operand types: any `Number` (`int`, `long`, `double`, `float`, `BigDecimal`, etc. — primitives are autoboxed), `boolean`, `String` (equality only — auto-escaped to Excel string literal), `LocalDate`, `LocalDateTime`, `Date`, `Calendar`, `Formula`.
+
+#### Date and time precision
+
+Dates emit as Excel formula expressions:
+
+| Type | Formula |
+|------|---------|
+| `LocalDate` | `DATE(y,m,d)` |
+| `LocalDateTime` | `DATE(y,m,d)+TIME(h,m,s)` — sub-second truncated |
+| `Date` | `DATE(y,m,d)+TIME(h,m,s)` — converted via system default timezone |
+| `Calendar` | `DATE(y,m,d)+TIME(h,m,s)` — converted via Calendar's timezone |
+
+Prefer `LocalDate` / `LocalDateTime` for deterministic CF rules. `Date` carries a system-timezone dependence; the resulting formula varies with the JVM `ZoneId.systemDefault()`.
+
+#### `cellIs` vs `expression`
+
+| | `cellIs` operators | `expression` |
+|---|---|---|
+| Compares | The cell against operand(s) | Arbitrary boolean formula |
+| Example | `.column("price").greaterThan(100)` | `.column("price").expression("$E1<$F1")` |
+| Use when | Direct comparison fits | Need cross-cell logic, `AND`/`OR`, `ISBLANK`, etc. |
+
+`expression(formula)` is passed verbatim to POI; do not include a leading `=`.
+
+#### Formula escape
 
 `Formula.of(text)` is a power-user escape — the text is emitted verbatim into the OOXML `<formula>` element. The library does not validate Excel syntax. `Formula.column(name)` resolves the schema column name to a row-relative reference (`$<col><dataStartRow>`) at write time, so Excel auto-shifts per cell in the formatting range.
-
-`expression(formula)` creates a `type="expression"` rule where the entire formula must return TRUE/FALSE; useful for conditions that don't fit `cellIs` operators.
 
 Style → DXF: fill, font, and border only. Alignment and wrap-text are silently skipped.
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -618,7 +618,10 @@ SpreadsheetMapper mapper = SpreadsheetMapper.builder()
         .freezePane(0, 1)
         .autoFilter()
         .conditionalFormatting()
-            .column("score").greaterThanOrEqual("80").style("highlight").end())
+            .column("score")
+            .greaterThanOrEqual(80)
+            .style("highlight")
+            .end())
     .build();
 ```
 
@@ -628,13 +631,36 @@ SpreadsheetMapper mapper = SpreadsheetMapper.builder()
 
 `column(name)` matches `@DataColumn(value)`, the field name, or `@JsonAlias`. `style(name)` matches a `cellStyle(name)` in `StylesBuilder`. Both resolve at write time — typos throw `IllegalArgumentException` listing the available names.
 
+Operators accept typed values (numeric, boolean, string, date) or `Formula` for cell references and Excel expressions. String operands are auto-quoted; dates emit as `DATE(y,m,d)+TIME(h,m,s)`.
+
 ```java
-.conditionalFormatting().column("score").greaterThan("90").style("good").end()
-.conditionalFormatting().column("status").equalTo("\"URGENT\"").style("warn").end()  // text: quote the value
-.conditionalFormatting().column("price").between("100", "500").style("warn").end()
+// Typed primitives
+.conditionalFormatting().column("score").greaterThan(90).style("good").end()
+.conditionalFormatting().column("price").between(100, 500).style("warn").end()
+.conditionalFormatting().column("status").equalTo("URGENT").style("warn").end()
+.conditionalFormatting().column("active").equalTo(true).style("info").end()
+
+// Date types — LocalDate, LocalDateTime, Date, Calendar all supported
+.conditionalFormatting().column("createdAt").greaterThan(LocalDate.of(2026, 1, 1)).style("recent").end()
+
+// Cell reference / function — Formula.of for raw passthrough
+.conditionalFormatting().column("price").greaterThan(Formula.of("$D$1")).style("warn").end()
+.conditionalFormatting().column("price").greaterThan(Formula.of("AVERAGE($B$2:$B$100)")).style("aboveAvg").end()
+
+// Schema-aware cross-column reference — row-relative, schema-safe
+.conditionalFormatting().column("price").greaterThan(Formula.column("minPrice")).style("warn").end()
+
+// Arbitrary boolean expression rule (type="expression")
+.conditionalFormatting().column("score").expression("AND($A1>0, $B1<100)").style("warn").end()
 ```
 
-Operators: `greaterThan`, `greaterThanOrEqual`, `lessThan`, `lessThanOrEqual`, `equalTo`, `notEqualTo`, `between`, `notBetween`.
+Operators: `greaterThan`, `greaterThanOrEqual`, `lessThan`, `lessThanOrEqual`, `equalTo`, `notEqualTo`, `between`, `notBetween`. Equality also accepts `boolean` and `String`.
+
+Operand types: `Number` (long, double, int, BigDecimal — autoboxed), `boolean`, `String` (equality only — auto-escaped), `LocalDate`, `LocalDateTime`, `Date`, `Calendar`, `Formula`.
+
+`Formula.of(text)` is a power-user escape — the text is emitted verbatim into the OOXML `<formula>` element. The library does not validate Excel syntax. `Formula.column(name)` resolves the schema column name to a row-relative reference (`$<col><dataStartRow>`) at write time, so Excel auto-shifts per cell in the formatting range.
+
+`expression(formula)` creates a `type="expression"` rule where the entire formula must return TRUE/FALSE; useful for conditions that don't fit `cellIs` operators.
 
 Style → DXF: fill, font, and border only. Alignment and wrap-text are silently skipped.
 

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ Available on Maven Central:
 <dependency>
     <groupId>io.github.scndry</groupId>
     <artifactId>jackson-dataformat-spreadsheet</artifactId>
-    <version>1.4.1</version>
+    <version>1.5.0</version>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-implementation "io.github.scndry:jackson-dataformat-spreadsheet:1.4.1"
+implementation "io.github.scndry:jackson-dataformat-spreadsheet:1.5.0"
 ```
 
 ### Requirements
@@ -274,7 +274,7 @@ Fastest read and write throughput at 100K rows. 6x faster read than Apache POI. 
 XLSX (OOXML) and XLS (legacy). XLSX uses StAX streaming; XLS uses POI object model.
 
 **Q: Is it production-ready?**
-Yes. Version 1.4.1 on Maven Central. Java 8+, Jackson 2.14+, POI 4.1.1+. Listed as a [community data format module](https://github.com/FasterXML/jackson#data-format-modules) in the FasterXML jackson repository.
+Yes. Version 1.5.0 on Maven Central. Java 8+, Jackson 2.14+, POI 4.1.1+. Listed as a [community data format module](https://github.com/FasterXML/jackson#data-format-modules) in the FasterXML jackson repository.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,10 @@ SpreadsheetMapper mapper = SpreadsheetMapper.builder()
         .freezePane(0, 1)
         .autoFilter()
         .conditionalFormatting()
-            .column("score").greaterThanOrEqual("80").style("highlight").end())
+            .column("score")
+            .greaterThanOrEqual(80)
+            .style("highlight")
+            .end())
     .build();
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "io.github.scndry"
-version = "1.4.1"
+version = "1.5.0-SNAPSHOT"
 description = "Support for reading and writing Spreadsheet via Jackson abstractions."
 
 val title = "Jackson dataformat: Spreadsheet"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,6 @@
-import com.vanniktech.maven.publish.SonatypeHost
-
 plugins {
     id("java-library")
-    id("com.vanniktech.maven.publish") version "0.30.0"
+    id("com.vanniktech.maven.publish") version "0.36.0"
     id("jacoco")
     id("me.champeau.jmh") version "0.6.8"
 }
@@ -68,7 +66,7 @@ tasks.named<JavaCompile>("compileJmhJava") {
 }
 
 mavenPublishing {
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+    publishToMavenCentral()
     signAllPublications()
 
     pom {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "io.github.scndry"
-version = "1.5.0-SNAPSHOT"
+version = "1.5.0"
 description = "Support for reading and writing Spreadsheet via Jackson abstractions."
 
 val title = "Jackson dataformat: Spreadsheet"

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/grid/ConditionalFormattingRuleSpec.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/grid/ConditionalFormattingRuleSpec.java
@@ -1,5 +1,11 @@
 package io.github.scndry.jackson.dataformat.spreadsheet.schema.grid;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Calendar;
+import java.util.Date;
+
 import org.apache.poi.ss.usermodel.ComparisonOperator;
 
 /**
@@ -7,15 +13,26 @@ import org.apache.poi.ss.usermodel.ComparisonOperator;
  * References a column by name and a style by name (defined in
  * {@link io.github.scndry.jackson.dataformat.spreadsheet.schema.style.StylesBuilder}).
  *
+ * <p>Operands accept typed values (numeric, boolean, string, date) or
+ * {@link Formula} for cell references and arbitrary Excel formula expressions.
+ * String operands are auto-quoted for Excel string literal syntax.
+ *
  * @see GridConfigurer#conditionalFormatting()
  */
 public final class ConditionalFormattingRuleSpec {
 
+    enum Type { CELL_IS, EXPRESSION }
+
     private final GridConfigurer _parent;
     String _columnName;
+    Type _type;
+    // CELL_IS
     byte _operator;
-    String _formula1;
-    String _formula2;
+    Object _operand1;
+    Object _operand2;
+    // EXPRESSION
+    String _expression;
+
     String _styleName;
 
     ConditionalFormattingRuleSpec(final GridConfigurer parent) {
@@ -27,53 +44,246 @@ public final class ConditionalFormattingRuleSpec {
         return this;
     }
 
-    public ConditionalFormattingRuleSpec greaterThan(final String formula) {
-        _operator = ComparisonOperator.GT;
-        _formula1 = formula;
-        return this;
+    // ─── greaterThan ───────────────────────────────────────────────
+
+    public ConditionalFormattingRuleSpec greaterThan(final Number value) {
+        return _cellIs(ComparisonOperator.GT, _f(value));
     }
 
-    public ConditionalFormattingRuleSpec greaterThanOrEqual(final String formula) {
-        _operator = ComparisonOperator.GE;
-        _formula1 = formula;
-        return this;
+    public ConditionalFormattingRuleSpec greaterThan(final LocalDate value) {
+        return _cellIs(ComparisonOperator.GT, _f(value));
     }
 
-    public ConditionalFormattingRuleSpec lessThan(final String formula) {
-        _operator = ComparisonOperator.LT;
-        _formula1 = formula;
-        return this;
+    public ConditionalFormattingRuleSpec greaterThan(final LocalDateTime value) {
+        return _cellIs(ComparisonOperator.GT, _f(value));
     }
 
-    public ConditionalFormattingRuleSpec lessThanOrEqual(final String formula) {
-        _operator = ComparisonOperator.LE;
-        _formula1 = formula;
-        return this;
+    public ConditionalFormattingRuleSpec greaterThan(final Date value) {
+        return _cellIs(ComparisonOperator.GT, _f(value));
     }
 
-    public ConditionalFormattingRuleSpec equalTo(final String formula) {
-        _operator = ComparisonOperator.EQUAL;
-        _formula1 = formula;
-        return this;
+    public ConditionalFormattingRuleSpec greaterThan(final Calendar value) {
+        return _cellIs(ComparisonOperator.GT, _f(value));
     }
 
-    public ConditionalFormattingRuleSpec notEqualTo(final String formula) {
-        _operator = ComparisonOperator.NOT_EQUAL;
-        _formula1 = formula;
-        return this;
+    public ConditionalFormattingRuleSpec greaterThan(final Formula formula) {
+        return _cellIs(ComparisonOperator.GT, formula);
     }
 
-    public ConditionalFormattingRuleSpec between(final String formula1, final String formula2) {
-        _operator = ComparisonOperator.BETWEEN;
-        _formula1 = formula1;
-        _formula2 = formula2;
-        return this;
+    // ─── greaterThanOrEqual ────────────────────────────────────────
+
+    public ConditionalFormattingRuleSpec greaterThanOrEqual(final Number value) {
+        return _cellIs(ComparisonOperator.GE, _f(value));
     }
 
-    public ConditionalFormattingRuleSpec notBetween(final String formula1, final String formula2) {
-        _operator = ComparisonOperator.NOT_BETWEEN;
-        _formula1 = formula1;
-        _formula2 = formula2;
+    public ConditionalFormattingRuleSpec greaterThanOrEqual(final LocalDate value) {
+        return _cellIs(ComparisonOperator.GE, _f(value));
+    }
+
+    public ConditionalFormattingRuleSpec greaterThanOrEqual(final LocalDateTime value) {
+        return _cellIs(ComparisonOperator.GE, _f(value));
+    }
+
+    public ConditionalFormattingRuleSpec greaterThanOrEqual(final Date value) {
+        return _cellIs(ComparisonOperator.GE, _f(value));
+    }
+
+    public ConditionalFormattingRuleSpec greaterThanOrEqual(final Calendar value) {
+        return _cellIs(ComparisonOperator.GE, _f(value));
+    }
+
+    public ConditionalFormattingRuleSpec greaterThanOrEqual(final Formula formula) {
+        return _cellIs(ComparisonOperator.GE, formula);
+    }
+
+    // ─── lessThan ──────────────────────────────────────────────────
+
+    public ConditionalFormattingRuleSpec lessThan(final Number value) {
+        return _cellIs(ComparisonOperator.LT, _f(value));
+    }
+
+    public ConditionalFormattingRuleSpec lessThan(final LocalDate value) {
+        return _cellIs(ComparisonOperator.LT, _f(value));
+    }
+
+    public ConditionalFormattingRuleSpec lessThan(final LocalDateTime value) {
+        return _cellIs(ComparisonOperator.LT, _f(value));
+    }
+
+    public ConditionalFormattingRuleSpec lessThan(final Date value) {
+        return _cellIs(ComparisonOperator.LT, _f(value));
+    }
+
+    public ConditionalFormattingRuleSpec lessThan(final Calendar value) {
+        return _cellIs(ComparisonOperator.LT, _f(value));
+    }
+
+    public ConditionalFormattingRuleSpec lessThan(final Formula formula) {
+        return _cellIs(ComparisonOperator.LT, formula);
+    }
+
+    // ─── lessThanOrEqual ───────────────────────────────────────────
+
+    public ConditionalFormattingRuleSpec lessThanOrEqual(final Number value) {
+        return _cellIs(ComparisonOperator.LE, _f(value));
+    }
+
+    public ConditionalFormattingRuleSpec lessThanOrEqual(final LocalDate value) {
+        return _cellIs(ComparisonOperator.LE, _f(value));
+    }
+
+    public ConditionalFormattingRuleSpec lessThanOrEqual(final LocalDateTime value) {
+        return _cellIs(ComparisonOperator.LE, _f(value));
+    }
+
+    public ConditionalFormattingRuleSpec lessThanOrEqual(final Date value) {
+        return _cellIs(ComparisonOperator.LE, _f(value));
+    }
+
+    public ConditionalFormattingRuleSpec lessThanOrEqual(final Calendar value) {
+        return _cellIs(ComparisonOperator.LE, _f(value));
+    }
+
+    public ConditionalFormattingRuleSpec lessThanOrEqual(final Formula formula) {
+        return _cellIs(ComparisonOperator.LE, formula);
+    }
+
+    // ─── equalTo ───────────────────────────────────────────────────
+
+    public ConditionalFormattingRuleSpec equalTo(final Number value) {
+        return _cellIs(ComparisonOperator.EQUAL, _f(value));
+    }
+
+    public ConditionalFormattingRuleSpec equalTo(final boolean value) {
+        return _cellIs(ComparisonOperator.EQUAL, _f(value));
+    }
+
+    public ConditionalFormattingRuleSpec equalTo(final String value) {
+        return _cellIs(ComparisonOperator.EQUAL, _f(value));
+    }
+
+    public ConditionalFormattingRuleSpec equalTo(final LocalDate value) {
+        return _cellIs(ComparisonOperator.EQUAL, _f(value));
+    }
+
+    public ConditionalFormattingRuleSpec equalTo(final LocalDateTime value) {
+        return _cellIs(ComparisonOperator.EQUAL, _f(value));
+    }
+
+    public ConditionalFormattingRuleSpec equalTo(final Date value) {
+        return _cellIs(ComparisonOperator.EQUAL, _f(value));
+    }
+
+    public ConditionalFormattingRuleSpec equalTo(final Calendar value) {
+        return _cellIs(ComparisonOperator.EQUAL, _f(value));
+    }
+
+    public ConditionalFormattingRuleSpec equalTo(final Formula formula) {
+        return _cellIs(ComparisonOperator.EQUAL, formula);
+    }
+
+    // ─── notEqualTo ────────────────────────────────────────────────
+
+    public ConditionalFormattingRuleSpec notEqualTo(final Number value) {
+        return _cellIs(ComparisonOperator.NOT_EQUAL, _f(value));
+    }
+
+    public ConditionalFormattingRuleSpec notEqualTo(final boolean value) {
+        return _cellIs(ComparisonOperator.NOT_EQUAL, _f(value));
+    }
+
+    public ConditionalFormattingRuleSpec notEqualTo(final String value) {
+        return _cellIs(ComparisonOperator.NOT_EQUAL, _f(value));
+    }
+
+    public ConditionalFormattingRuleSpec notEqualTo(final LocalDate value) {
+        return _cellIs(ComparisonOperator.NOT_EQUAL, _f(value));
+    }
+
+    public ConditionalFormattingRuleSpec notEqualTo(final LocalDateTime value) {
+        return _cellIs(ComparisonOperator.NOT_EQUAL, _f(value));
+    }
+
+    public ConditionalFormattingRuleSpec notEqualTo(final Date value) {
+        return _cellIs(ComparisonOperator.NOT_EQUAL, _f(value));
+    }
+
+    public ConditionalFormattingRuleSpec notEqualTo(final Calendar value) {
+        return _cellIs(ComparisonOperator.NOT_EQUAL, _f(value));
+    }
+
+    public ConditionalFormattingRuleSpec notEqualTo(final Formula formula) {
+        return _cellIs(ComparisonOperator.NOT_EQUAL, formula);
+    }
+
+    // ─── between ───────────────────────────────────────────────────
+
+    public ConditionalFormattingRuleSpec between(final Number low, final Number high) {
+        return _cellIs(ComparisonOperator.BETWEEN, _f(low), _f(high));
+    }
+
+    public ConditionalFormattingRuleSpec between(final LocalDate low, final LocalDate high) {
+        return _cellIs(ComparisonOperator.BETWEEN, _f(low), _f(high));
+    }
+
+    public ConditionalFormattingRuleSpec between(final LocalDateTime low, final LocalDateTime high) {
+        return _cellIs(ComparisonOperator.BETWEEN, _f(low), _f(high));
+    }
+
+    public ConditionalFormattingRuleSpec between(final Date low, final Date high) {
+        return _cellIs(ComparisonOperator.BETWEEN, _f(low), _f(high));
+    }
+
+    public ConditionalFormattingRuleSpec between(final Calendar low, final Calendar high) {
+        return _cellIs(ComparisonOperator.BETWEEN, _f(low), _f(high));
+    }
+
+    public ConditionalFormattingRuleSpec between(final Formula low, final Formula high) {
+        return _cellIs(ComparisonOperator.BETWEEN, low, high);
+    }
+
+    // ─── notBetween ────────────────────────────────────────────────
+
+    public ConditionalFormattingRuleSpec notBetween(final Number low, final Number high) {
+        return _cellIs(ComparisonOperator.NOT_BETWEEN, _f(low), _f(high));
+    }
+
+    public ConditionalFormattingRuleSpec notBetween(final LocalDate low, final LocalDate high) {
+        return _cellIs(ComparisonOperator.NOT_BETWEEN, _f(low), _f(high));
+    }
+
+    public ConditionalFormattingRuleSpec notBetween(final LocalDateTime low, final LocalDateTime high) {
+        return _cellIs(ComparisonOperator.NOT_BETWEEN, _f(low), _f(high));
+    }
+
+    public ConditionalFormattingRuleSpec notBetween(final Date low, final Date high) {
+        return _cellIs(ComparisonOperator.NOT_BETWEEN, _f(low), _f(high));
+    }
+
+    public ConditionalFormattingRuleSpec notBetween(final Calendar low, final Calendar high) {
+        return _cellIs(ComparisonOperator.NOT_BETWEEN, _f(low), _f(high));
+    }
+
+    public ConditionalFormattingRuleSpec notBetween(final Formula low, final Formula high) {
+        return _cellIs(ComparisonOperator.NOT_BETWEEN, low, high);
+    }
+
+    // ─── expression rule (type="expression") ───────────────────────
+
+    /**
+     * Arbitrary boolean Excel formula evaluated per cell in the conditional formatting range.
+     * Maps to OOXML {@code <cfRule type="expression">}. The formula must return TRUE or FALSE.
+     *
+     * <pre>{@code
+     * .column("price").expression("=AND($A1>0, $B1<100)").style("warn")
+     * }</pre>
+     */
+    public ConditionalFormattingRuleSpec expression(final String formula) {
+        if (formula == null || formula.isEmpty()) {
+            throw new IllegalArgumentException("Expression formula must not be empty");
+        }
+        _type = Type.EXPRESSION;
+        _expression = formula;
         return this;
     }
 
@@ -86,13 +296,66 @@ public final class ConditionalFormattingRuleSpec {
         if (_columnName == null) {
             throw new IllegalStateException("column() must be called before end()");
         }
-        if (_formula1 == null) {
-            throw new IllegalStateException("A comparison method (greaterThan, equalTo, etc.) must be called before end()");
+        if (_type == null) {
+            throw new IllegalStateException(
+                    "A comparison method (greaterThan, equalTo, etc.) or expression() must be called before end()");
         }
         if (_styleName == null) {
             throw new IllegalStateException("style() must be called before end()");
         }
         _parent._addRule(this);
         return _parent;
+    }
+
+    private ConditionalFormattingRuleSpec _cellIs(final byte operator, final Object operand) {
+        _type = Type.CELL_IS;
+        _operator = operator;
+        _operand1 = operand;
+        _operand2 = null;
+        return this;
+    }
+
+    private ConditionalFormattingRuleSpec _cellIs(final byte operator, final Object low, final Object high) {
+        _type = Type.CELL_IS;
+        _operator = operator;
+        _operand1 = low;
+        _operand2 = high;
+        return this;
+    }
+
+    // ─── formatters ────────────────────────────────────────────────
+
+    private static String _f(final Number value) {
+        return value.toString();
+    }
+
+    private static String _f(final boolean value) {
+        return value ? "TRUE" : "FALSE";
+    }
+
+    private static String _f(final String value) {
+        // Excel string literal: surrounded by quotes; internal quotes doubled
+        return "\"" + value.replace("\"", "\"\"") + "\"";
+    }
+
+    private static String _f(final LocalDate value) {
+        return "DATE(" + value.getYear() + ","
+                + value.getMonthValue() + ","
+                + value.getDayOfMonth() + ")";
+    }
+
+    private static String _f(final LocalDateTime value) {
+        return _f(value.toLocalDate())
+                + "+TIME(" + value.getHour() + ","
+                + value.getMinute() + ","
+                + value.getSecond() + ")";
+    }
+
+    private static String _f(final Date value) {
+        return _f(LocalDateTime.ofInstant(value.toInstant(), ZoneId.systemDefault()));
+    }
+
+    private static String _f(final Calendar value) {
+        return _f(LocalDateTime.ofInstant(value.toInstant(), value.getTimeZone().toZoneId()));
     }
 }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/grid/Formula.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/grid/Formula.java
@@ -1,0 +1,62 @@
+package io.github.scndry.jackson.dataformat.spreadsheet.schema.grid;
+
+/**
+ * Operand reference for conditional formatting rules.
+ * Use {@link #of(String)} for raw Excel formula passthrough (cell references, functions, expressions).
+ * Use {@link #column(String)} for schema-aware row-relative references to another schema column.
+ *
+ * @see ConditionalFormattingRuleSpec
+ */
+public final class Formula {
+
+    enum Kind { OF, COLUMN }
+
+    private final Kind _kind;
+    private final String _value;
+
+    private Formula(final Kind kind, final String value) {
+        _kind = kind;
+        _value = value;
+    }
+
+    /**
+     * Raw Excel formula passthrough. The value is emitted verbatim into the OOXML
+     * {@code <formula>} element. The library does not validate or parse it.
+     *
+     * <pre>{@code
+     * Formula.of("$D$1")
+     * Formula.of("AVERAGE($B$2:$B$100)")
+     * Formula.of("$E1 * 0.9")
+     * }</pre>
+     */
+    public static Formula of(final String text) {
+        if (text == null || text.isEmpty()) {
+            throw new IllegalArgumentException("Formula text must not be empty");
+        }
+        return new Formula(Kind.OF, text);
+    }
+
+    /**
+     * Schema-aware row-relative reference to another column in the data grid.
+     * Resolved to {@code $<colLetter><dataStartRow>} at apply time, so Excel
+     * auto-shifts the row for each cell in the conditional formatting range.
+     *
+     * <pre>{@code
+     * .column("price").greaterThan(Formula.column("minPrice"))   // this row's price > this row's minPrice
+     * }</pre>
+     */
+    public static Formula column(final String name) {
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException("Column name must not be empty");
+        }
+        return new Formula(Kind.COLUMN, name);
+    }
+
+    Kind kind() {
+        return _kind;
+    }
+
+    String value() {
+        return _value;
+    }
+}

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/grid/GridConfigurer.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/grid/GridConfigurer.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.apache.poi.ss.SpreadsheetVersion;
 import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.ss.util.CellRangeAddress;
+import org.apache.poi.ss.util.CellReference;
 import org.apache.poi.xssf.usermodel.XSSFCellStyle;
 import org.apache.poi.xssf.usermodel.XSSFFont;
 
@@ -88,13 +89,40 @@ public final class GridConfigurer {
             if (cs == null) {
                 throw new IllegalArgumentException("Style '" + spec._styleName + "' not found");
             }
-            final ConditionalFormattingRule rule = spec._formula2 != null
-                    ? scf.createConditionalFormattingRule(spec._operator, spec._formula1, spec._formula2)
-                    : scf.createConditionalFormattingRule(spec._operator, spec._formula1);
+            final ConditionalFormattingRule rule;
+            if (spec._type == ConditionalFormattingRuleSpec.Type.EXPRESSION) {
+                rule = scf.createConditionalFormattingRule(spec._expression);
+            } else {
+                final String f1 = _resolveOperand(spec._operand1, schema);
+                final String f2 = spec._operand2 != null ? _resolveOperand(spec._operand2, schema) : null;
+                rule = f2 != null
+                        ? scf.createConditionalFormattingRule(spec._operator, f1, f2)
+                        : scf.createConditionalFormattingRule(spec._operator, f1);
+            }
             _applyCellStyleToDxf(rule, cs, wb);
             scf.addConditionalFormatting(
                     new CellRangeAddress[]{new CellRangeAddress(dataRow, endRow, colIndex, colIndex)}, rule);
         }
+    }
+
+    private static String _resolveOperand(final Object operand, final SpreadsheetSchema schema) {
+        if (operand instanceof Formula) {
+            final Formula f = (Formula) operand;
+            switch (f.kind()) {
+                case OF:
+                    return f.value();
+                case COLUMN:
+                    final int col = schema.columnIndexByName(f.value());
+                    if (col < 0) {
+                        throw new IllegalArgumentException("Formula column '" + f.value()
+                                + "' not found in schema. Available columns: " + schema.columnNames());
+                    }
+                    return "$" + CellReference.convertNumToColString(col) + (schema.getDataRow() + 1);
+                default:
+                    throw new IllegalStateException("Unknown Formula kind: " + f.kind());
+            }
+        }
+        return (String) operand;
     }
 
     private static void _applyCellStyleToDxf(final ConditionalFormattingRule rule,

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/ConditionalFormattingTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/ConditionalFormattingTest.java
@@ -61,7 +61,7 @@ class ConditionalFormattingTest {
                 .gridConfigurer(new GridConfigurer()
                         .conditionalFormatting()
                             .column("score")
-                            .greaterThanOrEqual("80")
+                            .greaterThanOrEqual(80)
                             .style("highlight")
                             .end())
                 .build();
@@ -97,7 +97,7 @@ class ConditionalFormattingTest {
                 .gridConfigurer(new GridConfigurer()
                         .conditionalFormatting()
                             .column("score")
-                            .greaterThanOrEqual("80")
+                            .greaterThanOrEqual(80)
                             .style("highlight")
                             .end())
                 .build();
@@ -145,7 +145,7 @@ class ConditionalFormattingTest {
                 .gridConfigurer(new GridConfigurer()
                         .conditionalFormatting()
                             .column("score")
-                            .greaterThanOrEqual("80")
+                            .greaterThanOrEqual(80)
                             .style("highlight")
                             .end())
                 .build();
@@ -171,7 +171,7 @@ class ConditionalFormattingTest {
         GridConfigurer gridConfigurer = new GridConfigurer()
                 .conditionalFormatting()
                     .column("score")
-                    .greaterThanOrEqual("80")
+                    .greaterThanOrEqual(80)
                     .style("highlight")
                     .end();
 
@@ -212,7 +212,7 @@ class ConditionalFormattingTest {
                 .gridConfigurer(new GridConfigurer()
                         .conditionalFormatting()
                             .column("score")
-                            .greaterThanOrEqual("80")
+                            .greaterThanOrEqual(80)
                             .style("highlight")
                             .end())
                 .build();

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/ConditionalFormattingTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/ConditionalFormattingTest.java
@@ -336,6 +336,34 @@ class ConditionalFormattingTest {
     }
 
     @Test
+    void lessThanOrEqualMapsToLE() throws Exception {
+        ConditionalFormattingRule rule = _writeAndGetRule("score",
+                spec -> spec.lessThanOrEqual(20).style("highlight"), Score.class,
+                Arrays.asList(new Score("Alice", 90)));
+        assertThat(rule.getComparisonOperation()).isEqualTo(ComparisonOperator.LE);
+        assertThat(rule.getFormula1()).isEqualTo("20");
+    }
+
+    @Test
+    void notEqualToMapsToNotEqual() throws Exception {
+        ConditionalFormattingRule rule = _writeAndGetRule("score",
+                spec -> spec.notEqualTo(0).style("highlight"), Score.class,
+                Arrays.asList(new Score("Alice", 90)));
+        assertThat(rule.getComparisonOperation()).isEqualTo(ComparisonOperator.NOT_EQUAL);
+        assertThat(rule.getFormula1()).isEqualTo("0");
+    }
+
+    @Test
+    void notBetweenMapsToNotBetween() throws Exception {
+        ConditionalFormattingRule rule = _writeAndGetRule("score",
+                spec -> spec.notBetween(0, 20).style("highlight"), Score.class,
+                Arrays.asList(new Score("Alice", 90)));
+        assertThat(rule.getComparisonOperation()).isEqualTo(ComparisonOperator.NOT_BETWEEN);
+        assertThat(rule.getFormula1()).isEqualTo("0");
+        assertThat(rule.getFormula2()).isEqualTo("20");
+    }
+
+    @Test
     void formulaOfRawCellRef() throws Exception {
         ConditionalFormattingRule rule = _writeAndGetRule("score",
                 spec -> spec.greaterThan(Formula.of("$D$1")).style("highlight"),

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/ConditionalFormattingTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/ConditionalFormattingTest.java
@@ -1,12 +1,14 @@
 package io.github.scndry.jackson.dataformat.spreadsheet;
 
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.grid.Formula;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.grid.GridConfigurer;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.style.StylesBuilder;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.apache.poi.ss.usermodel.ComparisonOperator;
+import org.apache.poi.ss.usermodel.ConditionType;
 import org.apache.poi.ss.usermodel.ConditionalFormatting;
 import org.apache.poi.ss.usermodel.ConditionalFormattingRule;
 import org.apache.poi.ss.usermodel.IndexedColors;
@@ -21,14 +23,20 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
 import java.io.File;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
+import java.util.TimeZone;
 
 import static io.github.scndry.jackson.dataformat.spreadsheet.OpcXmlHelper.NS_SPREADSHEETML;
 import static io.github.scndry.jackson.dataformat.spreadsheet.OpcXmlHelper.parsePart;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ConditionalFormattingTest {
 
@@ -223,6 +231,216 @@ class ConditionalFormattingTest {
             SheetConditionalFormatting scf = wb.getSheetAt(0).getSheetConditionalFormatting();
             // No data rows — CF rules are skipped
             assertThat(scf.getNumConditionalFormattings()).isZero();
+        }
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class Item {
+        private String name;
+        private double price;
+        private double minPrice;
+    }
+
+    @Test
+    void typedNumericLong() throws Exception {
+        ConditionalFormattingRule rule = _writeAndGetRule("score",
+                spec -> spec.greaterThan(80L).style("highlight"), Score.class,
+                Arrays.asList(new Score("Alice", 90)));
+        assertThat(rule.getComparisonOperation()).isEqualTo(ComparisonOperator.GT);
+        assertThat(rule.getFormula1()).isEqualTo("80");
+    }
+
+    @Test
+    void typedNumericDouble() throws Exception {
+        ConditionalFormattingRule rule = _writeAndGetRule("score",
+                spec -> spec.lessThan(80.5).style("highlight"), Score.class,
+                Arrays.asList(new Score("Alice", 90)));
+        assertThat(rule.getComparisonOperation()).isEqualTo(ComparisonOperator.LT);
+        assertThat(rule.getFormula1()).isEqualTo("80.5");
+    }
+
+    @Test
+    void typedBoolean() throws Exception {
+        ConditionalFormattingRule rule = _writeAndGetRule("score",
+                spec -> spec.equalTo(true).style("highlight"), Score.class,
+                Arrays.asList(new Score("Alice", 90)));
+        assertThat(rule.getComparisonOperation()).isEqualTo(ComparisonOperator.EQUAL);
+        assertThat(rule.getFormula1()).isEqualTo("TRUE");
+    }
+
+    @Test
+    void typedStringAutoEscape() throws Exception {
+        ConditionalFormattingRule rule = _writeAndGetRule("name",
+                spec -> spec.equalTo("URGENT").style("highlight"), Score.class,
+                Arrays.asList(new Score("Alice", 90)));
+        assertThat(rule.getComparisonOperation()).isEqualTo(ComparisonOperator.EQUAL);
+        assertThat(rule.getFormula1()).isEqualTo("\"URGENT\"");
+    }
+
+    @Test
+    void typedStringInternalQuoteEscape() throws Exception {
+        ConditionalFormattingRule rule = _writeAndGetRule("name",
+                spec -> spec.equalTo("say \"hi\"").style("highlight"), Score.class,
+                Arrays.asList(new Score("Alice", 90)));
+        // Excel doubles internal quotes
+        assertThat(rule.getFormula1()).isEqualTo("\"say \"\"hi\"\"\"");
+    }
+
+    @Test
+    void typedLocalDate() throws Exception {
+        ConditionalFormattingRule rule = _writeAndGetRule("score",
+                spec -> spec.greaterThan(LocalDate.of(2026, 1, 1)).style("highlight"),
+                Score.class, Arrays.asList(new Score("Alice", 90)));
+        assertThat(rule.getFormula1()).isEqualTo("DATE(2026,1,1)");
+    }
+
+    @Test
+    void typedLocalDateTime() throws Exception {
+        ConditionalFormattingRule rule = _writeAndGetRule("score",
+                spec -> spec.greaterThan(LocalDateTime.of(2026, 1, 1, 10, 30, 0)).style("highlight"),
+                Score.class, Arrays.asList(new Score("Alice", 90)));
+        assertThat(rule.getFormula1()).isEqualTo("DATE(2026,1,1)+TIME(10,30,0)");
+    }
+
+    @Test
+    void typedDate() throws Exception {
+        Calendar cal = Calendar.getInstance(TimeZone.getDefault());
+        cal.set(2026, Calendar.JANUARY, 1, 12, 0, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        Date date = cal.getTime();
+        ConditionalFormattingRule rule = _writeAndGetRule("score",
+                spec -> spec.greaterThan(date).style("highlight"),
+                Score.class, Arrays.asList(new Score("Alice", 90)));
+        assertThat(rule.getFormula1()).startsWith("DATE(2026,1,1)+TIME(");
+    }
+
+    @Test
+    void typedCalendar() throws Exception {
+        Calendar cal = Calendar.getInstance(TimeZone.getDefault());
+        cal.set(2026, Calendar.JANUARY, 1, 12, 0, 0);
+        cal.set(Calendar.MILLISECOND, 0);
+        ConditionalFormattingRule rule = _writeAndGetRule("score",
+                spec -> spec.greaterThan(cal).style("highlight"),
+                Score.class, Arrays.asList(new Score("Alice", 90)));
+        assertThat(rule.getFormula1()).isEqualTo("DATE(2026,1,1)+TIME(12,0,0)");
+    }
+
+    @Test
+    void typedBetween() throws Exception {
+        ConditionalFormattingRule rule = _writeAndGetRule("score",
+                spec -> spec.between(80, 100).style("highlight"), Score.class,
+                Arrays.asList(new Score("Alice", 90)));
+        assertThat(rule.getComparisonOperation()).isEqualTo(ComparisonOperator.BETWEEN);
+        assertThat(rule.getFormula1()).isEqualTo("80");
+        assertThat(rule.getFormula2()).isEqualTo("100");
+    }
+
+    @Test
+    void formulaOfRawCellRef() throws Exception {
+        ConditionalFormattingRule rule = _writeAndGetRule("score",
+                spec -> spec.greaterThan(Formula.of("$D$1")).style("highlight"),
+                Score.class, Arrays.asList(new Score("Alice", 90)));
+        assertThat(rule.getFormula1()).isEqualTo("$D$1");
+    }
+
+    @Test
+    void formulaOfFunction() throws Exception {
+        ConditionalFormattingRule rule = _writeAndGetRule("score",
+                spec -> spec.greaterThan(Formula.of("AVERAGE($B$2:$B$100)")).style("highlight"),
+                Score.class, Arrays.asList(new Score("Alice", 90)));
+        assertThat(rule.getFormula1()).isEqualTo("AVERAGE($B$2:$B$100)");
+    }
+
+    @Test
+    void formulaColumnResolvesToRowRelativeRef() throws Exception {
+        ConditionalFormattingRule rule = _writeAndGetRule("price",
+                spec -> spec.greaterThan(Formula.column("minPrice")).style("highlight"),
+                Item.class, Arrays.asList(new Item("Apple", 10.0, 5.0)));
+        // Item: name=A, price=B, minPrice=C; data starts at row 2 (origin A1, header at row 1)
+        assertThat(rule.getFormula1()).isEqualTo("$C2");
+    }
+
+    @Test
+    void formulaColumnMissingColumnFails() throws Exception {
+        File file = new File(tempDir, "cf-missing-col.xlsx");
+        SpreadsheetMapper mapper = SpreadsheetMapper.builder()
+                .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL)
+                .stylesBuilder(new StylesBuilder()
+                        .cellStyle("highlight")
+                            .fillForegroundColor(IndexedColors.RED.getIndex())
+                            .fillPattern().solidForeground()
+                            .end())
+                .gridConfigurer(new GridConfigurer()
+                        .conditionalFormatting()
+                            .column("price")
+                            .greaterThan(Formula.column("nonexistent"))
+                            .style("highlight")
+                            .end())
+                .build();
+        assertThatThrownBy(() -> mapper.writeValue(file, Arrays.asList(new Item("A", 1.0, 0.5)), Item.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Formula column 'nonexistent' not found");
+    }
+
+    @Test
+    void expressionRule() throws Exception {
+        File file = new File(tempDir, "cf-expression.xlsx");
+        SpreadsheetMapper mapper = SpreadsheetMapper.builder()
+                .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL)
+                .stylesBuilder(new StylesBuilder()
+                        .cellStyle("highlight")
+                            .fillForegroundColor(IndexedColors.RED.getIndex())
+                            .fillPattern().solidForeground()
+                            .end())
+                .gridConfigurer(new GridConfigurer()
+                        .conditionalFormatting()
+                            .column("score")
+                            .expression("AND($B2>0, $B2<100)")
+                            .style("highlight")
+                            .end())
+                .build();
+        mapper.writeValue(file, Arrays.asList(new Score("Alice", 90)), Score.class);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            ConditionalFormattingRule rule = wb.getSheetAt(0).getSheetConditionalFormatting()
+                    .getConditionalFormattingAt(0).getRule(0);
+            assertThat(rule.getConditionType()).isEqualTo(ConditionType.FORMULA);
+            assertThat(rule.getFormula1()).isEqualTo("AND($B2>0, $B2<100)");
+        }
+    }
+
+    @Test
+    void expressionRejectsEmpty() {
+        GridConfigurer configurer = new GridConfigurer();
+        assertThatThrownBy(() -> configurer.conditionalFormatting()
+                .column("score").expression("").style("highlight").end())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must not be empty");
+    }
+
+    /** Helper: write a CF rule and return the resulting POI rule. */
+    private <T> ConditionalFormattingRule _writeAndGetRule(
+            String column,
+            java.util.function.Function<io.github.scndry.jackson.dataformat.spreadsheet.schema.grid.ConditionalFormattingRuleSpec,
+                io.github.scndry.jackson.dataformat.spreadsheet.schema.grid.ConditionalFormattingRuleSpec> ruleConfigurer,
+            Class<T> type,
+            List<T> data) throws Exception {
+        File file = new File(tempDir, "cf-typed-" + System.nanoTime() + ".xlsx");
+        GridConfigurer gc = new GridConfigurer();
+        ruleConfigurer.apply(gc.conditionalFormatting().column(column)).end();
+        SpreadsheetMapper mapper = SpreadsheetMapper.builder()
+                .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL)
+                .stylesBuilder(new StylesBuilder()
+                        .cellStyle("highlight")
+                            .fillForegroundColor(IndexedColors.RED.getIndex())
+                            .fillPattern().solidForeground()
+                            .end())
+                .gridConfigurer(gc)
+                .build();
+        mapper.writeValue(file, data, type);
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            return wb.getSheetAt(0).getSheetConditionalFormatting()
+                    .getConditionalFormattingAt(0).getRule(0);
         }
     }
 

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/grid/FormulaTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/grid/FormulaTest.java
@@ -1,0 +1,58 @@
+package io.github.scndry.jackson.dataformat.spreadsheet.schema.grid;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class FormulaTest {
+
+    @Test
+    void of_storesTextAndKind() {
+        Formula f = Formula.of("$D$1");
+        assertThat(f.kind()).isEqualTo(Formula.Kind.OF);
+        assertThat(f.value()).isEqualTo("$D$1");
+    }
+
+    @Test
+    void of_acceptsExpressionString() {
+        Formula f = Formula.of("AVERAGE($B$2:$B$100) * 0.9");
+        assertThat(f.kind()).isEqualTo(Formula.Kind.OF);
+        assertThat(f.value()).isEqualTo("AVERAGE($B$2:$B$100) * 0.9");
+    }
+
+    @Test
+    void of_rejectsNull() {
+        assertThatThrownBy(() -> Formula.of(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must not be empty");
+    }
+
+    @Test
+    void of_rejectsEmpty() {
+        assertThatThrownBy(() -> Formula.of(""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must not be empty");
+    }
+
+    @Test
+    void column_storesNameAndKind() {
+        Formula f = Formula.column("minPrice");
+        assertThat(f.kind()).isEqualTo(Formula.Kind.COLUMN);
+        assertThat(f.value()).isEqualTo("minPrice");
+    }
+
+    @Test
+    void column_rejectsNull() {
+        assertThatThrownBy(() -> Formula.column(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must not be empty");
+    }
+
+    @Test
+    void column_rejectsEmpty() {
+        assertThatThrownBy(() -> Formula.column(""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must not be empty");
+    }
+}


### PR DESCRIPTION
## Highlights

- Typed conditional formatting API (#81) — see GUIDE.md / Migration table

## Breaking Changes

`GridConfigurer.conditionalFormatting()` operands typed. String-based methods removed.

| Before (1.4.x) | After (1.5.0) |
|---|---|
| \`greaterThan("90")\` | \`greaterThan(90)\` |
| \`equalTo("\"URGENT\"")\` | \`equalTo("URGENT")\` |
| \`between("100", "500")\` | \`between(100, 500)\` |
| \`equalTo("\$D\$1")\` | \`equalTo(Formula.of("\$D\$1"))\` |
| \`greaterThan("AVG(...)")\` | \`greaterThan(Formula.of("AVG(...)"))\` |
| \`greaterThan("\$D2")\` (cross-column) | \`greaterThan(Formula.column("minPrice"))\` |

## New

- \`Formula.of(text)\` — raw Excel formula passthrough
- \`Formula.column(name)\` — schema-aware row-relative reference
- \`expression(formula)\` — \`type="expression"\` rules
- Typed operands: Number, boolean, String (auto-escaped), LocalDate, LocalDateTime, Date, Calendar