### PR TITLE
CI improvements: POI 5.1.0+ test guards + version compat matrix (#95)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,18 @@ permissions:
 
 jobs:
   build:
+    name: build (${{ matrix.name }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: default
+            poiVersion: ""
+            jacksonVersion: ""
+          - name: compat-min
+            poiVersion: "4.1.1"
+            jacksonVersion: "2.14.0"
     steps:
       - uses: actions/checkout@v6
       - name: Set up JDK
@@ -20,4 +31,8 @@ jobs:
           java-version: 17
           distribution: temurin
       - name: Build and test
-        run: ./gradlew check --console=plain
+        run: |
+          ARGS=""
+          [ -n "${{ matrix.poiVersion }}" ] && ARGS="$ARGS -PpoiVersion=${{ matrix.poiVersion }}"
+          [ -n "${{ matrix.jacksonVersion }}" ] && ARGS="$ARGS -PjacksonVersion=${{ matrix.jacksonVersion }}"
+          ./gradlew check --console=plain $ARGS

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,8 +10,9 @@ version = "1.6.0-SNAPSHOT"
 description = "Support for reading and writing Spreadsheet via Jackson abstractions."
 
 val title = "Jackson dataformat: Spreadsheet"
-val jacksonVersion = "2.21.3"
-val poiVersion = "5.5.1"
+// Compat-test override: ./gradlew test -PpoiVersion=4.1.1 -PjacksonVersion=2.14.0
+val jacksonVersion = (findProperty("jacksonVersion") as? String)?.takeIf { it.isNotEmpty() } ?: "2.21.3"
+val poiVersion = (findProperty("poiVersion") as? String)?.takeIf { it.isNotEmpty() } ?: "5.5.1"
 val snapshots = version.toString().endsWith("SNAPSHOT")
 
 repositories {

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/PoiVersionProbe.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/PoiVersionProbe.java
@@ -1,0 +1,28 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import org.apache.poi.openxml4j.opc.OPCPackage;
+
+/**
+ * Probes the runtime POI version for feature gates in tests.
+ * The library targets POI 4.1.1+; some tests assert behavior that diverges
+ * between POI 4.x and 5.x and are guarded with {@link #isPoi510OrLater()}.
+ */
+public final class PoiVersionProbe {
+
+    private PoiVersionProbe() {
+    }
+
+    /**
+     * @return {@code true} if the runtime POI is 5.1.0 or later. Detected by probing
+     * for {@code OPCPackage#isStrictOoxmlFormat()}, which was added in POI 5.1.0
+     * (see {@code POICompat.STRICT_FORMAT_METHOD}).
+     */
+    public static boolean isPoi510OrLater() {
+        try {
+            OPCPackage.class.getMethod("isStrictOoxmlFormat");
+            return true;
+        } catch (NoSuchMethodException e) {
+            return false;
+        }
+    }
+}

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/SSMLSheetWriterDomEquivalenceTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/SSMLSheetWriterDomEquivalenceTest.java
@@ -13,6 +13,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.apache.poi.openxml4j.opc.OPCPackage;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
@@ -48,6 +49,11 @@ class SSMLSheetWriterDomEquivalenceTest {
 
     @Test
     void sheetXmlDomEquivalent() throws Exception {
+        // POI 4.x omits default <c s="0"> while SSML writer (and POI 5.x) emit it,
+        // breaking strict DOM equality. Library/test design decision tracked in #96.
+        Assumptions.assumeTrue(PoiVersionProbe.isPoi510OrLater(),
+                "DOM equivalence with POI output diverges on POI 4.x — see #96");
+
         File ssmlFile = _debugFile("dom-sheet-ssml.xlsx");
         File poiFile = _debugFile("dom-sheet-poi.xlsx");
 

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLSheetReaderTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLSheetReaderTest.java
@@ -3,8 +3,10 @@ package io.github.scndry.jackson.dataformat.spreadsheet.poi.ooxml;
 import java.io.File;
 
 import org.apache.poi.openxml4j.opc.PackagePart;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
+import io.github.scndry.jackson.dataformat.spreadsheet.PoiVersionProbe;
 import io.github.scndry.jackson.dataformat.spreadsheet.deser.SheetReaderTestBase;
 
 class SSMLSheetReaderTest extends SheetReaderTestBase {
@@ -20,6 +22,11 @@ class SSMLSheetReaderTest extends SheetReaderTestBase {
 
     @Test
     void strict() throws Exception {
+        // Strict OOXML reading requires POI 5.1.0+ (see GUIDE.md, POICompat.STRICT_FORMAT_METHOD).
+        // POI 4.x cannot resolve the worksheet relationship in a strict-format package.
+        Assumptions.assumeTrue(PoiVersionProbe.isPoi510OrLater(),
+                "Strict OOXML reading requires POI 5.1.0+");
+
         SSMLWorkbook workbook = SSMLWorkbook.create(strictSource);
         PackagePart part = workbook.getWorksheetPartAt(0);
         reader = new SSMLSheetReader(part, workbook, false, false);


### PR DESCRIPTION
Closes part of #95.

## Summary

- **Item 5**: Two POI 4.x-divergent tests now guard with `Assumptions.assumeTrue(PoiVersionProbe.isPoi510OrLater(), ...)`. The probe checks for `OPCPackage#isStrictOoxmlFormat`, added in POI 5.1.0.
  - `SSMLSheetReaderTest.strict()` — strict OOXML reading is a POI 5.1.0+ feature
  - `SSMLSheetWriterDomEquivalenceTest.sheetXmlDomEquivalent` — POI 4.x omits default `<c s="0">`. The guard is **temporary**; library/test design decision tracked in #96.
- **Item 6**: `build.gradle.kts` reads `poiVersion` and `jacksonVersion` Gradle properties (default to current latest). `build.yml` runs a 2-entry matrix — `default` (current versions) and `compat-min` (POI 4.1.1 + Jackson 2.14.0).

Items 1, 2 (workflow trigger/path filters) were applied directly to `release/1.6.0` ahead of this PR (`679e523`) so this very PR could be gated by `build`.

Items 3, 4 (repo settings) are tracked as out-of-band tasks in #95.

## Verification

- Local `./gradlew test` passes on default (POI 5.5.1) — guards permit; all tests run
- Local `./gradlew test -PpoiVersion=4.1.1 -PjacksonVersion=2.14.0` passes — guards skip the 2 POI 5.1.0+ tests; everything else runs
- This PR should now trigger `build` on both `default` and `compat-min` matrix entries (release/** PR-trigger fix already in target branch)

## Test plan
- [ ] CI green on `default`
- [ ] CI green on `compat-min`