### PR TITLE
Tighten DOM equivalence guard to POI 5.2.3+ (#96)

### DIFF
--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/PoiVersionProbe.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/PoiVersionProbe.java
@@ -1,11 +1,12 @@
 package io.github.scndry.jackson.dataformat.spreadsheet;
 
+import org.apache.poi.Version;
 import org.apache.poi.openxml4j.opc.OPCPackage;
 
 /**
  * Probes the runtime POI version for feature gates in tests.
  * The library targets POI 4.1.1+; some tests assert behavior that diverges
- * between POI 4.x and 5.x and are guarded with {@link #isPoi510OrLater()}.
+ * across POI versions and are guarded with the predicates here.
  */
 public final class PoiVersionProbe {
 
@@ -24,5 +25,36 @@ public final class PoiVersionProbe {
         } catch (NoSuchMethodException e) {
             return false;
         }
+    }
+
+    /**
+     * @return {@code true} if the runtime POI is 5.2.3 or later. Determined by parsing
+     * {@link Version#getVersion()}. POI 5.2.3 introduced the bug-51037 fix in
+     * {@code XSSFRow.onDocumentWrite} that applies a default cell style to every
+     * unstyled cell, causing {@code s="0"} to be emitted unconditionally —
+     * diverging from POI 4.x ~ 5.2.2 output. Tests that assert DOM equality
+     * against POI's output use this predicate to skip on lower versions.
+     */
+    public static boolean isPoi523OrLater() {
+        final int[] v = _parseVersion(Version.getVersion());
+        return v[0] > 5
+                || (v[0] == 5 && v[1] > 2)
+                || (v[0] == 5 && v[1] == 2 && v[2] >= 3);
+    }
+
+    private static int[] _parseVersion(final String version) {
+        final String[] parts = version.split("\\.");
+        return new int[]{
+                _parseLeadingInt(parts.length > 0 ? parts[0] : "0"),
+                _parseLeadingInt(parts.length > 1 ? parts[1] : "0"),
+                _parseLeadingInt(parts.length > 2 ? parts[2] : "0"),
+        };
+    }
+
+    /** Parses leading digits as int; tolerates suffixes like "5.5.1-beta1". */
+    private static int _parseLeadingInt(final String s) {
+        int end = 0;
+        while (end < s.length() && Character.isDigit(s.charAt(end))) end++;
+        return end == 0 ? 0 : Integer.parseInt(s.substring(0, end));
     }
 }

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/SSMLSheetWriterDomEquivalenceTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/SSMLSheetWriterDomEquivalenceTest.java
@@ -49,10 +49,11 @@ class SSMLSheetWriterDomEquivalenceTest {
 
     @Test
     void sheetXmlDomEquivalent() throws Exception {
-        // POI 4.x omits default <c s="0"> while SSML writer (and POI 5.x) emit it,
-        // breaking strict DOM equality. Library/test design decision tracked in #96.
-        Assumptions.assumeTrue(PoiVersionProbe.isPoi510OrLater(),
-                "DOM equivalence with POI output diverges on POI 4.x — see #96");
+        // SSML writer always emits <c s="0">, matching POI 5.2.3+ (bug-51037 fix).
+        // POI 4.x ~ 5.2.2 omit default s, so DOM equality only holds on POI 5.2.3+.
+        // Library policy: follow latest POI behavior; older-version drift is ignored. (#96)
+        Assumptions.assumeTrue(PoiVersionProbe.isPoi523OrLater(),
+                "DOM equivalence asserted only on POI 5.2.3+ — see #96");
 
         File ssmlFile = _debugFile("dom-sheet-ssml.xlsx");
         File poiFile = _debugFile("dom-sheet-poi.xlsx");


### PR DESCRIPTION
Closes #96.

## Decision

Library SSML writer follows the latest POI behavior — always emit `<c s="0">` (matching POI 5.2.3+ from bug-51037 side effect). The DOM equivalence test asserts equality only on the version range where POI's writer matches: **POI 5.2.3+**. Older versions are version-gated and skipped.

This is a *style* choice, not a spec requirement (ECMA-376 allows both presence and absence). Rationale: track upstream POI rather than pin to a particular older convention.

## Changes

- `PoiVersionProbe.isPoi523OrLater()` — parses `Version.getVersion()`. Distinguishes 5.2.3 (bug-51037 landed) from earlier 5.x versions where `s="0"` is still omitted.
- `SSMLSheetWriterDomEquivalenceTest.sheetXmlDomEquivalent` switched from `isPoi510OrLater` to `isPoi523OrLater`. The previous predicate was too permissive: POI 5.1.0 ~ 5.2.2 still omit default `s` and would have failed the test if exercised. CI matrix only covers POI 4.1.1 and the current latest, so the gap was latent.
- `isPoi510OrLater` retained — `SSMLSheetReaderTest.strict()` (strict OOXML reading, independent feature, requires POI 5.1.0+).

## Out of scope

- Library output behavior (emit vs omit default `s`) — kept as current (always emit). See #96 discussion for the reasoning behind not changing it.
- POI upstream contribution about bug-51037's unstyled-cell side effect — deferred (separate decision per #96 discussion).

## Test plan
- [x] `./gradlew test` (default, POI 5.5.1) — all pass; DOM equiv guard permits, test runs
- [x] `./gradlew test -PpoiVersion=4.1.1 -PjacksonVersion=2.14.0` — all pass; DOM equiv guard skips
- [ ] CI matrix green