### PR TITLE
Absorb POI interop notes into existing docs and code comments

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -621,6 +621,8 @@ Supported: `Date`, `Calendar`, `LocalDate`, `LocalDateTime`.
 
 No configuration needed. Read an Excel date cell and get a `LocalDate`. Write a `LocalDate` and get an Excel-formatted date.
 
+On read, the workbook's date system (1900 or 1904) is detected and applied automatically. Write defaults to 1900.
+
 ## Sheet-Level Features
 
 `GridConfigurer` controls sheet-level features anchored on the data grid. The conditional formatting call below uses factory methods from `ConditionalFormats`, typically static-imported (see [Conditional Formatting](#conditional-formatting) for details):

--- a/README.md
+++ b/README.md
@@ -273,6 +273,9 @@ XLSX (OOXML) and XLS (legacy). XLSX uses StAX streaming; XLS uses POI object mod
 **Q: Is it production-ready?**
 Yes. Version 1.6.0 on Maven Central. Java 8+, Jackson 2.14+, POI 4.1.1+. Listed as a [community data format module](https://github.com/FasterXML/jackson#data-format-modules) in the FasterXML jackson repository.
 
+**Q: Is the mapper thread-safe?**
+The mapper instance is reusable across threads once configured (same rule as Jackson's `ObjectMapper`). Concurrent calls with `File` / `InputStream` / `OutputStream` inputs are safe — the library opens an isolated `Workbook` per call. If you pass a `Sheet` directly, POI's `Workbook`/`Sheet` are not thread-safe, so each thread needs its own.
+
 ## License
 
 [Apache License 2.0](LICENSE)

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SpreadsheetFactory.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SpreadsheetFactory.java
@@ -288,6 +288,7 @@ public final class SpreadsheetFactory extends JsonFactory {
         return new POISheetReader(sheet);
     }
 
+    // Copy InputStream to temp File — POI's File path uses much less heap than InputStream (POIFS HOWTO ~20% vs ~120% for HSSF; OPCPackage Javadoc reports the same trend for OOXML).
     @SuppressWarnings("unchecked")
     private SheetInput<?> _preferRawAsFile(final SheetInput<?> src) throws IOException {
         if (src.isFile()) return src;

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ss/POISheetWriter.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ss/POISheetWriter.java
@@ -243,6 +243,7 @@ public final class POISheetWriter implements SheetWriter {
     public void close() throws IOException {
         final Workbook workbook = _sheet.getWorkbook();
         workbook.close();
+        // Explicit dispose() — close→dispose became automatic only in recent POI (Bug 68183); safe across POI 4.1.1+.
         if (workbook instanceof SXSSFWorkbook) {
             ((SXSSFWorkbook) workbook).dispose();
         }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/grid/GridConfigurer.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/grid/GridConfigurer.java
@@ -218,6 +218,7 @@ public final class GridConfigurer {
         return (String) operand;
     }
 
+    // Each rule allocates its own dxf — POI does not deduplicate across rules sharing the same style.
     private static void _applyCellStyleToDxf(final ConditionalFormattingRule rule,
             final CellStyle cs, final Workbook wb) {
         if (cs.getFillPattern() != FillPatternType.NO_FILL) {

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/style/StylesBuilder.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/style/StylesBuilder.java
@@ -20,6 +20,7 @@ import io.github.scndry.jackson.dataformat.spreadsheet.schema.Styles;
  */
 public final class StylesBuilder implements Builder<Styles> {
 
+    // Each name maps to one POI CellStyle — bounded by Excel's cell-style cap (4K HSSF / 64K XSSF).
     private final Map<Object, CellStyleBuilder> _builders;
 
     public StylesBuilder() {


### PR DESCRIPTION
## Summary

- Code comments at four POI-quirk call sites (`SpreadsheetFactory._preferRawAsFile` InputStream→File budget; `POISheetWriter.close` SXSSF dispose; `StylesBuilder` cell-style cap; `GridConfigurer` dxf dedup)
- `GUIDE.md` Excel Dates — read/write 1900/1904 contract (read auto-detects, write defaults to 1900)
- `README.md` FAQ — thread-safety entry (mapper reusable, File/Stream inputs concurrent-safe via per-call `Workbook` isolation, direct `Sheet` requires per-thread instance)

## Test plan
- [x] `./gradlew test` BUILD SUCCESSFUL
- [x] Comment-only Java changes — bytecode unchanged
- [x] Markdown changes — render verified locally