### PR TITLE
Clarify non-obvious semantics in three call sites

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -901,6 +901,10 @@ Requires `com.h2database:h2` on the classpath:
 
 Trades ~40% throughput for constant heap usage regardless of string table size. The temporary file is automatically deleted when the reader is closed.
 
+## Logging
+
+SLF4J `TRACE` level emits per-cell values and addresses — disable in environments handling sensitive data.
+
 ## FAQ
 
 **Q: Does `@DataGrid` have to be on the root class?**

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/ColumnPointer.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/ColumnPointer.java
@@ -9,6 +9,10 @@ import java.util.stream.Stream;
  * and iteration over path segments, similar to
  * {@link java.nio.file.Path} for file systems.
  *
+ * <p>Array indices collapse: {@code items[0]/qty} and
+ * {@code items[1]/qty} map to the same column (unlike
+ * Jackson's {@code JsonPointer}).
+ *
  * @see Column
  * @see SpreadsheetSchema
  */

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
@@ -22,7 +22,8 @@ import io.github.scndry.jackson.dataformat.spreadsheet.schema.style.StylesBuilde
  * {@link FormatSchema} implementation that defines the column
  * layout for spreadsheet reading and writing. Contains an
  * ordered list of {@link Column} definitions, a cell origin,
- * and style configuration.
+ * and style configuration. Do not mutate the builders or
+ * columns after construction.
  *
  * @see Column
  * @see io.github.scndry.jackson.dataformat.spreadsheet.SchemaGenerator


### PR DESCRIPTION
## Summary

- `ColumnPointer` Javadoc: array indices collapse (`items[0]/qty` and `items[1]/qty` map to the same column, unlike Jackson's `JsonPointer`)
- `SpreadsheetSchema` Javadoc: do not mutate builders or columns after construction
- `GUIDE.md` Logging: SLF4J `TRACE` emits per-cell values and addresses — security warning

## Test plan
- [x] `./gradlew test` BUILD SUCCESSFUL
- [x] Comment-only Java changes — bytecode unchanged