### PR TITLE
Add Scarf pixel for anonymous README usage tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,3 +279,10 @@ The mapper instance is reusable across threads once configured (same rule as Jac
 ## License
 
 [Apache License 2.0](LICENSE)
+
+---
+
+<sub>This README includes an anonymous, aggregated usage tracker via [Scarf](https://about.scarf.sh/). No personal information is collected.</sub>
+
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=5217c9e5-45fd-4941-a10b-354455edbd72" />
+


### PR DESCRIPTION
## Summary

- Embed Scarf tracking pixel in `README.md` footer to measure README views across GitHub and Maven Central
- Anonymous, aggregated usage data only — no personal information
- Includes transparency footnote per OSS norms

## Why

Library is in production (1.6.0, FasterXML community modules listing) but adoption metrics (downloads, dependents, README views) are not tracked. Scarf pixel adds anonymous reach measurement without invasive instrumentation.

## Test plan
- [x] README renders correctly in markdown preview
- [x] Pixel ID matches Scarf dashboard (`5217c9e5-...`)