### PR TITLE
Revert Scarf pixel from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,10 +279,3 @@ The mapper instance is reusable across threads once configured (same rule as Jac
 ## License
 
 [Apache License 2.0](LICENSE)
-
----
-
-<sub>This README includes an anonymous, aggregated usage tracker via [Scarf](https://about.scarf.sh/). No personal information is collected.</sub>
-
-<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=5217c9e5-45fd-4941-a10b-354455edbd72" />
-


### PR DESCRIPTION
## Summary
- Reverts PR #103 (Scarf pixel in README footer)
- GitHub camo proxy wraps the `<img>` in an anchor tag, causing broken-image rendering on the GitHub mobile app
- Tracking pixel will be moved to jackson-spreadsheet-examples repo where the audience is closer to actual library usage

## Test plan
- [x] `git diff` shows only the Scarf footer removed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)