### PR TITLE
Re-add Scarf pixel for anonymous README usage tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,3 +279,9 @@ The mapper instance is reusable across threads once configured (same rule as Jac
 ## License
 
 [Apache License 2.0](LICENSE)
+
+---
+
+<sub>This README includes an anonymous, aggregated usage tracker via [Scarf](https://about.scarf.sh/). No personal information is collected.</sub>
+
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=5217c9e5-45fd-4941-a10b-354455edbd72" />


### PR DESCRIPTION
## Summary
- Reinstates the Scarf pixel reverted in #104
- The earlier revert was based on a mobile rendering observation later traced to camo cache state — both pixel URLs return identical `200 image/png` from Scarf
- Re-adding now to begin tracking; no library code changes

## Test plan
- [x] Diff is README-only
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)