### PR TITLE
Add Scarf pixel to all docs with per-page segmentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -351,3 +351,8 @@ By default, both XLSX read and write paths bypass POI's User Model — the read 
 Public API surface (types users typically import): `SpreadsheetMapper`, `@DataGrid`, `@DataColumn`, `SheetInput`, `SheetOutput`, `SpreadsheetSchema`, `StylesBuilder`, `GridConfigurer`, `SheetMappingIterator`, `SheetLocation`, `SheetParser.Feature`, `SpreadsheetFactory.Feature`.
 
 Everything under `poi/` is implementation detail — swappable without affecting the streaming contract.
+
+---
+
+<sub>Anonymous, aggregated usage tracking via [Scarf](https://about.scarf.sh/). No personal information is collected.</sub>
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=5217c9e5-45fd-4941-a10b-354455edbd72&page=ARCHITECTURE.md" />

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -137,3 +137,8 @@ Filter specific benchmarks (and route results to per-benchmark files for separat
 ```
 
 Run benchmarks separately to avoid system noise accumulation across categories. GC profiler is enabled by default.
+
+---
+
+<sub>Anonymous, aggregated usage tracking via [Scarf](https://about.scarf.sh/). No personal information is collected.</sub>
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=5217c9e5-45fd-4941-a10b-354455edbd72&page=BENCHMARK.md" />

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -163,3 +163,8 @@ If you can do it with Jackson for JSON, you can do it with this library for Exce
 Same annotations. Same API. Different format. That's the abstraction.
 
 If it doesn't pass this test — if the user has to learn a new API or write spreadsheet-specific code for something Jackson already handles — it's a design failure.
+
+---
+
+<sub>Anonymous, aggregated usage tracking via [Scarf](https://about.scarf.sh/). No personal information is collected.</sub>
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=5217c9e5-45fd-4941-a10b-354455edbd72&page=DESIGN.md" />

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -931,3 +931,8 @@ Yes. Create a `SpreadsheetMapper` bean and inject it. It is thread-safe like `Ob
 - [BENCHMARK.md](BENCHMARK.md) — JMH benchmark results
 - [Jackson documentation](https://github.com/FasterXML/jackson-docs)
 - [Apache POI](https://poi.apache.org/components/spreadsheet/index.html)
+
+---
+
+<sub>Anonymous, aggregated usage tracking via [Scarf](https://about.scarf.sh/). No personal information is collected.</sub>
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=5217c9e5-45fd-4941-a10b-354455edbd72&page=GUIDE.md" />

--- a/README.md
+++ b/README.md
@@ -282,5 +282,5 @@ The mapper instance is reusable across threads once configured (same rule as Jac
 
 ---
 
-<sub>This README includes an anonymous, aggregated usage tracker via [Scarf](https://about.scarf.sh/). No personal information is collected.</sub>
-<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=5217c9e5-45fd-4941-a10b-354455edbd72" />
+<sub>Anonymous, aggregated usage tracking via [Scarf](https://about.scarf.sh/). No personal information is collected.</sub>
+<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=5217c9e5-45fd-4941-a10b-354455edbd72&page=README.md" />


### PR DESCRIPTION
## Summary
- Add Scarf pixel to GUIDE, ARCHITECTURE, BENCHMARK, DESIGN (README already had it)
- All 5 docs use a per-doc `&page=` query parameter for per-file segmentation in the Scarf dashboard (workaround for GitHub camo prefetch)
- Unified the transparency sub text across all 5 docs

## Test plan
- [x] Diff is doc-only (5 files, +22/-2)
- [ ] CI green