### PR TITLE
Validate sheet name in SheetOutput.target(*, String) (#100)

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -257,6 +257,8 @@ Use `SheetOutput` when you need to specify a sheet name:
 mapper.writeValue(SheetOutput.target(file, "Products"), products, Product.class);
 ```
 
+Sheet names must satisfy Excel constraints: 1–31 characters, no `/ \ ? * ] [`, and no leading or trailing apostrophe. Invalid names throw `IllegalArgumentException` at `SheetOutput.target(..., name)`.
+
 ### Streaming (Default)
 
 By default, XLSX read/write uses streaming — bypassing POI's User Model for direct XML generation. No configuration needed:

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/ser/SheetOutput.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/ser/SheetOutput.java
@@ -5,6 +5,7 @@ import java.io.OutputStream;
 import java.nio.file.Path;
 
 import lombok.EqualsAndHashCode;
+import org.apache.poi.ss.util.WorkbookUtil;
 
 import io.github.scndry.jackson.dataformat.spreadsheet.SheetContent;
 
@@ -30,6 +31,10 @@ public final class SheetOutput<T> implements SheetContent<T> {
         _name = name;
     }
 
+    private static void _validateSheetName(final String name) {
+        if (name != null) WorkbookUtil.validateSheetName(name);
+    }
+
     /**
      * Creates a {@code SheetOutput} writing to the given file
      * with an auto-generated sheet name.
@@ -41,8 +46,12 @@ public final class SheetOutput<T> implements SheetContent<T> {
     /**
      * Creates a {@code SheetOutput} writing to the given file
      * with the specified sheet name.
+     *
+     * @throws IllegalArgumentException if {@code sheetName} violates Excel constraints
+     *         (1-31 chars, no {@code / \ ? * ] [}, no leading/trailing apostrophe).
      */
     public static SheetOutput<File> target(final File raw, final String sheetName) {
+        _validateSheetName(sheetName);
         return new SheetOutput<>(raw, sheetName);
     }
 
@@ -57,6 +66,9 @@ public final class SheetOutput<T> implements SheetContent<T> {
     /**
      * Creates a {@code SheetOutput} writing to the given path
      * with the specified sheet name.
+     *
+     * @throws IllegalArgumentException if {@code sheetName} violates Excel constraints
+     *         (1-31 chars, no {@code / \ ? * ] [}, no leading/trailing apostrophe).
      */
     public static SheetOutput<File> target(final Path raw, final String sheetName) {
         return target(raw.toFile(), sheetName);
@@ -73,8 +85,12 @@ public final class SheetOutput<T> implements SheetContent<T> {
     /**
      * Creates a {@code SheetOutput} writing to the given stream
      * with the specified sheet name.
+     *
+     * @throws IllegalArgumentException if {@code sheetName} violates Excel constraints
+     *         (1-31 chars, no {@code / \ ? * ] [}, no leading/trailing apostrophe).
      */
     public static SheetOutput<OutputStream> target(final OutputStream raw, final String sheetName) {
+        _validateSheetName(sheetName);
         return new SheetOutput<>(raw, sheetName);
     }
 

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/ser/SheetOutputTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/ser/SheetOutputTest.java
@@ -1,0 +1,63 @@
+package io.github.scndry.jackson.dataformat.spreadsheet.ser;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SheetOutputTest {
+
+    private static final File DUMMY_FILE = new File("dummy.xlsx");
+    private static final Path DUMMY_PATH = DUMMY_FILE.toPath();
+    private static final ByteArrayOutputStream DUMMY_STREAM = new ByteArrayOutputStream();
+
+    @Test
+    void allowsNullName() {
+        assertThat(SheetOutput.target(DUMMY_FILE, null).getName()).isNull();
+        assertThat(SheetOutput.target(DUMMY_PATH, null).getName()).isNull();
+        assertThat(SheetOutput.target(DUMMY_STREAM, null).getName()).isNull();
+    }
+
+    @Test
+    void acceptsValidName() {
+        assertThat(SheetOutput.target(DUMMY_FILE, "A").getName()).isEqualTo("A");
+        assertThat(SheetOutput.target(DUMMY_FILE, "1234567890123456789012345678901").getName())
+                .hasSize(31);
+    }
+
+    @Test
+    void rejectsEmptyName() {
+        assertThatThrownBy(() -> SheetOutput.target(DUMMY_FILE, ""))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void rejectsTooLongName() {
+        // 32 chars
+        assertThatThrownBy(() -> SheetOutput.target(DUMMY_FILE, "12345678901234567890123456789012"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void rejectsForbiddenCharacters() {
+        for (final char c : new char[]{'/', '\\', '?', '*', '[', ']'}) {
+            assertThatThrownBy(() -> SheetOutput.target(DUMMY_FILE, "Sheet" + c + "Name"))
+                    .as("char: " + c)
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Test
+    void validatesAcrossAllOverloads() {
+        assertThatThrownBy(() -> SheetOutput.target(DUMMY_FILE, "Bad/Name"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> SheetOutput.target(DUMMY_PATH, "Bad/Name"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> SheetOutput.target(DUMMY_STREAM, "Bad/Name"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
## Summary
- Validate sheet name via POI's `WorkbookUtil.validateSheetName` in all three `SheetOutput.target(*, String)` overloads
- Adds a 1-line constraint note in GUIDE (1-31 chars, no `/ \ ? * ] [`, no leading/trailing apostrophe)
- New `SheetOutputTest` covering null/empty/length boundary/forbidden chars across all 3 overloads

Closes #100.

## Test plan
- [x] `./gradlew test` passes (CI)
- [ ] CI green