### PR TITLE
Document USE_POI_USER_MODEL as disk-restricted escape hatch

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -207,7 +207,7 @@ Both implement `SheetReader`. Format is auto-detected via ZIP magic bytes (`File
 | Shared strings | Custom `SharedStringsLookup` (lazy StAX) | POI's built-in `SharedStringsTable` |
 | When used | Auto-detected for XLSX files | XLS files, direct `Sheet` input, or `USE_POI_USER_MODEL` |
 
-When the input is an `InputStream`, OOXML files are copied to a temporary file — ZIP random access requires seekable I/O.
+When the input is an `InputStream`, OOXML files are copied to a temporary file — ZIP random access requires seekable I/O. `USE_POI_USER_MODEL` bypasses this copy: the stream is handed directly to POI, which holds the entire ZIP in memory (`ZipInputStreamZipEntrySource`). This is the escape hatch for disk-write-restricted environments — at the cost of higher heap usage.
 
 ### SharedStrings
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -814,7 +814,7 @@ SpreadsheetMapper mapper = SpreadsheetMapper.builder()
 
 | Feature | Default | Description |
 |---------|---------|-------------|
-| `USE_POI_USER_MODEL` | disabled | Use POI's User Model (Sheet/Row/Cell) for all read/write, bypassing streaming |
+| `USE_POI_USER_MODEL` | disabled | Use POI's User Model (Sheet/Row/Cell) for all read/write, bypassing streaming. Also skips InputStream temp-file copy — see [InputStream Handling](#inputstream-handling). |
 | `FILE_BACKED_SHARED_STRINGS` | disabled | Store shared strings on disk for read and write (requires `com.h2database:h2`) |
 | `ENCRYPT_FILE_BACKED_STORE` | disabled | Encrypt the file-backed store with AES (requires `FILE_BACKED_SHARED_STRINGS`) |
 
@@ -844,6 +844,19 @@ For large files, XLSX is strongly recommended.
 When reading from an `InputStream`, OOXML (XLSX) files are copied to a temporary file first because ZIP format requires random access. The temp file is cleaned up when the parser is closed.
 
 For best performance with large XLSX files, prefer `File` input over `InputStream`.
+
+**Disk-write-restricted environments** (AWS Lambda read-only filesystem, Kubernetes pods with `readOnlyRootFilesystem: true`, Docker `--read-only`, sandbox runners) cannot create the temp file. Two options:
+
+1. **Use `File` input** — POI reads directly from disk, no temp file.
+2. **Enable `USE_POI_USER_MODEL`** — InputStream is passed directly to POI, which holds the entire ZIP in memory (no temp file). Trade-off: higher heap usage. POI's own javadoc recommends `File` over `InputStream` when possible because of this.
+
+```java
+// In-memory read from InputStream (no temp file)
+SpreadsheetMapper mapper = SpreadsheetMapper.builder()
+    .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL)
+    .build();
+List<Row> rows = mapper.readValues(inputStream, Row.class);
+```
 
 ## Performance
 
@@ -919,7 +932,7 @@ It is ignored. Only columns matching the schema (derived from the class structur
 Yes. Use `SheetInput.source(file, "SheetName")` or `SheetInput.source(file, sheetIndex)` to target a specific sheet. For multiple sheets, use direct `Sheet` access via POI `Workbook`.
 
 **Q: Why does InputStream reading create a temp file?**
-XLSX is a ZIP archive. ZIP requires random access (seek), which `InputStream` does not support. The library copies the stream to a temp file, reads it, and deletes the file when done.
+XLSX is a ZIP archive. ZIP requires random access (seek), which `InputStream` does not support. The library copies the stream to a temp file, reads it, and deletes the file when done. In disk-write-restricted environments (Lambda read-only fs, Kubernetes `readOnlyRootFilesystem`), enable `USE_POI_USER_MODEL` to skip the temp file at the cost of higher heap usage — see [InputStream Handling](#inputstream-handling).
 
 **Q: How is the column order determined?**
 By the field declaration order in the Java class. Nested object fields are flattened in-place.

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SpreadsheetFactory.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SpreadsheetFactory.java
@@ -300,13 +300,26 @@ public final class SpreadsheetFactory extends JsonFactory {
                     ? SheetInput.source(raw, src.getName())
                     : SheetInput.source(raw, src.getIndex());
         }
-        final File file = POICompat.createSecureTempFile("jackson-spreadsheet-input-", ".xlsx").toFile();
-        try (FileOutputStream out = new FileOutputStream(file)) {
-            final byte[] buf = new byte[8192];
-            int n;
-            while ((n = raw.read(buf)) != -1) {
-                out.write(buf, 0, n);
+        File file = null;
+        try {
+            file = POICompat.createSecureTempFile("jackson-spreadsheet-input-", ".xlsx").toFile();
+            try (FileOutputStream out = new FileOutputStream(file)) {
+                final byte[] buf = new byte[8192];
+                int n;
+                while ((n = raw.read(buf)) != -1) {
+                    out.write(buf, 0, n);
+                }
             }
+        } catch (IOException e) {
+            if (file != null) {
+                try { Files.deleteIfExists(file.toPath()); } catch (IOException cleanup) { e.addSuppressed(cleanup); }
+            }
+            throw new IOException(
+                    "Failed to spool InputStream to temp file. "
+                            + "If running in a disk-write-restricted environment "
+                            + "(e.g. Lambda read-only filesystem, Kubernetes readOnlyRootFilesystem), "
+                            + "enable SpreadsheetFactory.Feature.USE_POI_USER_MODEL to read directly "
+                            + "from the InputStream (uses more heap; see POI WorkbookFactory javadoc).", e);
         }
         if (log.isDebugEnabled()) {
             log.debug("Copied InputStream to temp file: {}", file);


### PR DESCRIPTION
## Summary

The InputStream read path silently spools OOXML to a temp file, which fails in disk-write-restricted environments (Lambda read-only fs, Kubernetes `readOnlyRootFilesystem`, Docker `--read-only`). Users typically discover this only at deployment when local dev works fine.

`USE_POI_USER_MODEL` bypasses the spool by passing the stream directly to POI, which holds the entire ZIP in memory (verified against POI 5.5.1 source: `ZipInputStreamZipEntrySource` with default `thresholdForTempFiles = -1` means temp files are not used). This is a real escape hatch — the trade-off is higher heap usage, which POI's own javadoc flags.

## Changes

- **GUIDE InputStream Handling**: list disk-restricted environments and document the two escape hatches (`File` input or `USE_POI_USER_MODEL`) with a code example.
- **GUIDE Features table**: surface the disk-bypass effect on the `USE_POI_USER_MODEL` row so users browsing features see it.
- **GUIDE FAQ** entry on temp files: link to the new section.
- **ARCHITECTURE**: extend the InputStream paragraph to name the bypass mechanism (`ZipInputStreamZipEntrySource`) and call it the escape hatch.
- **`_preferRawAsFile` catch**: wrap the `IOException` with a hint pointing to `USE_POI_USER_MODEL`, and clean up any partial temp file via `addSuppressed` (prevents leak when write fails mid-stream after `createSecureTempFile` succeeded).

No fallback is introduced — fail-fast is preserved so users get a clear signal and choose the escape hatch consciously, rather than silently trading disk for OOM risk on large files.

## Test plan

- [x] Full test suite green
- [x] POI 5.5.1 source verified (`ZipInputStreamZipEntrySource.java:41` default `-1`, `ZipPackage.java:63` default `false`)
- [x] Doc cross-references resolve (`#inputstream-handling` anchor)
- [ ] CI green