### PR TITLE
Track temp files via Set + shutdown hook (replace deleteOnExit)

### DIFF
--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SpreadsheetFactory.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SpreadsheetFactory.java
@@ -312,7 +312,7 @@ public final class SpreadsheetFactory extends JsonFactory {
             }
         } catch (IOException e) {
             if (file != null) {
-                try { Files.deleteIfExists(file.toPath()); } catch (IOException cleanup) { e.addSuppressed(cleanup); }
+                try { POICompat.releaseTempFile(file.toPath()); } catch (IOException cleanup) { e.addSuppressed(cleanup); }
             }
             throw new IOException(
                     "Failed to spool InputStream to temp file. "

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetParser.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetParser.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.Iterator;
@@ -25,6 +24,7 @@ import io.github.scndry.jackson.dataformat.spreadsheet.PackageVersion;
 import io.github.scndry.jackson.dataformat.spreadsheet.SheetLocation;
 import io.github.scndry.jackson.dataformat.spreadsheet.SheetStreamContext;
 import io.github.scndry.jackson.dataformat.spreadsheet.SheetStreamReadException;
+import io.github.scndry.jackson.dataformat.spreadsheet.poi.POICompat;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.ColumnPointer;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
@@ -309,7 +309,7 @@ public final class SheetParser extends ParserMinimalBase {
         if (content instanceof SheetInput) {
             final SheetInput<?> input = (SheetInput<?>) content;
             if (_ioContext.isResourceManaged() && input.isFile()) {
-                Files.deleteIfExists(((File) input.getRaw()).toPath());
+                POICompat.releaseTempFile(((File) input.getRaw()).toPath());
             }
         }
     }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/POICompat.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/POICompat.java
@@ -8,6 +8,8 @@ import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.EnumSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.poi.openxml4j.opc.OPCPackage;
 import org.apache.poi.ss.usermodel.Workbook;
@@ -56,9 +58,27 @@ public final class POICompat {
     private static volatile File _tempDir;
 
     /**
+     * Tracked temp files awaiting cleanup. The shutdown hook deletes any
+     * entries still present at JVM exit. Normal release paths
+     * ({@link #releaseTempFile}) remove their entry, so steady-state usage
+     * does not accumulate — avoiding the unbounded growth of
+     * {@link File#deleteOnExit()} (which has no unregister API).
+     */
+    private static final Set<Path> TRACKED = ConcurrentHashMap.newKeySet();
+
+    static {
+        Runtime.getRuntime().addShutdownHook(new Thread(POICompat::_cleanupTrackedOnShutdown,
+                "jackson-spreadsheet-temp-cleanup"));
+    }
+
+    /**
      * Creates a temporary file in POI's temp directory under a dedicated
      * {@code jackson-spreadsheet} subdirectory, with owner-only permissions
      * on POSIX systems. Falls back to default permissions on Windows.
+     * <p>
+     * The returned path is tracked for shutdown-time cleanup. Callers must
+     * invoke {@link #releaseTempFile(Path)} when the file is no longer
+     * needed so the tracker entry is removed.
      */
     public static Path createSecureTempFile(final String prefix, final String suffix) throws IOException {
         final Path dir = tempDir().toPath();
@@ -71,8 +91,32 @@ public final class POICompat {
         } catch (UnsupportedOperationException e) {
             path = Files.createTempFile(dir, prefix, suffix);
         }
-        path.toFile().deleteOnExit();
+        TRACKED.add(path);
         return path;
+    }
+
+    /**
+     * Deletes the temp file and removes it from the shutdown tracker.
+     * Safe to call on a path that was never tracked or already released.
+     * <p>
+     * Delete is attempted before the tracker is updated: if delete fails,
+     * the path stays in the tracker so the shutdown hook can retry — useful
+     * for transient failures (full disk, Windows file lock) that may resolve
+     * by JVM exit time.
+     */
+    public static void releaseTempFile(final Path path) throws IOException {
+        Files.deleteIfExists(path);
+        TRACKED.remove(path);
+    }
+
+    private static void _cleanupTrackedOnShutdown() {
+        for (final Path p : TRACKED) {
+            try {
+                Files.deleteIfExists(p);
+            } catch (Exception ignored) {
+            }
+        }
+        TRACKED.clear();
     }
 
     /**

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/FileBackedSharedStringsLookup.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/FileBackedSharedStringsLookup.java
@@ -1,7 +1,6 @@
 package io.github.scndry.jackson.dataformat.spreadsheet.poi.ooxml;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.SecureRandom;
 import java.util.Arrays;
@@ -62,7 +61,7 @@ final class FileBackedSharedStringsLookup implements SharedStringsLookup {
             _strings = _store.openMap("sharedStrings");
         } catch (RuntimeException e) {
             _reader.close();
-            try { Files.deleteIfExists(_storePath); } catch (IOException ignored) {}
+            try { POICompat.releaseTempFile(_storePath); } catch (IOException ignored) {}
             throw e;
         }
     }
@@ -91,7 +90,7 @@ final class FileBackedSharedStringsLookup implements SharedStringsLookup {
             _reader.close();
             _store.close();
         } finally {
-            Files.deleteIfExists(_storePath);
+            POICompat.releaseTempFile(_storePath);
         }
     }
 

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/FileBackedSharedStringsStore.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/FileBackedSharedStringsStore.java
@@ -1,7 +1,6 @@
 package io.github.scndry.jackson.dataformat.spreadsheet.poi.ooxml;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.SecureRandom;
 import java.util.Arrays;
@@ -46,7 +45,7 @@ final class FileBackedSharedStringsStore implements SharedStringsStore {
             _stringsByIndex = _store.openMap("indexToString");
         } catch (RuntimeException e) {
             try {
-                Files.deleteIfExists(_storePath);
+                POICompat.releaseTempFile(_storePath);
             } catch (IOException ignored) {
             }
             throw e;
@@ -106,7 +105,7 @@ final class FileBackedSharedStringsStore implements SharedStringsStore {
                 _store.close();
             }
         } finally {
-            Files.deleteIfExists(_storePath);
+            POICompat.releaseTempFile(_storePath);
         }
     }
 

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLSheetWriter.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLSheetWriter.java
@@ -253,8 +253,14 @@ public final class SSMLSheetWriter implements SheetWriter {
         } catch (IOException e) {
             failure = _mergeFailure(failure, e);
         }
-        if (_scaffold != null && !_scaffold.delete() && log.isDebugEnabled()) {
-            log.debug("Failed to delete scaffold temp file: {}", _scaffold);
+        if (_scaffold != null) {
+            try {
+                POICompat.releaseTempFile(_scaffold.toPath());
+            } catch (IOException e) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Failed to delete scaffold temp file: {}", _scaffold, e);
+                }
+            }
         }
         if (failure != null) {
             throw failure;


### PR DESCRIPTION
## Summary

POI's `TempFile` javadoc warns that `File.deleteOnExit()` can cause `OutOfMemoryError` under frequent usage, because JDK's `DeleteOnExitHook` holds every registered path in a `LinkedHashSet` with no unregister API. POI's own default strategy uses `deleteOnExit` only when an opt-in system property (`poi.delete.tmp.files.on.exit`) is set — verified against POI 5.5.1 source (`DefaultTempFileCreationStrategy.java:99-101`).

`POICompat.createSecureTempFile` called `deleteOnExit` unconditionally on every temp file (input spool, SSML scaffold, file-backed shared strings store/lookup). On a long-running server with high request volume this accumulates path entries indefinitely — the normal close path deletes the underlying file but the JDK has no way to remove the entry from the deleteOnExit list.

Replace with a `Set<Path>` tracker plus a single shutdown hook.

## Changes

**`POICompat`:**
- `createSecureTempFile()` registers the path in `TRACKED`, no `deleteOnExit`.
- `releaseTempFile(Path)` deletes the file then removes the entry — delete first, so a transient failure (full disk, Windows file lock) leaves the entry in `TRACKED` for the shutdown hook to retry by JVM exit time.
- Shutdown hook iterates `TRACKED` and best-effort deletes anything not explicitly released. Catches `Exception` (not just `IOException`) so a single `SecurityException` cannot abort the loop and leave later entries on disk.

**Call sites updated to release through `POICompat`:**
- `SpreadsheetFactory._preferRawAsFile` catch path
- `SheetParser.close` (resource-managed file input)
- `SSMLSheetWriter` scaffold cleanup
- `FileBackedSharedStringsStore` constructor catch + `close`
- `FileBackedSharedStringsLookup` constructor catch + `close`

## Behavioral change

Code that never calls `close()` on parsers or writers used to have its temp files deleted at JVM exit via `deleteOnExit`. With this change, the shutdown hook still cleans them up as long as the JVM exits cleanly — same fallback, without the unbounded list growth. Security floor (POSIX owner-only permissions on the temp file, JVM-bound lifetime as a worst case) is preserved.

## Test plan

- [x] Full test suite green
- [x] POI 5.5.1 source verified (`DefaultTempFileCreationStrategy.java:99-101`, `TempFile.java:79`)
- [x] All 6 call sites of `Files.deleteIfExists` / `_scaffold.delete()` migrated
- [ ] CI green