### PR TITLE
Drop dead SSML branch from _createInputStreamSheetReader

### DIFF
--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SpreadsheetFactory.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SpreadsheetFactory.java
@@ -251,12 +251,9 @@ public final class SpreadsheetFactory extends JsonFactory {
 
     private SheetReader _createInputStreamSheetReader(
             final SheetInput<InputStream> src) throws IOException {
-        if (Feature.USE_POI_USER_MODEL.enabledIn(_featureFlags)) {
-            return _createPOISheetReader(WorkbookFactory.create(src.getRaw()), src);
-        }
-        if (PackageUtil.isOOXML(src.getRaw())) {
-            return _createSSMLSheetReader(SSMLWorkbook.create(src.getRaw()), src);
-        }
+        // Reachable only when _preferRawAsFile did not spool to a file:
+        //   USE_POI_USER_MODEL enabled, or non-OOXML input.
+        // Either way the read uses POI's User Model — SSML needs seekable I/O.
         return _createPOISheetReader(WorkbookFactory.create(src.getRaw()), src);
     }
 


### PR DESCRIPTION
## Summary

`_preferRawAsFile` spools every `InputStream` + OOXML input to a temp file when `USE_POI_USER_MODEL` is disabled, so by the time `createParser` dispatches by `source.isFile()` the OOXML+stream case has already been converted to a file. `_createInputStreamSheetReader` is therefore only reachable for two cases:

1. `USE_POI_USER_MODEL` enabled (OOXML or not)
2. `USE_POI_USER_MODEL` disabled + non-OOXML stream

The SSML branch (`if (PackageUtil.isOOXML(src.getRaw())) { return _createSSMLSheetReader(...); }`) was unreachable. Both remaining branches routed through `POISheetReader` anyway, so the `USE_POI_USER_MODEL` conditional collapsed too.

## Changes

`_createInputStreamSheetReader` reduced to a single `POISheetReader` return with an inline comment documenting the reachability invariant.

```java
private SheetReader _createInputStreamSheetReader(
        final SheetInput<InputStream> src) throws IOException {
    // Reachable only when _preferRawAsFile did not spool to a file:
    //   USE_POI_USER_MODEL enabled, or non-OOXML input.
    // Either way the read uses POI's User Model — SSML needs seekable I/O.
    return _createPOISheetReader(WorkbookFactory.create(src.getRaw()), src);
}
```

## Test plan

- [x] Full test suite green — no behavior change
- [x] Reachability verified by case analysis on `_preferRawAsFile` (every other case routes to `_createFileSheetReader`)
- [ ] CI green