### PR TITLE
Extract _generateKey to EncryptionKeys helper

### DIFF
--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/EncryptionKeys.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/EncryptionKeys.java
@@ -1,0 +1,26 @@
+package io.github.scndry.jackson.dataformat.spreadsheet.poi.ooxml;
+
+import java.security.SecureRandom;
+import java.util.Arrays;
+
+import org.apache.commons.codec.binary.Hex;
+
+/**
+ * Random key generation for the H2 MVStore-backed shared strings cache.
+ * H2's {@code MVStore.Builder.encryptionKey(char[])} expects hex-encoded
+ * characters; this helper produces 32 lower-case hex characters from
+ * 16 cryptographically random bytes.
+ */
+final class EncryptionKeys {
+
+    private EncryptionKeys() {
+    }
+
+    static char[] generate() {
+        final byte[] bytes = new byte[16];
+        new SecureRandom().nextBytes(bytes);
+        final char[] key = Hex.encodeHex(bytes);
+        Arrays.fill(bytes, (byte) 0);
+        return key;
+    }
+}

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/FileBackedSharedStringsLookup.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/FileBackedSharedStringsLookup.java
@@ -2,7 +2,6 @@ package io.github.scndry.jackson.dataformat.spreadsheet.poi.ooxml;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -53,7 +52,7 @@ final class FileBackedSharedStringsLookup implements SharedStringsLookup {
                     .cacheSize(4)
                     .autoCommitDisabled();
             if (encrypt) {
-                final char[] key = _generateKey();
+                final char[] key = EncryptionKeys.generate();
                 builder.encryptionKey(key);
                 Arrays.fill(key, '\0');
             }
@@ -92,18 +91,6 @@ final class FileBackedSharedStringsLookup implements SharedStringsLookup {
         } finally {
             POICompat.releaseTempFile(_storePath);
         }
-    }
-
-    private static char[] _generateKey() {
-        final byte[] bytes = new byte[16];
-        new SecureRandom().nextBytes(bytes);
-        final char[] key = new char[32];
-        for (int i = 0; i < bytes.length; i++) {
-            key[i * 2] = Character.forDigit((bytes[i] >> 4) & 0xF, 16);
-            key[i * 2 + 1] = Character.forDigit(bytes[i] & 0xF, 16);
-        }
-        Arrays.fill(bytes, (byte) 0);
-        return key;
     }
 
     private static Path _createSecureTempFile() throws IOException {

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/FileBackedSharedStringsStore.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/FileBackedSharedStringsStore.java
@@ -2,7 +2,6 @@ package io.github.scndry.jackson.dataformat.spreadsheet.poi.ooxml;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.security.SecureRandom;
 import java.util.Arrays;
 
 import org.h2.mvstore.MVMap;
@@ -36,7 +35,7 @@ final class FileBackedSharedStringsStore implements SharedStringsStore {
                     .cacheSize(4)
                     .autoCommitDisabled();
             if (encrypt) {
-                final char[] key = _generateKey();
+                final char[] key = EncryptionKeys.generate();
                 builder.encryptionKey(key);
                 Arrays.fill(key, '\0');
             }
@@ -107,18 +106,6 @@ final class FileBackedSharedStringsStore implements SharedStringsStore {
         } finally {
             POICompat.releaseTempFile(_storePath);
         }
-    }
-
-    private static char[] _generateKey() {
-        final byte[] bytes = new byte[16];
-        new SecureRandom().nextBytes(bytes);
-        final char[] key = new char[32];
-        for (int i = 0; i < bytes.length; i++) {
-            key[i * 2] = Character.forDigit((bytes[i] >> 4) & 0xF, 16);
-            key[i * 2 + 1] = Character.forDigit(bytes[i] & 0xF, 16);
-        }
-        Arrays.fill(bytes, (byte) 0);
-        return key;
     }
 
     private static Path _createSecureTempFile() throws IOException {


### PR DESCRIPTION
## Summary

`FileBackedSharedStringsStore` and `FileBackedSharedStringsLookup` carried identical 11-line copies of `_generateKey`. Pull the shared logic into a package-private `EncryptionKeys` helper in `poi/ooxml`, and replace the manual hex loop with `org.apache.commons.codec.binary.Hex.encodeHex` — already on the runtime classpath as a transitive POI dependency (verified via `./gradlew dependencies`: `commons-codec:1.20.0`).

## Changes

- New: `poi/ooxml/EncryptionKeys.java` — `static char[] generate()` returning 32 lower-case hex characters from 16 random bytes, with the intermediate byte buffer zeroed before return.
- `FileBackedSharedStringsStore`: drop `_generateKey`, call `EncryptionKeys.generate()`. Remove unused `SecureRandom` import.
- `FileBackedSharedStringsLookup`: same.

## Performance

`Hex.encodeHex` uses a lookup-table encode (`DIGITS_LOWER[(0xF0 & b) >>> 4]`) — at worst equivalent to `Character.forDigit` per char, likely slightly faster (no branches). Either way `_generateKey` is invoked once per encrypted store instance, so no measurable hot-path impact.

## Test plan

- [x] Full test suite green
- [x] `FileBackedSharedStringsStoreEncryptionTest` passes (including the wrong-key-rejected case, which transitively confirms the new key format is byte-compatible with the old loop)
- [ ] CI green