### PR TITLE
Remove Scarf tracking pixel from docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -352,7 +352,3 @@ Public API surface (types users typically import): `SpreadsheetMapper`, `@DataGr
 
 Everything under `poi/` is implementation detail — swappable without affecting the streaming contract.
 
----
-
-<sub>Anonymous, aggregated usage tracking via [Scarf](https://about.scarf.sh/). No personal information is collected.</sub>
-<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=5217c9e5-45fd-4941-a10b-354455edbd72&page=ARCHITECTURE.md" />

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -138,7 +138,3 @@ Filter specific benchmarks (and route results to per-benchmark files for separat
 
 Run benchmarks separately to avoid system noise accumulation across categories. GC profiler is enabled by default.
 
----
-
-<sub>Anonymous, aggregated usage tracking via [Scarf](https://about.scarf.sh/). No personal information is collected.</sub>
-<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=5217c9e5-45fd-4941-a10b-354455edbd72&page=BENCHMARK.md" />

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -164,7 +164,3 @@ Same annotations. Same API. Different format. That's the abstraction.
 
 If it doesn't pass this test — if the user has to learn a new API or write spreadsheet-specific code for something Jackson already handles — it's a design failure.
 
----
-
-<sub>Anonymous, aggregated usage tracking via [Scarf](https://about.scarf.sh/). No personal information is collected.</sub>
-<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=5217c9e5-45fd-4941-a10b-354455edbd72&page=DESIGN.md" />

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -947,7 +947,3 @@ Yes. Create a `SpreadsheetMapper` bean and inject it. It is thread-safe like `Ob
 - [Jackson documentation](https://github.com/FasterXML/jackson-docs)
 - [Apache POI](https://poi.apache.org/components/spreadsheet/index.html)
 
----
-
-<sub>Anonymous, aggregated usage tracking via [Scarf](https://about.scarf.sh/). No personal information is collected.</sub>
-<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=5217c9e5-45fd-4941-a10b-354455edbd72&page=GUIDE.md" />

--- a/README.md
+++ b/README.md
@@ -280,7 +280,3 @@ The mapper instance is reusable across threads once configured (same rule as Jac
 
 [Apache License 2.0](LICENSE)
 
----
-
-<sub>Anonymous, aggregated usage tracking via [Scarf](https://about.scarf.sh/). No personal information is collected.</sub>
-<img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=5217c9e5-45fd-4941-a10b-354455edbd72&page=README.md" />


### PR DESCRIPTION
Drops the Scarf pixel and disclosure footnote from README, GUIDE, ARCHITECTURE, DESIGN, BENCHMARK.

Privacy friction not worth the page-view data — Maven Central download stats are sufficient.