### PR TITLE
Transition to GitHub Flow + Maven SNAPSHOT on main

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -2,7 +2,7 @@ name: Snapshot
 
 on:
   push:
-    branches: [ 'release/**' ]
+    branches: [ 'main' ]
     paths-ignore:
       - '**.md'
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "io.github.scndry"
-version = "1.6.1"
+version = "1.6.2-SNAPSHOT"
 description = "Support for reading and writing Spreadsheet via Jackson abstractions."
 
 val title = "Jackson dataformat: Spreadsheet"


### PR DESCRIPTION
Branch policy 정합 정정.

- `snapshot.yml` trigger: `release/**` → `main`
- main version: `1.6.1` → `1.6.2-SNAPSHOT`

이후부터 main 이 항상 `X.Y.Z-SNAPSHOT` 상태 유지, main push 마다 snapshot publish 자동. `release/X.Y.Z` branch 사용 안 함.