### PR TITLE
Clean up develop and release/** branch references in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, 'release/**' ]
+    branches: [ main ]
 
 permissions:
   contents: read


### PR DESCRIPTION
Brand policy (1.6.2+) is main-only — drop `develop` and `release/**` references.