### PR TITLE
Clarify XLSX read/write streaming internals

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -103,7 +103,7 @@ You don't choose between XLSX and XLS parsers. You pass a file.
 mapper.readValues(file, Employee.class);  // XLSX or XLS — auto-detected
 ```
 
-Why auto-detect? Because the user shouldn't care about the container format. The data is the same. XLSX uses StAX streaming internally; XLS uses POI object model. The API is identical.
+Why auto-detect? Because the user shouldn't care about the container format. The data is the same. XLSX uses StAX for read and StringBuilder over a POI scaffold for write; XLS uses POI object model. The API is identical.
 
 ### Shared strings, styles, packaging → Configuration
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Fastest read and write throughput at 100K rows. See [BENCHMARK.md](BENCHMARK.md)
 | XLS read/write | Yes | Yes | No | No |
 | Annotation mapping | Yes | No | Yes | No |
 
-¹ XLSX streams via StAX; XLS uses in-memory POI workbook (HSSF has no streaming API).
+¹ XLSX read streams via StAX, write via StringBuilder over a POI scaffold; XLS uses in-memory POI workbook (HSSF has no streaming API).
 
 ## Key Features
 


### PR DESCRIPTION
XLSX read streams via StAX; XLSX write uses StringBuilder over a POI scaffold (no StAX). The earlier wording lumped both under StAX.