### PR TITLE
Refine package description to mention Excel (XLSX/XLS)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 group = "io.github.scndry"
 version = "1.6.2-SNAPSHOT"
-description = "Support for reading and writing Spreadsheet via Jackson abstractions."
+description = "Support for reading and writing Excel (XLSX/XLS) via Jackson abstractions."
 
 val title = "Jackson dataformat: Spreadsheet"
 // Compat-test override: ./gradlew test -PpoiVersion=4.1.1 -PjacksonVersion=2.14.0


### PR DESCRIPTION
The previous description (`reading and writing Spreadsheet via Jackson abstractions`) omitted the Excel keyword, weakening Maven Central / mvnrepository / search-engine matches. Aligns with how the README, GUIDE, and social preview already frame the library.