### PR TITLE
Add @DataColumnGroup multi-row header support

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -496,6 +496,59 @@ Customizes individual column properties. Unset attributes inherit from the enclo
 
 When `USE_POI_USER_MODEL` is enabled, `autoSize` measures the first 100 data rows in full, then samples every 100th data row thereafter. Sampling is anchored to the data start row, so a high `origin` does not skip the early data. This keeps overhead bounded for large workbooks (~1.5× write time at 100K rows). Outlier-long values that fall between sample rows after the first 100 may not influence the final width — pin a known column with `width` if exact fit matters more than sampling speed.
 
+### @DataColumnGroup
+
+Renders flattened columns from a nested object field under a shared group header. The annotation stacks across nesting depth to form multi-row headers — parent group on top, leaf names at the bottom.
+
+| Attribute | Default | Description |
+|-----------|---------|-------------|
+| `value` | field name | Column group header name |
+| `comment` | `""` | Group header cell comment text |
+
+```java
+@DataGrid
+class Employee {
+    int id;
+    String name;
+    @DataColumnGroup(value = "Address", comment = "Customer billing address")
+    Address address;
+}
+class Address { String city; String zip; }
+```
+
+renders as:
+
+```
+| ID | Name | ====== Address ====== |
+|    |      | City      |   Zip     |
+| 1  | Alice| Seoul     |   12345   |
+```
+
+The header row count is `max(group depth) + 1`, derived automatically. Flat or shallow columns vertically merge from their hierarchy depth down to the leaf header row. Adjacent columns sharing parent path and group name merge horizontally; a different parent yields separate cells (e.g. `Q1` under `2024` vs `Q1` under `2025`). On read the parser auto-skips header rows and column reordering only matches the leaf row.
+
+For deeper hierarchies the annotation stacks naturally:
+
+```java
+class Company {
+    String name;
+    @DataColumnGroup("2024") YearMetrics year2024;
+    @DataColumnGroup("2025") YearMetrics year2025;
+}
+class YearMetrics {
+    @DataColumnGroup("Q1") QuarterMetrics q1;
+    @DataColumnGroup("Q2") QuarterMetrics q2;
+}
+class QuarterMetrics { int sales; int profit; }
+```
+
+```
+|       | ============== 2024 ============ | ============= 2025 ============ |
+|       | ===== Q1 ===== | ==== Q2 ======= | ===== Q1 ===== | ==== Q2 ====== |
+| Name  | Sales | Profit | Sales | Profit  | Sales | Profit | Sales | Profit |
+```
+
+Depth 3 is the practical limit; readability degrades beyond that. `setColumnReordering(true)` combined with `@DataColumnGroup` fails fast with `IllegalStateException` — disable reordering or remove the annotations.
+
 ### Attribute Resolution Order
 
 Column attributes resolve in priority order:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,6 +97,13 @@ mavenPublishing {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+    // Forward selected -P properties to the test JVM as system properties so
+    // demo-style tests (gated by @EnabledIfSystemProperty) can opt in.
+    listOf("demo").forEach { name ->
+        if (project.hasProperty(name)) {
+            systemProperty(name, project.property(name)!!)
+        }
+    }
 }
 
 jmh {

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/annotation/DataColumnGroup.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/annotation/DataColumnGroup.java
@@ -1,0 +1,122 @@
+package io.github.scndry.jackson.dataformat.spreadsheet.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import lombok.EqualsAndHashCode;
+
+import com.fasterxml.jackson.annotation.JacksonAnnotationValue;
+
+/**
+ * Annotates a nested object field to render its flattened columns
+ * under a shared group header. The {@link #value()} text becomes
+ * a horizontally merged header cell spanning all child columns of
+ * the nested object. Annotations stack across nesting depth to form
+ * multi-row headers (parent group on top, leaf column names at the
+ * bottom).
+ *
+ * <p>Applies to nested object fields. Collections of nested objects
+ * ({@code List<NestedType>}, arrays) are also supported — the group
+ * header spans every flattened column produced by the element type.
+ * On leaf fields the annotation is ignored (a warning is logged at
+ * schema build time).
+ *
+ * @see DataGrid
+ * @see DataColumn
+ * @see io.github.scndry.jackson.dataformat.spreadsheet.schema.Column
+ */
+@Target({ElementType.ANNOTATION_TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DataColumnGroup {
+
+    /** Group header text shown above the flattened child columns. */
+    String value();
+
+    @EqualsAndHashCode
+    final class Value implements JacksonAnnotationValue<DataColumnGroup> {
+
+        private static final Value EMPTY = new Value("");
+
+        private final String _name;
+
+        public Value(final String name) {
+            _name = name;
+        }
+
+        private Value(final DataColumnGroup ann) {
+            this(ann.value());
+        }
+
+        public static Value empty() { return EMPTY; }
+
+        public static Value from(final DataColumnGroup ann) {
+            return ann == null ? EMPTY : new Value(ann);
+        }
+
+        public String getName() { return _name; }
+
+        public boolean isEmpty() { return _name.isEmpty(); }
+
+        @Override
+        public Class<DataColumnGroup> valueFor() { return DataColumnGroup.class; }
+
+        @Override
+        public String toString() {
+            return "DataColumnGroup.Value(name=" + _name + ")";
+        }
+    }
+
+    /**
+     * Ordered hierarchy of {@link Value} entries representing the
+     * {@code @DataColumnGroup} annotations stacked from the outermost
+     * nested-object field down to the leaf column. An empty hierarchy means
+     * the column is flat (no enclosing group).
+     */
+    @EqualsAndHashCode
+    final class Hierarchy implements Iterable<Value> {
+
+        private static final Hierarchy EMPTY = new Hierarchy(Collections.emptyList());
+
+        private final List<Value> _groups;
+
+        private Hierarchy(final List<Value> groups) {
+            _groups = groups;
+        }
+
+        public static Hierarchy empty() { return EMPTY; }
+
+        public int depth() { return _groups.size(); }
+
+        public boolean isEmpty() { return _groups.isEmpty(); }
+
+        public Value at(final int depth) { return _groups.get(depth); }
+
+        public Hierarchy parentPath(final int depth) {
+            if (depth == 0) return EMPTY;
+            if (depth == _groups.size()) return this;
+            return new Hierarchy(Collections.unmodifiableList(_groups.subList(0, depth)));
+        }
+
+        public Hierarchy append(final Value group) {
+            if (group.isEmpty()) return this;
+            final List<Value> next = new ArrayList<>(_groups.size() + 1);
+            next.addAll(_groups);
+            next.add(group);
+            return new Hierarchy(Collections.unmodifiableList(next));
+        }
+
+        @Override
+        public Iterator<Value> iterator() { return _groups.iterator(); }
+
+        @Override
+        public String toString() {
+            return "DataColumnGroup.Hierarchy" + _groups;
+        }
+    }
+}

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/annotation/DataColumnGroup.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/annotation/DataColumnGroup.java
@@ -27,30 +27,39 @@ import com.fasterxml.jackson.annotation.JacksonAnnotationValue;
  * On leaf fields the annotation is ignored (a warning is logged at
  * schema build time).
  *
+ * <p>If combined with {@link com.fasterxml.jackson.annotation.JsonUnwrapped @JsonUnwrapped}
+ * on the same field, the group is silently ignored.
+ *
  * @see DataGrid
  * @see DataColumn
  * @see io.github.scndry.jackson.dataformat.spreadsheet.schema.Column
  */
+@Incubating
 @Target({ElementType.ANNOTATION_TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface DataColumnGroup {
 
-    /** Group header text shown above the flattened child columns. */
-    String value();
+    /** Column group header name. */
+    String value() default "";
+
+    /** Comment text for the header cell of this column group. */
+    String comment() default "";
 
     @EqualsAndHashCode
     final class Value implements JacksonAnnotationValue<DataColumnGroup> {
 
-        private static final Value EMPTY = new Value("");
+        private static final Value EMPTY = new Value("", "");
 
         private final String _name;
+        private final String _comment;
 
-        public Value(final String name) {
+        public Value(final String name, final String comment) {
             _name = name;
+            _comment = comment;
         }
 
         private Value(final DataColumnGroup ann) {
-            this(ann.value());
+            this(ann.value(), ann.comment());
         }
 
         public static Value empty() { return EMPTY; }
@@ -61,6 +70,8 @@ public @interface DataColumnGroup {
 
         public String getName() { return _name; }
 
+        public String getComment() { return _comment; }
+
         public boolean isEmpty() { return _name.isEmpty(); }
 
         @Override
@@ -68,7 +79,7 @@ public @interface DataColumnGroup {
 
         @Override
         public String toString() {
-            return "DataColumnGroup.Value(name=" + _name + ")";
+            return "DataColumnGroup.Value(name=" + _name + ", comment=" + _comment + ")";
         }
     }
 
@@ -89,20 +100,39 @@ public @interface DataColumnGroup {
             _groups = groups;
         }
 
+        /** Returns the canonical empty hierarchy (no enclosing groups). */
         public static Hierarchy empty() { return EMPTY; }
 
+        /** Number of groups in this hierarchy. {@code 0} for {@link #empty()}. */
         public int depth() { return _groups.size(); }
 
         public boolean isEmpty() { return _groups.isEmpty(); }
 
+        /**
+         * Returns the {@link Value} at the given hierarchy position.
+         *
+         * @throws IndexOutOfBoundsException if {@code depth < 0 || depth >= depth()}
+         */
         public Value at(final int depth) { return _groups.get(depth); }
 
+        /**
+         * Returns a sub-hierarchy containing the first {@code depth} groups.
+         * {@code parentPath(0)} returns {@link #empty()}; {@code parentPath(depth())}
+         * returns this same hierarchy.
+         *
+         * @throws IndexOutOfBoundsException if {@code depth < 0 || depth > depth()}
+         */
         public Hierarchy parentPath(final int depth) {
             if (depth == 0) return EMPTY;
             if (depth == _groups.size()) return this;
             return new Hierarchy(Collections.unmodifiableList(_groups.subList(0, depth)));
         }
 
+        /**
+         * Returns a new hierarchy with {@code group} appended at the bottom.
+         * If {@code group} is {@link Value#isEmpty() empty}, returns this same
+         * instance unchanged (no-op).
+         */
         public Hierarchy append(final Value group) {
             if (group.isEmpty()) return this;
             final List<Value> next = new ArrayList<>(_groups.size() + 1);

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetParser.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetParser.java
@@ -91,6 +91,12 @@ public final class SheetParser extends ParserMinimalBase {
     @Override
     public void setSchema(final FormatSchema schema) {
         _schema = (SpreadsheetSchema) schema;
+        if (_schema.getHeaderRowCount() > 1 && _schema.reordersColumns()) {
+            throw new IllegalStateException(
+                    "Column reordering is not supported with multi-row headers"
+                    + " (@DataColumnGroup). Disable column reordering or remove the"
+                    + " @DataColumnGroup annotations from the target class.");
+        }
         _parsingContext = SheetStreamContext.createRootContext(_schema);
     }
 
@@ -211,13 +217,18 @@ public final class SheetParser extends ParserMinimalBase {
         }
         SheetToken token = _reader.next();
         if (token == SheetToken.ROW_START) {
-            if (!_headerProcessed && _schema.usesHeader()
-                    && _schema.reordersColumns()
-                    && _reader.getRow() == _schema.getOriginRow()) {
-                _reorderSchemaByHeader();
-                _headerProcessed = true;
-            }
-            while (!_schema.isInRowBounds(_reader.getRow())) {
+            // Skip header rows (group rows + leaf header row). The reorder
+            // hook fires only when the reader sits on the leaf header row,
+            // so the check must run inside the skip loop — otherwise multi-
+            // row headers blow past the leaf row before reorder can happen.
+            while (true) {
+                if (!_headerProcessed && _schema.usesHeader()
+                        && _schema.reordersColumns()
+                        && _reader.getRow() == _schema.getLeafHeaderRow()) {
+                    _reorderSchemaByHeader();
+                    _headerProcessed = true;
+                }
+                if (_schema.isInRowBounds(_reader.getRow())) break;
                 token = _reader.next();
                 if (token == SheetToken.SHEET_DATA_END) break;
             }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLSheetWriter.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLSheetWriter.java
@@ -24,6 +24,7 @@ import org.apache.poi.xssf.usermodel.XSSFRelation;
 import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
 import io.github.scndry.jackson.dataformat.spreadsheet.poi.POICompat;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.ColumnPointer;
@@ -158,11 +159,82 @@ public final class SSMLSheetWriter implements SheetWriter {
 
     @Override
     public void writeHeaders() {
-        final int row = _schema.getOriginRow();
-        for (final Column column : _schema) {
-            final int col = _schema.columnIndexOf(column);
-            setReference(new CellAddress(row, col));
-            writeString(column.getName());
+        final int originRow = _schema.getOriginRow();
+        final int headerRowCount = _schema.getHeaderRowCount();
+        final int leafRow = _schema.getLeafHeaderRow();
+        final List<Column> columns = _schema.getColumns(ColumnPointer.empty());
+
+        // SSML is forward-only: write rows top-to-bottom. Each row mixes
+        // leaf column names (where hierarchy ends) and group cells (where
+        // hierarchy still extends below). Empty positions are handled by
+        // the vertical-merge step below.
+        for (int depth = 0; depth < headerRowCount; depth++) {
+            _writeMixedHeaderRow(originRow + depth, depth, columns);
+        }
+
+        // Vertical span for shallow-hierarchy (incl. flat) columns down to leaf row.
+        for (final Column column : columns) {
+            if (column == null) continue;
+            final int h = column.getGroupHierarchy().depth();
+            if (h >= headerRowCount - 1) continue;
+            final int colIdx = _schema.columnIndexOf(column);
+            final int rowspanStart = originRow + h;
+            if (leafRow > rowspanStart) {
+                _mergeRanges.add(new MergeRange(rowspanStart, leafRow, colIdx, colIdx));
+            }
+        }
+    }
+
+    private void _writeMixedHeaderRow(final int row, final int depth, final List<Column> columns) {
+        int i = 0;
+        while (i < columns.size()) {
+            final Column col = columns.get(i);
+            if (col == null) { i++; continue; }
+            final DataColumnGroup.Hierarchy hierarchy = col.getGroupHierarchy();
+            final int h = hierarchy.depth();
+
+            if (h == depth) {
+                // Column hierarchy ends at this depth — write leaf column name.
+                final int colIdx = _schema.columnIndexOf(col);
+                setReference(new CellAddress(row, colIdx));
+                writeString(col.getName());
+                i++;
+                continue;
+            }
+
+            if (h < depth) {
+                // Hierarchy ended above this row — vertical merge covers, skip.
+                i++;
+                continue;
+            }
+
+            // h > depth: group cell at this depth, possibly merged across adjacent
+            // columns sharing the same parent path + group name.
+            final DataColumnGroup.Hierarchy parentPath = hierarchy.parentPath(depth);
+            final String groupName = hierarchy.at(depth).getName();
+
+            int j = i + 1;
+            while (j < columns.size()) {
+                final Column col2 = columns.get(j);
+                if (col2 == null) break;
+                final DataColumnGroup.Hierarchy h2 = col2.getGroupHierarchy();
+                if (h2.depth() <= depth) break;
+                if (!h2.parentPath(depth).equals(parentPath)) break;
+                if (!h2.at(depth).getName().equals(groupName)) break;
+                j++;
+            }
+
+            final int firstColIdx = _schema.columnIndexOf(col);
+            final int lastColIdx = _schema.columnIndexOf(columns.get(j - 1));
+
+            setReference(new CellAddress(row, firstColIdx));
+            writeString(groupName);
+
+            if (firstColIdx < lastColIdx) {
+                _mergeRanges.add(new MergeRange(row, row, firstColIdx, lastColIdx));
+            }
+
+            i = j;
         }
     }
 
@@ -287,7 +359,7 @@ public final class SSMLSheetWriter implements SheetWriter {
             if (pointer.relativize(column.getPointer()).contains(ColumnPointer.array())) continue;
             final int col = _schema.columnIndexOf(column);
             if (col < 0) continue;
-            _mergeRanges.add(new MergeRange(row, row + size - 1, col));
+            _mergeRanges.add(new MergeRange(row, row + size - 1, col, col));
         }
     }
 
@@ -584,9 +656,9 @@ public final class SSMLSheetWriter implements SheetWriter {
         sb.append("<mergeCells count=\"").append(_mergeRanges.size()).append("\">");
         for (final MergeRange range : _mergeRanges) {
             sb.append("<mergeCell ref=\"")
-                    .append(_cellRef(range._firstRow, range._column))
+                    .append(_cellRef(range._firstRow, range._firstColumn))
                     .append(":")
-                    .append(_cellRef(range._lastRow, range._column))
+                    .append(_cellRef(range._lastRow, range._lastColumn))
                     .append("\"/>");
         }
         sb.append("</mergeCells>");
@@ -718,12 +790,15 @@ public final class SSMLSheetWriter implements SheetWriter {
     private static final class MergeRange {
         final int _firstRow;
         final int _lastRow;
-        final int _column;
+        final int _firstColumn;
+        final int _lastColumn;
 
-        MergeRange(final int firstRow, final int lastRow, final int column) {
+        MergeRange(final int firstRow, final int lastRow,
+                   final int firstColumn, final int lastColumn) {
             _firstRow = firstRow;
             _lastRow = lastRow;
-            _column = column;
+            _firstColumn = firstColumn;
+            _lastColumn = lastColumn;
         }
     }
 

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLSheetWriter.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLSheetWriter.java
@@ -28,6 +28,7 @@ import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGrou
 import io.github.scndry.jackson.dataformat.spreadsheet.poi.POICompat;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.ColumnPointer;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.HeaderLayoutVisitor;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.Styles;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.BackWriteProjection;
@@ -159,83 +160,28 @@ public final class SSMLSheetWriter implements SheetWriter {
 
     @Override
     public void writeHeaders() {
-        final int originRow = _schema.getOriginRow();
-        final int headerRowCount = _schema.getHeaderRowCount();
-        final int leafRow = _schema.getLeafHeaderRow();
-        final List<Column> columns = _schema.getColumns(ColumnPointer.empty());
-
-        // SSML is forward-only: write rows top-to-bottom. Each row mixes
-        // leaf column names (where hierarchy ends) and group cells (where
-        // hierarchy still extends below). Empty positions are handled by
-        // the vertical-merge step below.
-        for (int depth = 0; depth < headerRowCount; depth++) {
-            _writeMixedHeaderRow(originRow + depth, depth, columns);
-        }
-
-        // Vertical span for shallow-hierarchy (incl. flat) columns down to leaf row.
-        for (final Column column : columns) {
-            if (column == null) continue;
-            final int h = column.getGroupHierarchy().depth();
-            if (h >= headerRowCount - 1) continue;
-            final int colIdx = _schema.columnIndexOf(column);
-            final int rowspanStart = originRow + h;
-            if (leafRow > rowspanStart) {
-                _mergeRanges.add(new MergeRange(rowspanStart, leafRow, colIdx, colIdx));
-            }
-        }
-    }
-
-    private void _writeMixedHeaderRow(final int row, final int depth, final List<Column> columns) {
-        int i = 0;
-        while (i < columns.size()) {
-            final Column col = columns.get(i);
-            if (col == null) { i++; continue; }
-            final DataColumnGroup.Hierarchy hierarchy = col.getGroupHierarchy();
-            final int h = hierarchy.depth();
-
-            if (h == depth) {
-                // Column hierarchy ends at this depth — write leaf column name.
-                final int colIdx = _schema.columnIndexOf(col);
-                setReference(new CellAddress(row, colIdx));
-                writeString(col.getName());
-                i++;
-                continue;
+        _schema.forEachHeaderCell(new HeaderLayoutVisitor() {
+            @Override
+            public void visitColumnHeader(final int row, final int col, final Column column) {
+                setReference(new CellAddress(row, col));
+                writeString(column.getName());
             }
 
-            if (h < depth) {
-                // Hierarchy ended above this row — vertical merge covers, skip.
-                i++;
-                continue;
+            @Override
+            public void visitGroupCell(final int row, final int firstCol, final int lastCol,
+                                       final DataColumnGroup.Value group) {
+                setReference(new CellAddress(row, firstCol));
+                writeString(group.getName());
+                if (firstCol < lastCol) {
+                    _mergeRanges.add(new MergeRange(row, row, firstCol, lastCol));
+                }
             }
 
-            // h > depth: group cell at this depth, possibly merged across adjacent
-            // columns sharing the same parent path + group name.
-            final DataColumnGroup.Hierarchy parentPath = hierarchy.parentPath(depth);
-            final String groupName = hierarchy.at(depth).getName();
-
-            int j = i + 1;
-            while (j < columns.size()) {
-                final Column col2 = columns.get(j);
-                if (col2 == null) break;
-                final DataColumnGroup.Hierarchy h2 = col2.getGroupHierarchy();
-                if (h2.depth() <= depth) break;
-                if (!h2.parentPath(depth).equals(parentPath)) break;
-                if (!h2.at(depth).getName().equals(groupName)) break;
-                j++;
+            @Override
+            public void visitVerticalMerge(final int firstRow, final int lastRow, final int col) {
+                _mergeRanges.add(new MergeRange(firstRow, lastRow, col, col));
             }
-
-            final int firstColIdx = _schema.columnIndexOf(col);
-            final int lastColIdx = _schema.columnIndexOf(columns.get(j - 1));
-
-            setReference(new CellAddress(row, firstColIdx));
-            writeString(groupName);
-
-            if (firstColIdx < lastColIdx) {
-                _mergeRanges.add(new MergeRange(row, row, firstColIdx, lastColIdx));
-            }
-
-            i = j;
-        }
+        });
     }
 
     @Override

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ss/POISheetWriter.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ss/POISheetWriter.java
@@ -26,6 +26,7 @@ import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGrou
 import io.github.scndry.jackson.dataformat.spreadsheet.poi.POICompat;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.ColumnPointer;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.HeaderLayoutVisitor;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.Styles;
 import io.github.scndry.jackson.dataformat.spreadsheet.ser.SheetWriter;
@@ -86,76 +87,28 @@ public final class POISheetWriter implements SheetWriter {
 
     @Override
     public void writeHeaders() {
-        final int originRow = _schema.getOriginRow();
-        final int headerRowCount = _schema.getHeaderRowCount();
-        final int leafRow = _schema.getLeafHeaderRow();
-
-        // Column header text — each column at row = originRow + hierarchy depth
-        // so flat / shallow columns land at the top of their vertical-merge region
-        // (the cell actually rendered by the spreadsheet viewer).
-        for (final Column column : _schema) {
-            final int colIdx = _schema.columnIndexOf(column);
-            final int textRow = originRow + column.getGroupHierarchy().depth();
-            setReference(new CellAddress(textRow, colIdx));
-            writeString(column.getName());
-        }
-
-        if (headerRowCount == 1) return;
-
-        // Group header rows — adjacent columns sharing parent path + group name
-        // at this depth merge horizontally.
-        final List<Column> columns = _schema.getColumns(ColumnPointer.empty());
-        for (int depth = 0; depth < headerRowCount - 1; depth++) {
-            _writeGroupRow(originRow + depth, depth, columns);
-        }
-
-        // Vertical span for shallow-hierarchy (incl. flat) columns down to leaf row.
-        for (final Column column : _schema) {
-            final int h = column.getGroupHierarchy().depth();
-            if (h >= headerRowCount - 1) continue;
-            final int colIdx = _schema.columnIndexOf(column);
-            final int rowspanStart = originRow + h;
-            if (leafRow > rowspanStart) {
-                _sheet.addMergedRegion(new CellRangeAddress(
-                        rowspanStart, leafRow, colIdx, colIdx));
-            }
-        }
-    }
-
-    private void _writeGroupRow(final int row, final int depth, final List<Column> columns) {
-        int i = 0;
-        while (i < columns.size()) {
-            final Column col = columns.get(i);
-            if (col == null) { i++; continue; }
-            final DataColumnGroup.Hierarchy hierarchy = col.getGroupHierarchy();
-            if (depth >= hierarchy.depth()) { i++; continue; }
-            final DataColumnGroup.Hierarchy parentPath = hierarchy.parentPath(depth);
-            final String groupName = hierarchy.at(depth).getName();
-
-            int j = i + 1;
-            while (j < columns.size()) {
-                final Column col2 = columns.get(j);
-                if (col2 == null) break;
-                final DataColumnGroup.Hierarchy h2 = col2.getGroupHierarchy();
-                if (depth >= h2.depth()) break;
-                if (!h2.parentPath(depth).equals(parentPath)) break;
-                if (!h2.at(depth).getName().equals(groupName)) break;
-                j++;
+        _schema.forEachHeaderCell(new HeaderLayoutVisitor() {
+            @Override
+            public void visitColumnHeader(final int row, final int col, final Column column) {
+                setReference(new CellAddress(row, col));
+                writeString(column.getName());
             }
 
-            final int firstColIdx = _schema.columnIndexOf(col);
-            final int lastColIdx = _schema.columnIndexOf(columns.get(j - 1));
-
-            setReference(new CellAddress(row, firstColIdx));
-            writeString(groupName);
-
-            if (firstColIdx < lastColIdx) {
-                _sheet.addMergedRegion(new CellRangeAddress(
-                        row, row, firstColIdx, lastColIdx));
+            @Override
+            public void visitGroupCell(final int row, final int firstCol, final int lastCol,
+                                       final DataColumnGroup.Value group) {
+                setReference(new CellAddress(row, firstCol));
+                writeString(group.getName());
+                if (firstCol < lastCol) {
+                    _sheet.addMergedRegion(new CellRangeAddress(row, row, firstCol, lastCol));
+                }
             }
 
-            i = j;
-        }
+            @Override
+            public void visitVerticalMerge(final int firstRow, final int lastRow, final int col) {
+                _sheet.addMergedRegion(new CellRangeAddress(firstRow, lastRow, col, col));
+            }
+        });
     }
 
     @Override

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ss/POISheetWriter.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ss/POISheetWriter.java
@@ -22,6 +22,7 @@ import org.apache.poi.xssf.streaming.SXSSFSheet;
 import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
 import io.github.scndry.jackson.dataformat.spreadsheet.poi.POICompat;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.ColumnPointer;
@@ -85,11 +86,75 @@ public final class POISheetWriter implements SheetWriter {
 
     @Override
     public void writeHeaders() {
-        final int row = _schema.getOriginRow();
+        final int originRow = _schema.getOriginRow();
+        final int headerRowCount = _schema.getHeaderRowCount();
+        final int leafRow = _schema.getLeafHeaderRow();
+
+        // Column header text — each column at row = originRow + hierarchy depth
+        // so flat / shallow columns land at the top of their vertical-merge region
+        // (the cell actually rendered by the spreadsheet viewer).
         for (final Column column : _schema) {
-            final int col = _schema.columnIndexOf(column);
-            setReference(new CellAddress(row, col));
+            final int colIdx = _schema.columnIndexOf(column);
+            final int textRow = originRow + column.getGroupHierarchy().depth();
+            setReference(new CellAddress(textRow, colIdx));
             writeString(column.getName());
+        }
+
+        if (headerRowCount == 1) return;
+
+        // Group header rows — adjacent columns sharing parent path + group name
+        // at this depth merge horizontally.
+        final List<Column> columns = _schema.getColumns(ColumnPointer.empty());
+        for (int depth = 0; depth < headerRowCount - 1; depth++) {
+            _writeGroupRow(originRow + depth, depth, columns);
+        }
+
+        // Vertical span for shallow-hierarchy (incl. flat) columns down to leaf row.
+        for (final Column column : _schema) {
+            final int h = column.getGroupHierarchy().depth();
+            if (h >= headerRowCount - 1) continue;
+            final int colIdx = _schema.columnIndexOf(column);
+            final int rowspanStart = originRow + h;
+            if (leafRow > rowspanStart) {
+                _sheet.addMergedRegion(new CellRangeAddress(
+                        rowspanStart, leafRow, colIdx, colIdx));
+            }
+        }
+    }
+
+    private void _writeGroupRow(final int row, final int depth, final List<Column> columns) {
+        int i = 0;
+        while (i < columns.size()) {
+            final Column col = columns.get(i);
+            if (col == null) { i++; continue; }
+            final DataColumnGroup.Hierarchy hierarchy = col.getGroupHierarchy();
+            if (depth >= hierarchy.depth()) { i++; continue; }
+            final DataColumnGroup.Hierarchy parentPath = hierarchy.parentPath(depth);
+            final String groupName = hierarchy.at(depth).getName();
+
+            int j = i + 1;
+            while (j < columns.size()) {
+                final Column col2 = columns.get(j);
+                if (col2 == null) break;
+                final DataColumnGroup.Hierarchy h2 = col2.getGroupHierarchy();
+                if (depth >= h2.depth()) break;
+                if (!h2.parentPath(depth).equals(parentPath)) break;
+                if (!h2.at(depth).getName().equals(groupName)) break;
+                j++;
+            }
+
+            final int firstColIdx = _schema.columnIndexOf(col);
+            final int lastColIdx = _schema.columnIndexOf(columns.get(j - 1));
+
+            setReference(new CellAddress(row, firstColIdx));
+            writeString(groupName);
+
+            if (firstColIdx < lastColIdx) {
+                _sheet.addMergedRegion(new CellRangeAddress(
+                        row, row, firstColIdx, lastColIdx));
+            }
+
+            i = j;
         }
     }
 

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/Column.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/Column.java
@@ -7,12 +7,15 @@ import lombok.EqualsAndHashCode;
 import com.fasterxml.jackson.databind.JavaType;
 
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
 
 /**
  * Metadata for a single spreadsheet column within a
  * {@link SpreadsheetSchema}. Holds a {@link ColumnPointer}
- * identifying the column's position in the JSON tree and the
- * {@link DataColumn.Value} annotation values.
+ * identifying the column's position in the JSON tree, the
+ * {@link DataColumn.Value} annotation values, and the
+ * {@link DataColumnGroup} hierarchy (parent-to-leaf order)
+ * collected from enclosing nested-object fields.
  *
  * @see SpreadsheetSchema
  * @see ColumnPointer
@@ -24,17 +27,34 @@ public final class Column {
 
     private final ColumnPointer _pointer;
     private final DataColumn.Value _value;
+    private final DataColumnGroup.Hierarchy _groupHierarchy;
     private final JavaType _type;
     private final String[] _aliases;
 
     public Column(final ColumnPointer pointer, final DataColumn.Value value, final JavaType type) {
-        this(pointer, value, type, NO_ALIASES);
+        this(pointer, value, DataColumnGroup.Hierarchy.empty(), type, NO_ALIASES);
     }
 
     public Column(final ColumnPointer pointer, final DataColumn.Value value,
                   final JavaType type, final String[] aliases) {
+        this(pointer, value, DataColumnGroup.Hierarchy.empty(), type, aliases);
+    }
+
+    public Column(final ColumnPointer pointer,
+                  final DataColumn.Value value,
+                  final DataColumnGroup.Hierarchy groupHierarchy,
+                  final JavaType type) {
+        this(pointer, value, groupHierarchy, type, NO_ALIASES);
+    }
+
+    public Column(final ColumnPointer pointer,
+                  final DataColumn.Value value,
+                  final DataColumnGroup.Hierarchy groupHierarchy,
+                  final JavaType type,
+                  final String[] aliases) {
         this._pointer = pointer;
         this._value = value;
+        this._groupHierarchy = groupHierarchy == null ? DataColumnGroup.Hierarchy.empty() : groupHierarchy;
         this._type = type;
         this._aliases = aliases;
     }
@@ -72,6 +92,10 @@ public final class Column {
         return _value;
     }
 
+    public DataColumnGroup.Hierarchy getGroupHierarchy() {
+        return _groupHierarchy;
+    }
+
     public boolean isMerge() {
         return _value.isMerge();
     }
@@ -92,6 +116,7 @@ public final class Column {
         return new StringJoiner(", ", Column.class.getSimpleName() + "[", "]")
                 .add("pointer=" + _pointer)
                 .add("value=" + _value)
+                .add("groupHierarchy=" + _groupHierarchy)
                 .add("type=" + _type)
                 .toString();
     }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/HeaderLayoutVisitor.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/HeaderLayoutVisitor.java
@@ -1,0 +1,23 @@
+package io.github.scndry.jackson.dataformat.spreadsheet.schema;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.Incubating;
+
+/**
+ * Visitor invoked by {@link SpreadsheetSchema#forEachHeaderCell(HeaderLayoutVisitor)}
+ * for each cell in the header region of a multi-row header layout. All
+ * methods default to no-op so callers override only what they need.
+ */
+@Incubating
+public interface HeaderLayoutVisitor {
+
+    /** Leaf column header cell — written at row = origin + hierarchy depth. */
+    default void visitColumnHeader(final int row, final int col, final Column column) {}
+
+    /** Group header cell — possibly merged horizontally across firstCol..lastCol. */
+    default void visitGroupCell(final int row, final int firstCol, final int lastCol,
+                                final DataColumnGroup.Value group) {}
+
+    /** Vertical merge region for shallow-hierarchy columns (firstRow..lastRow at col). */
+    default void visitVerticalMerge(final int firstRow, final int lastRow, final int col) {}
+}

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
@@ -15,6 +15,7 @@ import org.apache.poi.ss.util.CellAddress;
 
 import com.fasterxml.jackson.core.FormatSchema;
 
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.grid.GridConfigurer;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.style.StylesBuilder;
 
@@ -113,6 +114,79 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
         return _origin.getRow() + (usesHeader() ? _headerRowCount - 1 : 0);
     }
 
+    /**
+     * Walk every cell in the header region (column headers, group cells,
+     * vertical-merge regions) and invoke the visitor. Used by writers and
+     * comment application to share the run-identification algorithm.
+     *
+     * <p>Cell visit order: row-by-row top to bottom, then vertical merges
+     * after the last header row. Within a row, columns are visited in
+     * declaration order. Group cells emit the firstCol..lastCol range so
+     * callers can register horizontal merges.
+     */
+    public void forEachHeaderCell(final HeaderLayoutVisitor visitor) {
+        if (!usesHeader()) return;
+        final int originRow = _origin.getRow();
+        for (int depth = 0; depth < _headerRowCount; depth++) {
+            _visitHeaderRow(originRow + depth, depth, visitor);
+        }
+        // Vertical merges for shallow-hierarchy (incl. flat) columns.
+        final int leafRow = originRow + _headerRowCount - 1;
+        for (final Column column : _columns) {
+            if (column == null) continue;
+            final int h = column.getGroupHierarchy().depth();
+            if (h >= _headerRowCount - 1) continue;
+            final int colIdx = columnIndexOf(column);
+            final int rowspanStart = originRow + h;
+            if (leafRow > rowspanStart) {
+                visitor.visitVerticalMerge(rowspanStart, leafRow, colIdx);
+            }
+        }
+    }
+
+    private void _visitHeaderRow(final int row, final int depth, final HeaderLayoutVisitor visitor) {
+        int i = 0;
+        while (i < _columns.size()) {
+            final Column col = _columns.get(i);
+            if (col == null) { i++; continue; }
+            final DataColumnGroup.Hierarchy hierarchy = col.getGroupHierarchy();
+            final int h = hierarchy.depth();
+
+            if (h == depth) {
+                // Column hierarchy ends at this depth — leaf header text.
+                visitor.visitColumnHeader(row, columnIndexOf(col), col);
+                i++;
+                continue;
+            }
+            if (h < depth) {
+                // Hierarchy ended above this row — vertical merge covers, skip.
+                i++;
+                continue;
+            }
+
+            // h > depth: group cell at this depth, possibly merged horizontally
+            // across adjacent columns sharing parent path + group name.
+            final DataColumnGroup.Hierarchy parentPath = hierarchy.parentPath(depth);
+            final String groupName = hierarchy.at(depth).getName();
+
+            int j = i + 1;
+            while (j < _columns.size()) {
+                final Column col2 = _columns.get(j);
+                if (col2 == null) break;
+                final DataColumnGroup.Hierarchy h2 = col2.getGroupHierarchy();
+                if (h2.depth() <= depth) break;
+                if (!h2.parentPath(depth).equals(parentPath)) break;
+                if (!h2.at(depth).getName().equals(groupName)) break;
+                j++;
+            }
+
+            final int firstColIdx = columnIndexOf(col);
+            final int lastColIdx = columnIndexOf(_columns.get(j - 1));
+            visitor.visitGroupCell(row, firstColIdx, lastColIdx, hierarchy.at(depth));
+            i = j;
+        }
+    }
+
     public boolean usesHeader() {
         return (_features & FEATURE_USE_HEADER) != 0;
     }
@@ -178,26 +252,34 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
 
     public void applyHeaderComments(final Sheet sheet) {
         if (!usesHeader()) return;
-        final int row = getDataRow() - 1;
         final CreationHelper factory = sheet.getWorkbook().getCreationHelper();
-        Drawing<?> drawing = null;
-        for (final Column column : _columns) {
-            if (column == null) continue;
-            final String text = column.getValue().getComment();
-            if (text.isEmpty()) continue;
-            if (drawing == null) {
-                drawing = sheet.createDrawingPatriarch();
+        forEachHeaderCell(new HeaderLayoutVisitor() {
+            private Drawing<?> drawing;
+
+            @Override
+            public void visitColumnHeader(final int row, final int col, final Column column) {
+                _addCommentIfPresent(row, col, column.getValue().getComment());
             }
-            final int col = columnIndexOf(column);
-            final ClientAnchor anchor = factory.createClientAnchor();
-            anchor.setCol1(col);
-            anchor.setRow1(row);
-            anchor.setCol2(col + COMMENT_BOX_WIDTH_COLS);
-            anchor.setRow2(row + COMMENT_BOX_HEIGHT_ROWS);
-            final Comment comment = drawing.createCellComment(anchor);
-            comment.setString(factory.createRichTextString(text));
-            comment.setAddress(row, col);
-        }
+
+            @Override
+            public void visitGroupCell(final int row, final int firstCol, final int lastCol,
+                                       final DataColumnGroup.Value group) {
+                _addCommentIfPresent(row, firstCol, group.getComment());
+            }
+
+            private void _addCommentIfPresent(final int row, final int col, final String text) {
+                if (text.isEmpty()) return;
+                if (drawing == null) drawing = sheet.createDrawingPatriarch();
+                final ClientAnchor anchor = factory.createClientAnchor();
+                anchor.setCol1(col);
+                anchor.setRow1(row);
+                anchor.setCol2(col + COMMENT_BOX_WIDTH_COLS);
+                anchor.setRow2(row + COMMENT_BOX_HEIGHT_ROWS);
+                final Comment c = drawing.createCellComment(anchor);
+                c.setString(factory.createRichTextString(text));
+                c.setAddress(row, col);
+            }
+        });
     }
 
     public void configureSheet(final Sheet sheet, final Styles styles, final int lastRow) {

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
@@ -45,6 +45,7 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
     private final int _features;
     private final StylesBuilder _stylesBuilder;
     private final GridConfigurer _gridConfigurer;
+    private final int _headerRowCount;
 
     public SpreadsheetSchema(
             final List<Column> columns,
@@ -57,6 +58,17 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
         _features = features;
         _stylesBuilder = stylesBuilder;
         _gridConfigurer = gridConfigurer;
+        _headerRowCount = _computeHeaderRowCount(columns);
+    }
+
+    private static int _computeHeaderRowCount(final List<Column> columns) {
+        int max = 0;
+        for (final Column col : columns) {
+            if (col == null) continue;
+            final int depth = col.getGroupHierarchy().depth();
+            if (depth > max) max = depth;
+        }
+        return max + 1;
     }
 
     @Override
@@ -85,7 +97,20 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
     }
 
     public int getDataRow() {
-        return _origin.getRow() + (usesHeader() ? 1 : 0);
+        return _origin.getRow() + (usesHeader() ? _headerRowCount : 0);
+    }
+
+    public int getHeaderRowCount() {
+        return _headerRowCount;
+    }
+
+    /**
+     * Row index of the last (leaf) header row — the row carrying column
+     * names. Group header rows (when present) sit above this row. When
+     * {@link #usesHeader()} is disabled this collapses to the origin row.
+     */
+    public int getLeafHeaderRow() {
+        return _origin.getRow() + (usesHeader() ? _headerRowCount - 1 : 0);
     }
 
     public boolean usesHeader() {
@@ -153,7 +178,7 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
 
     public void applyHeaderComments(final Sheet sheet) {
         if (!usesHeader()) return;
-        final int row = getOriginRow();
+        final int row = getDataRow() - 1;
         final CreationHelper factory = sheet.getWorkbook().getCreationHelper();
         Drawing<?> drawing = null;
         for (final Column column : _columns) {

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/generator/ArrayFormatVisitor.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/generator/ArrayFormatVisitor.java
@@ -35,7 +35,8 @@ final class ArrayFormatVisitor extends JsonArrayFormatVisitor.Base {
         final FormatVisitorWrapper visitor = new FormatVisitorWrapper(_wrapper, pointer);
         handler.acceptJsonFormatVisitor(visitor, elementType);
         if (visitor.isEmpty()) {
-            _wrapper.add(new Column(pointer, _wrapper.getColumn(), _type));
+            _wrapper.add(new Column(pointer, _wrapper.getColumn(),
+                    _wrapper.getGroupHierarchy(), _type));
         } else {
             _wrapper.addAll(visitor);
         }
@@ -44,6 +45,7 @@ final class ArrayFormatVisitor extends JsonArrayFormatVisitor.Base {
     @Override
     public void itemsFormat(final JsonFormatTypes format) throws JsonMappingException {
         final ColumnPointer pointer = _wrapper.getPointer().resolveArray();
-        _wrapper.add(new Column(pointer, _wrapper.getColumn(), _type));
+        _wrapper.add(new Column(pointer, _wrapper.getColumn(),
+                _wrapper.getGroupHierarchy(), _type));
     }
 }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/generator/FormatVisitorWrapper.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/generator/FormatVisitorWrapper.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonMapFormatVisitor;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonObjectFormatVisitor;
 
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.ColumnPointer;
@@ -30,25 +31,29 @@ public final class FormatVisitorWrapper
     private final ColumnPointer _pointer;
     private final DataGrid.Value _grid;
     private final DataColumn.Value _column;
+    private final DataColumnGroup.Hierarchy _groupHierarchy;
     private final List<Column> _columns;
 
     public FormatVisitorWrapper() {
-        this(ColumnPointer.empty(), DataGrid.Value.empty(), DataColumn.Value.empty(), null);
+        this(ColumnPointer.empty(), DataGrid.Value.empty(), DataColumn.Value.empty(),
+                DataColumnGroup.Hierarchy.empty(), null);
     }
 
     FormatVisitorWrapper(final FormatVisitorWrapper base, final ColumnPointer pointer) {
-        this(pointer, base._grid, base._column, base._provider);
+        this(pointer, base._grid, base._column, base._groupHierarchy, base._provider);
     }
 
     FormatVisitorWrapper(
             final ColumnPointer pointer,
             final DataGrid.Value sheet,
             final DataColumn.Value column,
+            final DataColumnGroup.Hierarchy groupHierarchy,
             final SerializerProvider provider) {
         super(provider);
         _pointer = pointer;
         _grid = sheet;
         _column = column;
+        _groupHierarchy = groupHierarchy;
         _columns = new ArrayList<>();
     }
 
@@ -84,6 +89,10 @@ public final class FormatVisitorWrapper
 
     DataColumn.Value getColumn() {
         return _column;
+    }
+
+    DataColumnGroup.Hierarchy getGroupHierarchy() {
+        return _groupHierarchy;
     }
 
     boolean isEmpty() {

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/generator/ObjectFormatVisitor.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/generator/ObjectFormatVisitor.java
@@ -59,15 +59,16 @@ final class ObjectFormatVisitor extends JsonObjectFormatVisitor.Base {
         final DataColumn.Value columnValue = _columnValue(prop, gridValue);
         final DataColumnGroup.Value groupValue = _columnGroupValue(prop);
 
+        final DataColumnGroup.Hierarchy childHierarchy = _wrapper.getGroupHierarchy().append(groupValue);
+
         final JsonTypeInfo typeInfo = type.getRawClass().getAnnotation(JsonTypeInfo.class);
         final JsonSubTypes subTypes = type.getRawClass().getAnnotation(JsonSubTypes.class);
         if (typeInfo != null && subTypes != null
                 && typeInfo.include() == JsonTypeInfo.As.PROPERTY) {
-            _polymorphicProperty(pointer, gridValue, columnValue, typeInfo, subTypes);
+            _polymorphicProperty(pointer, gridValue, columnValue, childHierarchy, typeInfo, subTypes);
             return;
         }
 
-        final DataColumnGroup.Hierarchy childHierarchy = _wrapper.getGroupHierarchy().append(groupValue);
         final FormatVisitorWrapper visitor = new FormatVisitorWrapper(
                 pointer,
                 gridValue,
@@ -95,9 +96,9 @@ final class ObjectFormatVisitor extends JsonObjectFormatVisitor.Base {
             final ColumnPointer pointer,
             final DataGrid.Value gridValue,
             final DataColumn.Value columnValue,
+            final DataColumnGroup.Hierarchy hierarchy,
             final JsonTypeInfo typeInfo,
             final JsonSubTypes subTypes) throws JsonMappingException {
-        final DataColumnGroup.Hierarchy hierarchy = _wrapper.getGroupHierarchy();
         // Type discriminator column
         final String discriminator = typeInfo.property();
         final ColumnPointer discPointer = pointer.resolve(discriminator);
@@ -158,7 +159,9 @@ final class ObjectFormatVisitor extends JsonObjectFormatVisitor.Base {
 
     private DataColumnGroup.Value _columnGroupValue(BeanProperty prop) {
         final DataColumnGroup ann = prop.getAnnotation(DataColumnGroup.class);
-        return DataColumnGroup.Value.from(ann);
+        if (ann == null) return DataColumnGroup.Value.empty();
+        final String name = ann.value().isEmpty() ? prop.getName() : ann.value();
+        return new DataColumnGroup.Value(name, ann.comment());
     }
 
     private void _checkTypeSupported(

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/generator/ObjectFormatVisitor.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/generator/ObjectFormatVisitor.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.util.ClassUtil;
 
 import io.github.scndry.jackson.dataformat.spreadsheet.ExcelDateModule;
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.ColumnPointer;
@@ -56,6 +57,7 @@ final class ObjectFormatVisitor extends JsonObjectFormatVisitor.Base {
         final ColumnPointer pointer = _wrapper.getPointer().resolve(prop.getName());
         final DataGrid.Value gridValue = _gridValue(prop);
         final DataColumn.Value columnValue = _columnValue(prop, gridValue);
+        final DataColumnGroup.Value groupValue = _columnGroupValue(prop);
 
         final JsonTypeInfo typeInfo = type.getRawClass().getAnnotation(JsonTypeInfo.class);
         final JsonSubTypes subTypes = type.getRawClass().getAnnotation(JsonSubTypes.class);
@@ -65,18 +67,25 @@ final class ObjectFormatVisitor extends JsonObjectFormatVisitor.Base {
             return;
         }
 
+        final DataColumnGroup.Hierarchy childHierarchy = _wrapper.getGroupHierarchy().append(groupValue);
         final FormatVisitorWrapper visitor = new FormatVisitorWrapper(
                 pointer,
                 gridValue,
                 columnValue,
+                childHierarchy,
                 _provider);
         final JsonSerializer<Object> serializer = _findValueSerializer(prop);
         _checkTypeSupported(serializer);
         serializer.acceptJsonFormatVisitor(visitor, type);
         if (visitor.isEmpty()) {
+            if (!groupValue.isEmpty() && log.isWarnEnabled()) {
+                log.warn("@DataColumnGroup on leaf field {} is ignored "
+                        + "(group requires a nested object).", pointer);
+            }
             final String columnName = _resolveColumnName(prop);
             final String[] aliases = _aliases(prop);
-            _wrapper.add(new Column(pointer, columnValue.withName(columnName), type, aliases));
+            _wrapper.add(new Column(pointer, columnValue.withName(columnName),
+                    _wrapper.getGroupHierarchy(), type, aliases));
         } else {
             _wrapper.addAll(visitor);
         }
@@ -88,11 +97,13 @@ final class ObjectFormatVisitor extends JsonObjectFormatVisitor.Base {
             final DataColumn.Value columnValue,
             final JsonTypeInfo typeInfo,
             final JsonSubTypes subTypes) throws JsonMappingException {
+        final DataColumnGroup.Hierarchy hierarchy = _wrapper.getGroupHierarchy();
         // Type discriminator column
         final String discriminator = typeInfo.property();
         final ColumnPointer discPointer = pointer.resolve(discriminator);
         _wrapper.add(new Column(discPointer,
                 columnValue.withName(discriminator),
+                hierarchy,
                 _provider.constructType(String.class)));
 
         // Union of all subtype fields (deduplicated by pointer)
@@ -101,7 +112,7 @@ final class ObjectFormatVisitor extends JsonObjectFormatVisitor.Base {
         for (final JsonSubTypes.Type sub : subTypes.value()) {
             final JavaType subType = _provider.constructType(sub.value());
             final FormatVisitorWrapper visitor = new FormatVisitorWrapper(
-                    pointer, gridValue, columnValue, _provider);
+                    pointer, gridValue, columnValue, hierarchy, _provider);
             final JsonSerializer<Object> ser = _provider.findValueSerializer(subType);
             ser.acceptJsonFormatVisitor(visitor, subType);
             for (final Column col : visitor) {
@@ -143,6 +154,11 @@ final class ObjectFormatVisitor extends JsonObjectFormatVisitor.Base {
     private DataColumn.Value _columnValue(BeanProperty prop, DataGrid.Value grid) {
         final DataColumn ann = prop.getAnnotation(DataColumn.class);
         return DataColumn.Value.from(ann).withDefaults(grid);
+    }
+
+    private DataColumnGroup.Value _columnGroupValue(BeanProperty prop) {
+        final DataColumnGroup ann = prop.getAnnotation(DataColumnGroup.class);
+        return DataColumnGroup.Value.from(ann);
     }
 
     private void _checkTypeSupported(

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/grid/GridConfigurer.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/grid/GridConfigurer.java
@@ -108,7 +108,7 @@ public final class GridConfigurer {
         if (!_autoFilter || schema.columnCount() == 0) return;
         final int firstCol = schema.getOriginColumn();
         final int lastCol = firstCol + schema.columnCount() - 1;
-        final int firstRow = schema.getOriginRow();
+        final int firstRow = schema.getLeafHeaderRow();
         final int endRow = lastRow < 0
                 ? sheet.getWorkbook().getSpreadsheetVersion().getMaxRows() - 1
                 : lastRow;

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/DataColumnGroupDemo.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/DataColumnGroupDemo.java
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import io.github.scndry.jackson.dataformat.spreadsheet.DataColumnGroupTest.Address;
 import io.github.scndry.jackson.dataformat.spreadsheet.DataColumnGroupTest.Company;
@@ -25,11 +26,14 @@ import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.grid.GridConfigurer;
 
 /**
- * Visual demo — writes 1-depth and 2-depth group output files to a stable
- * directory under the user home so LibreOffice / Excel can open them
- * directly. Re-runs each invocation overwrite the files.
+ * Visual demo — writes group output files to {@code build/data-column-group-demo/}
+ * so LibreOffice / Excel can open them directly. Disabled by default;
+ * enable with {@code ./gradlew test -Pdemo=true}.
  */
+@EnabledIfSystemProperty(named = "demo", matches = "true")
 class DataColumnGroupDemo {
+
+    private static final Path OUTPUT_DIR = Paths.get("build", "data-column-group-demo");
 
     @Test
     void writeDemoFiles() throws Exception {
@@ -39,7 +43,7 @@ class DataColumnGroupDemo {
                         .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL));
         SpreadsheetMapper ssmlMapper = new SpreadsheetMapper();
 
-        Path outDir = Paths.get(System.getProperty("user.home"), "jackson-spreadsheet-poc");
+        Path outDir = OUTPUT_DIR;
         Files.createDirectories(outDir);
 
         Employee employee = new Employee(1, "Alice", new Address("Seoul", "12345"));
@@ -90,7 +94,7 @@ class DataColumnGroupDemo {
                 .setOrigin("B2")
                 .setGridConfigurer(grid);
 
-        Path outDir = Paths.get(System.getProperty("user.home"), "jackson-spreadsheet-poc");
+        Path outDir = OUTPUT_DIR;
         Files.createDirectories(outDir);
 
         List<Employee> values = Arrays.asList(
@@ -144,7 +148,7 @@ class DataColumnGroupDemo {
                 .setOrigin("B2")
                 .setGridConfigurer(grid);
 
-        Path outDir = Paths.get(System.getProperty("user.home"), "jackson-spreadsheet-poc");
+        Path outDir = OUTPUT_DIR;
         Files.createDirectories(outDir);
 
         List<FlatEmployee> values = Arrays.asList(

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/DataColumnGroupDemo.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/DataColumnGroupDemo.java
@@ -1,0 +1,167 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.DataColumnGroupTest.Address;
+import io.github.scndry.jackson.dataformat.spreadsheet.DataColumnGroupTest.Company;
+import io.github.scndry.jackson.dataformat.spreadsheet.DataColumnGroupTest.Employee;
+import io.github.scndry.jackson.dataformat.spreadsheet.DataColumnGroupTest.QuarterMetrics;
+import io.github.scndry.jackson.dataformat.spreadsheet.DataColumnGroupTest.YearMetrics;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.grid.GridConfigurer;
+
+/**
+ * Visual demo — writes 1-depth and 2-depth group output files to a stable
+ * directory under the user home so LibreOffice / Excel can open them
+ * directly. Re-runs each invocation overwrite the files.
+ */
+class DataColumnGroupDemo {
+
+    @Test
+    void writeDemoFiles() throws Exception {
+        SpreadsheetMapper poiMapper = new SpreadsheetMapper(
+                new SpreadsheetFactory(SXSSFWorkbook::new,
+                        SpreadsheetFactory.DEFAULT_SHEET_PARSER_FEATURE_FLAGS)
+                        .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL));
+        SpreadsheetMapper ssmlMapper = new SpreadsheetMapper();
+
+        Path outDir = Paths.get(System.getProperty("user.home"), "jackson-spreadsheet-poc");
+        Files.createDirectories(outDir);
+
+        Employee employee = new Employee(1, "Alice", new Address("Seoul", "12345"));
+        Company company = new Company("Acme",
+                new YearMetrics(new QuarterMetrics(100, 20), new QuarterMetrics(110, 22)),
+                new YearMetrics(new QuarterMetrics(120, 25), new QuarterMetrics(130, 28)));
+
+        File poi1 = outDir.resolve("group-1depth-poi.xlsx").toFile();
+        poiMapper.writeValue(poi1, employee);
+        File poi2 = outDir.resolve("group-2depth-poi.xlsx").toFile();
+        poiMapper.writeValue(poi2, company);
+
+        File ssml1 = outDir.resolve("group-1depth-ssml.xlsx").toFile();
+        ssmlMapper.writeValue(ssml1, employee);
+        File ssml2 = outDir.resolve("group-2depth-ssml.xlsx").toFile();
+        ssmlMapper.writeValue(ssml2, company);
+
+        System.out.println("PoC demo files written to: " + outDir.toAbsolutePath());
+        System.out.println("  - " + poi1.getAbsolutePath());
+        System.out.println("  - " + poi2.getAbsolutePath());
+        System.out.println("  - " + ssml1.getAbsolutePath());
+        System.out.println("  - " + ssml2.getAbsolutePath());
+    }
+
+    /**
+     * Visual side-effect check — multi-row header combined with origin offset,
+     * autoFilter, and freezePane. Confirms that:
+     *   - origin "B2" shifts everything down/right (group rows + leaf + data)
+     *   - autoFilter arrows land on the leaf header row (not the top group row)
+     *   - freezePane covers all header rows + everything above origin
+     */
+    @Test
+    void writeDemoWithFeatures() throws Exception {
+        // origin = B2  → originRow=1
+        // 1-depth header → headerRowCount=2 → leafRow=2, dataRow=3
+        // freezePane rowSplit=3 → freeze rows 0..2 (everything above data)
+        GridConfigurer grid = new GridConfigurer()
+                .freezePane(0, 3)
+                .autoFilter();
+
+        SpreadsheetMapper poiMapper = new SpreadsheetMapper(
+                new SpreadsheetFactory(SXSSFWorkbook::new,
+                        SpreadsheetFactory.DEFAULT_SHEET_PARSER_FEATURE_FLAGS)
+                        .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL))
+                .setOrigin("B2")
+                .setGridConfigurer(grid);
+        SpreadsheetMapper ssmlMapper = new SpreadsheetMapper()
+                .setOrigin("B2")
+                .setGridConfigurer(grid);
+
+        Path outDir = Paths.get(System.getProperty("user.home"), "jackson-spreadsheet-poc");
+        Files.createDirectories(outDir);
+
+        List<Employee> values = Arrays.asList(
+                new Employee(1, "Alice", new Address("Seoul", "12345")),
+                new Employee(2, "Bob", new Address("Busan", "23456")),
+                new Employee(3, "Carol", new Address("Incheon", "34567")),
+                new Employee(4, "Dave", new Address("Daegu", "45678")),
+                new Employee(5, "Eve", new Address("Daejeon", "56789")));
+
+        File poi = outDir.resolve("group-with-features-poi.xlsx").toFile();
+        poiMapper.writeValue(poi, values, Employee.class);
+
+        File ssml = outDir.resolve("group-with-features-ssml.xlsx").toFile();
+        ssmlMapper.writeValue(ssml, values, Employee.class);
+
+        System.out.println("Features demo files:");
+        System.out.println("  - " + poi.getAbsolutePath());
+        System.out.println("  - " + ssml.getAbsolutePath());
+    }
+
+    /**
+     * Control case — same origin / autoFilter / freezePane setup but no
+     * {@link io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup}.
+     * Useful for diffing visual side effects against {@link #writeDemoWithFeatures()}.
+     */
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class FlatEmployee {
+        @DataColumn("ID") int id;
+        @DataColumn("Name") String name;
+        @DataColumn("City") String city;
+        @DataColumn("Zip") String zip;
+    }
+
+    @Test
+    void writeNonGroupDemoWithFeatures() throws Exception {
+        // origin = B2  → originRow=1
+        // No group → headerRowCount=1 → leafRow=1, dataRow=2
+        // freezePane rowSplit=2 (dataRow) → freeze rows 0..1, equivalent semantic to
+        // the group case (freeze everything above data).
+        GridConfigurer grid = new GridConfigurer()
+                .freezePane(0, 2)
+                .autoFilter();
+
+        SpreadsheetMapper poiMapper = new SpreadsheetMapper(
+                new SpreadsheetFactory(SXSSFWorkbook::new,
+                        SpreadsheetFactory.DEFAULT_SHEET_PARSER_FEATURE_FLAGS)
+                        .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL))
+                .setOrigin("B2")
+                .setGridConfigurer(grid);
+        SpreadsheetMapper ssmlMapper = new SpreadsheetMapper()
+                .setOrigin("B2")
+                .setGridConfigurer(grid);
+
+        Path outDir = Paths.get(System.getProperty("user.home"), "jackson-spreadsheet-poc");
+        Files.createDirectories(outDir);
+
+        List<FlatEmployee> values = Arrays.asList(
+                new FlatEmployee(1, "Alice", "Seoul", "12345"),
+                new FlatEmployee(2, "Bob", "Busan", "23456"),
+                new FlatEmployee(3, "Carol", "Incheon", "34567"),
+                new FlatEmployee(4, "Dave", "Daegu", "45678"),
+                new FlatEmployee(5, "Eve", "Daejeon", "56789"));
+
+        File poi = outDir.resolve("non-group-with-features-poi.xlsx").toFile();
+        poiMapper.writeValue(poi, values, FlatEmployee.class);
+
+        File ssml = outDir.resolve("non-group-with-features-ssml.xlsx").toFile();
+        ssmlMapper.writeValue(ssml, values, FlatEmployee.class);
+
+        System.out.println("Non-group features demo files:");
+        System.out.println("  - " + poi.getAbsolutePath());
+        System.out.println("  - " + ssml.getAbsolutePath());
+    }
+}

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/DataColumnGroupTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/DataColumnGroupTest.java
@@ -3,12 +3,20 @@ package io.github.scndry.jackson.dataformat.spreadsheet;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.usermodel.Comment;
+import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.util.CellRangeAddress;
 import org.apache.poi.xssf.streaming.SXSSFWorkbook;
@@ -20,6 +28,17 @@ import org.junit.jupiter.api.io.TempDir;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
@@ -383,6 +402,784 @@ class DataColumnGroupTest {
         assertThatThrownBy(() -> reorderMapper.readValue(file, EmployeeReadOrder.class))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Column reordering is not supported with multi-row headers");
+    }
+
+    // -- Group cell comment ----------------------------------------------
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class EmployeeWithGroupComment {
+        @DataColumn("ID") int id;
+        @DataColumn("Name") String name;
+        @DataColumnGroup(value = "Address", comment = "Customer billing address") Address address;
+    }
+
+    @Test
+    void groupCellComment_poi() throws Exception {
+        File file = tempFile("group-comment.xlsx");
+
+        EmployeeWithGroupComment value = new EmployeeWithGroupComment(
+                1, "Alice", new Address("Seoul", "12345"));
+        mapper.writeValue(file, value);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            // Group cell "Address" at (row 0, col 2)
+            Cell cell = sheet.getRow(0).getCell(2);
+            assertThat(cell.getStringCellValue()).isEqualTo("Address");
+            Comment comment = cell.getCellComment();
+            assertThat(comment).isNotNull();
+            assertThat(comment.getString().getString())
+                    .isEqualTo("Customer billing address");
+        }
+    }
+
+    @Test
+    void groupCellComment_ssml() throws Exception {
+        SpreadsheetMapper ssmlMapper = new SpreadsheetMapper();
+        File file = tempFile("group-comment-ssml.xlsx");
+
+        EmployeeWithGroupComment value = new EmployeeWithGroupComment(
+                1, "Alice", new Address("Seoul", "12345"));
+        ssmlMapper.writeValue(file, value);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            Cell cell = sheet.getRow(0).getCell(2);
+            assertThat(cell.getStringCellValue()).isEqualTo("Address");
+            Comment comment = cell.getCellComment();
+            assertThat(comment).isNotNull();
+            assertThat(comment.getString().getString())
+                    .isEqualTo("Customer billing address");
+        }
+    }
+
+    // -- value default fallback (field name) -----------------------------
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class EmployeeImplicitGroup {
+        @DataColumn("ID") int id;
+        @DataColumn("Name") String name;
+        @DataColumnGroup Address address;   // no value — falls back to field name
+    }
+
+    @Test
+    void groupValueFallsBackToFieldName() throws Exception {
+        File file = tempFile("group-implicit.xlsx");
+        EmployeeImplicitGroup value = new EmployeeImplicitGroup(
+                1, "Alice", new Address("Seoul", "12345"));
+        mapper.writeValue(file, value);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            // Group cell at (row 0, col 2) should carry the field name "address"
+            assertThat(sheet.getRow(0).getCell(2).getStringCellValue()).isEqualTo("address");
+        }
+    }
+
+    // -- Jackson annotation interop --------------------------------------
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+    @JsonSubTypes({
+            @JsonSubTypes.Type(value = Dog.class, name = "dog"),
+            @JsonSubTypes.Type(value = Cat.class, name = "cat")
+    })
+    static class Animal {
+        public String name;
+        public Animal() {}
+    }
+
+    static class Dog extends Animal {
+        public String breed;
+        public Dog() {}
+        public Dog(String name, String breed) { this.name = name; this.breed = breed; }
+    }
+
+    static class Cat extends Animal {
+        public boolean indoor;
+        public Cat() {}
+        public Cat(String name, boolean indoor) { this.name = name; this.indoor = indoor; }
+    }
+
+    @DataGrid
+    static class OwnerWithPet {
+        public String owner;
+        @DataColumnGroup("Pet") public Animal pet;
+        public OwnerWithPet() {}
+        public OwnerWithPet(String owner, Animal pet) { this.owner = owner; this.pet = pet; }
+    }
+
+    @Test
+    void polymorphicWithGroup() throws Exception {
+        File file = tempFile("group-polymorphic.xlsx");
+        mapper.writeValue(file, Arrays.asList(
+                new OwnerWithPet("Alice", new Dog("Rex", "Labrador")),
+                new OwnerWithPet("Bob", new Cat("Whiskers", true))),
+                OwnerWithPet.class);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            // Two header rows: row 0 (group + flat top), row 1 (leaf).
+            assertThat(sheet.getRow(0).getCell(0).getStringCellValue()).isEqualTo("owner");
+            assertThat(sheet.getRow(0).getCell(1).getStringCellValue()).isEqualTo("Pet");
+            assertThat(sheet.getRow(1).getCell(1).getStringCellValue()).isEqualTo("type");
+            assertThat(sheet.getRow(1).getCell(2).getStringCellValue()).isEqualTo("pet/name");
+            assertThat(sheet.getRow(1).getCell(3).getStringCellValue()).isEqualTo("pet/breed");
+            assertThat(sheet.getRow(1).getCell(4).getStringCellValue()).isEqualTo("pet/indoor");
+
+            // "Pet" group spans cols 1..4
+            List<CellRangeAddress> merged = sheet.getMergedRegions();
+            assertThat(merged).anySatisfy(r -> {
+                assertThat(r.getFirstRow()).isEqualTo(0);
+                assertThat(r.getLastRow()).isEqualTo(0);
+                assertThat(r.getFirstColumn()).isEqualTo(1);
+                assertThat(r.getLastColumn()).isEqualTo(4);
+            });
+
+            Row dogRow = sheet.getRow(2);
+            assertThat(dogRow.getCell(0).getStringCellValue()).isEqualTo("Alice");
+            assertThat(dogRow.getCell(1).getStringCellValue()).isEqualTo("dog");
+            assertThat(dogRow.getCell(2).getStringCellValue()).isEqualTo("Rex");
+            assertThat(dogRow.getCell(3).getStringCellValue()).isEqualTo("Labrador");
+        }
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class PlainAddress {
+        public String city;
+        public String zip;
+    }
+
+    // -- @JsonView + @DataColumnGroup -----------------------------------
+
+    static class GroupViews {
+        static class Summary {}
+        static class Detail extends Summary {}
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class ViewedDetails {
+        @JsonView(GroupViews.Summary.class) public String code;
+        @JsonView(GroupViews.Detail.class) public String description;
+    }
+
+    @DataGrid
+    static class WithViewedGroup {
+        @JsonView(GroupViews.Summary.class) public String name;
+        @DataColumnGroup("Details")
+        @JsonView(GroupViews.Summary.class)
+        public ViewedDetails details;
+        public WithViewedGroup() {}
+        public WithViewedGroup(String name, ViewedDetails details) {
+            this.name = name;
+            this.details = details;
+        }
+    }
+
+    /**
+     * Verifies {@code @JsonView} filtering inside a group: under the
+     * Summary view only Summary-tagged inner fields appear, and the group
+     * header still spans the visible columns.
+     */
+    @Test
+    void jsonViewWithGroup_summaryOnly() throws Exception {
+        SpreadsheetMapper viewMapper = SpreadsheetMapper.builder()
+                .configure(MapperFeature.DEFAULT_VIEW_INCLUSION, false)
+                .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL)
+                .build();
+
+        File file = tempFile("group-view.xlsx");
+        viewMapper.sheetWriterForWithView(WithViewedGroup.class, GroupViews.Summary.class)
+                .writeValue(file, Arrays.asList(
+                        new WithViewedGroup("A", new ViewedDetails("X", "long"))));
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            // Two header rows: outer "name" + group "Details", with single inner leaf.
+            assertThat(sheet.getRow(0).getCell(0).getStringCellValue()).isEqualTo("name");
+            assertThat(sheet.getRow(0).getCell(1).getStringCellValue()).isEqualTo("Details");
+            assertThat(sheet.getRow(1).getCell(1).getStringCellValue()).isEqualTo("details/code");
+            // "description" is filtered out.
+            assertThat(sheet.getRow(0).getCell(2)).isNull();
+
+            // Single-column group: no horizontal merge is created (library skips
+            // 1-cell merges in visitGroupCell). Vertical merge for the flat
+            // "name" column at col 0 still spans both header rows.
+            assertThat(sheet.getMergedRegions()).noneSatisfy(r -> {
+                assertThat(r.getFirstRow()).isEqualTo(0);
+                assertThat(r.getLastRow()).isEqualTo(0);
+                assertThat(r.getFirstColumn()).isEqualTo(1);
+                assertThat(r.getLastColumn()).isEqualTo(1);
+            });
+            assertThat(sheet.getMergedRegions()).anySatisfy(r -> {
+                assertThat(r.getFirstRow()).isEqualTo(0);
+                assertThat(r.getLastRow()).isEqualTo(1);
+                assertThat(r.getFirstColumn()).isEqualTo(0);
+                assertThat(r.getLastColumn()).isEqualTo(0);
+            });
+
+            Row dataRow = sheet.getRow(2);
+            assertThat(dataRow.getCell(0).getStringCellValue()).isEqualTo("A");
+            assertThat(dataRow.getCell(1).getStringCellValue()).isEqualTo("X");
+        }
+    }
+
+    @Test
+    void jsonViewWithGroup_detailIncludesAll() throws Exception {
+        SpreadsheetMapper viewMapper = SpreadsheetMapper.builder()
+                .configure(MapperFeature.DEFAULT_VIEW_INCLUSION, false)
+                .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL)
+                .build();
+
+        File file = tempFile("group-view-detail.xlsx");
+        viewMapper.sheetWriterForWithView(WithViewedGroup.class, GroupViews.Detail.class)
+                .writeValue(file, Arrays.asList(
+                        new WithViewedGroup("A", new ViewedDetails("X", "long"))));
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            // Detail extends Summary — both inner fields visible, group spans cols 1..2.
+            assertThat(sheet.getRow(0).getCell(0).getStringCellValue()).isEqualTo("name");
+            assertThat(sheet.getRow(0).getCell(1).getStringCellValue()).isEqualTo("Details");
+            assertThat(sheet.getRow(1).getCell(1).getStringCellValue()).isEqualTo("details/code");
+            assertThat(sheet.getRow(1).getCell(2).getStringCellValue()).isEqualTo("details/description");
+
+            assertThat(sheet.getMergedRegions()).anySatisfy(r -> {
+                assertThat(r.getFirstRow()).isEqualTo(0);
+                assertThat(r.getLastRow()).isEqualTo(0);
+                assertThat(r.getFirstColumn()).isEqualTo(1);
+                assertThat(r.getLastColumn()).isEqualTo(2);
+            });
+
+            Row dataRow = sheet.getRow(2);
+            assertThat(dataRow.getCell(0).getStringCellValue()).isEqualTo("A");
+            assertThat(dataRow.getCell(1).getStringCellValue()).isEqualTo("X");
+            assertThat(dataRow.getCell(2).getStringCellValue()).isEqualTo("long");
+        }
+    }
+
+    // -- @JsonNaming + @DataColumnGroup ---------------------------------
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class CamelInner {
+        public String streetName;
+        public String postalCode;
+    }
+
+    @DataGrid
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    static class WithSnakeCaseGroup {
+        public String userName;
+        @DataColumnGroup("Address")
+        public CamelInner homeAddress;
+        public WithSnakeCaseGroup() {}
+        public WithSnakeCaseGroup(String userName, CamelInner homeAddress) {
+            this.userName = userName;
+            this.homeAddress = homeAddress;
+        }
+    }
+
+    /**
+     * {@code @JsonNaming} is per-class — outer property names get the
+     * strategy applied (snake_case), but the inner class needs its own
+     * {@code @JsonNaming} to convert its fields. The group header value
+     * comes from the {@code @DataColumnGroup} literal and is untouched.
+     */
+    @Test
+    void jsonNamingWithGroup_outerStrategyOnly() throws Exception {
+        File file = tempFile("group-naming.xlsx");
+        mapper.writeValue(file, new WithSnakeCaseGroup(
+                "Alice", new CamelInner("Main", "12345")));
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            // Outer: snake_case applied. Group label: literal from annotation.
+            assertThat(sheet.getRow(0).getCell(0).getStringCellValue()).isEqualTo("user_name");
+            assertThat(sheet.getRow(0).getCell(1).getStringCellValue()).isEqualTo("Address");
+            // Inner leaf path: outer's @JsonNaming reaches the outer property
+            // ("home_address"); inner field names stay camelCase because
+            // CamelInner has no @JsonNaming of its own.
+            assertThat(sheet.getRow(1).getCell(1).getStringCellValue()).isEqualTo("home_address/streetName");
+            assertThat(sheet.getRow(1).getCell(2).getStringCellValue()).isEqualTo("home_address/postalCode");
+
+            Row dataRow = sheet.getRow(2);
+            assertThat(dataRow.getCell(0).getStringCellValue()).isEqualTo("Alice");
+            assertThat(dataRow.getCell(1).getStringCellValue()).isEqualTo("Main");
+            assertThat(dataRow.getCell(2).getStringCellValue()).isEqualTo("12345");
+        }
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    static class SnakeInner {
+        public String streetName;
+        public String postalCode;
+    }
+
+    @DataGrid
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    static class WithSnakeCaseGroupBoth {
+        public String userName;
+        @DataColumnGroup("Address")
+        public SnakeInner homeAddress;
+        public WithSnakeCaseGroupBoth() {}
+        public WithSnakeCaseGroupBoth(String userName, SnakeInner homeAddress) {
+            this.userName = userName;
+            this.homeAddress = homeAddress;
+        }
+    }
+
+    @Test
+    void jsonNamingWithGroup_appliedToInnerWhenAnnotated() throws Exception {
+        File file = tempFile("group-naming-both.xlsx");
+        mapper.writeValue(file, new WithSnakeCaseGroupBoth(
+                "Alice", new SnakeInner("Main", "12345")));
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            assertThat(sheet.getRow(0).getCell(0).getStringCellValue()).isEqualTo("user_name");
+            assertThat(sheet.getRow(0).getCell(1).getStringCellValue()).isEqualTo("Address");
+            // Inner with its own @JsonNaming → snake_case applied here too.
+            assertThat(sheet.getRow(1).getCell(1).getStringCellValue()).isEqualTo("home_address/street_name");
+            assertThat(sheet.getRow(1).getCell(2).getStringCellValue()).isEqualTo("home_address/postal_code");
+
+            Row dataRow = sheet.getRow(2);
+            assertThat(dataRow.getCell(0).getStringCellValue()).isEqualTo("Alice");
+            assertThat(dataRow.getCell(1).getStringCellValue()).isEqualTo("Main");
+            assertThat(dataRow.getCell(2).getStringCellValue()).isEqualTo("12345");
+        }
+    }
+
+    // -- @JsonPropertyOrder + @DataColumnGroup --------------------------
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    @JsonPropertyOrder({"surname", "givenName"})
+    static class OrderedInner {
+        public String givenName;
+        public String surname;
+    }
+
+    @DataGrid
+    @JsonPropertyOrder({"score", "details", "id"})
+    static class WithOrderAndGroup {
+        public int id;
+        @DataColumnGroup("Details")
+        public OrderedInner details;
+        public int score;
+        public WithOrderAndGroup() {}
+        public WithOrderAndGroup(int id, OrderedInner details, int score) {
+            this.id = id;
+            this.details = details;
+            this.score = score;
+        }
+    }
+
+    /**
+     * Outer {@code @JsonPropertyOrder} controls the position of the group
+     * field; inner {@code @JsonPropertyOrder} controls the order of leaf
+     * columns inside the group.
+     */
+    @Test
+    void jsonPropertyOrderWithGroup_innerAndOuter() throws Exception {
+        File file = tempFile("group-order.xlsx");
+        mapper.writeValue(file, new WithOrderAndGroup(
+                7, new OrderedInner("Alice", "Kim"), 99));
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            // Outer order: score, details (group spans cols 1..2), id.
+            assertThat(sheet.getRow(0).getCell(0).getStringCellValue()).isEqualTo("score");
+            assertThat(sheet.getRow(0).getCell(1).getStringCellValue()).isEqualTo("Details");
+            assertThat(sheet.getRow(0).getCell(3).getStringCellValue()).isEqualTo("id");
+            // Inner order: surname before givenName.
+            assertThat(sheet.getRow(1).getCell(1).getStringCellValue()).isEqualTo("details/surname");
+            assertThat(sheet.getRow(1).getCell(2).getStringCellValue()).isEqualTo("details/givenName");
+
+            assertThat(sheet.getMergedRegions()).anySatisfy(r -> {
+                assertThat(r.getFirstRow()).isEqualTo(0);
+                assertThat(r.getLastRow()).isEqualTo(0);
+                assertThat(r.getFirstColumn()).isEqualTo(1);
+                assertThat(r.getLastColumn()).isEqualTo(2);
+            });
+
+            Row dataRow = sheet.getRow(2);
+            assertThat((int) dataRow.getCell(0).getNumericCellValue()).isEqualTo(99);
+            assertThat(dataRow.getCell(1).getStringCellValue()).isEqualTo("Kim");
+            assertThat(dataRow.getCell(2).getStringCellValue()).isEqualTo("Alice");
+            assertThat((int) dataRow.getCell(3).getNumericCellValue()).isEqualTo(7);
+        }
+    }
+
+    // -- Mix-in + @DataColumnGroup --------------------------------------
+
+    static class ThirdPartyOrder {
+        public int id;
+        public PlainAddress address;
+        public ThirdPartyOrder() {}
+        public ThirdPartyOrder(int id, PlainAddress address) {
+            this.id = id;
+            this.address = address;
+        }
+    }
+
+    @DataGrid
+    abstract static class ThirdPartyOrderMixin {
+        @JsonProperty int id;
+        @DataColumnGroup("Address") PlainAddress address;
+    }
+
+    /**
+     * Verifies {@code @DataColumnGroup} can be applied via Jackson Mix-in
+     * to a third-party class that the user can't modify directly. The
+     * group header reaches the visitor through Jackson's annotation
+     * introspection.
+     */
+    @Test
+    void mixinWithGroup_appliesGroupHeader() throws Exception {
+        mapper.addMixIn(ThirdPartyOrder.class, ThirdPartyOrderMixin.class);
+
+        File file = tempFile("group-mixin.xlsx");
+        mapper.writeValue(file, new ThirdPartyOrder(
+                1, new PlainAddress("Seoul", "12345")));
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            assertThat(sheet.getRow(0).getCell(0).getStringCellValue()).isEqualTo("id");
+            assertThat(sheet.getRow(0).getCell(1).getStringCellValue()).isEqualTo("Address");
+            assertThat(sheet.getRow(1).getCell(1).getStringCellValue()).isEqualTo("address/city");
+            assertThat(sheet.getRow(1).getCell(2).getStringCellValue()).isEqualTo("address/zip");
+
+            assertThat(sheet.getMergedRegions()).anySatisfy(r -> {
+                assertThat(r.getFirstRow()).isEqualTo(0);
+                assertThat(r.getLastRow()).isEqualTo(0);
+                assertThat(r.getFirstColumn()).isEqualTo(1);
+                assertThat(r.getLastColumn()).isEqualTo(2);
+            });
+
+            Row dataRow = sheet.getRow(2);
+            assertThat((int) dataRow.getCell(0).getNumericCellValue()).isEqualTo(1);
+            assertThat(dataRow.getCell(1).getStringCellValue()).isEqualTo("Seoul");
+            assertThat(dataRow.getCell(2).getStringCellValue()).isEqualTo("12345");
+        }
+    }
+
+    // -- Collection<NestedType> + @DataColumnGroup ---------------------
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class LineItem {
+        public String sku;
+        public int qty;
+    }
+
+    @DataGrid
+    static class OrderWithItemList {
+        public int id;
+        @DataColumnGroup("Items")
+        public List<LineItem> items;
+        public OrderWithItemList() {}
+        public OrderWithItemList(int id, List<LineItem> items) {
+            this.id = id;
+            this.items = items;
+        }
+    }
+
+    /**
+     * Verifies the {@code @DataColumnGroup} javadoc claim that
+     * {@code List<NestedType>} fields are supported — the group header
+     * spans every flattened column produced by the element type.
+     */
+    @Test
+    void collectionOfNestedWithGroup() throws Exception {
+        File file = tempFile("group-collection.xlsx");
+        mapper.writeValue(file, new OrderWithItemList(
+                1, Arrays.asList(new LineItem("A", 2), new LineItem("B", 5))));
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            assertThat(sheet.getRow(0).getCell(0).getStringCellValue()).isEqualTo("id");
+            assertThat(sheet.getRow(0).getCell(1).getStringCellValue()).isEqualTo("Items");
+            assertThat(sheet.getRow(1).getCell(1).getStringCellValue()).isEqualTo("items/[]/sku");
+            assertThat(sheet.getRow(1).getCell(2).getStringCellValue()).isEqualTo("items/[]/qty");
+
+            assertThat(sheet.getMergedRegions()).anySatisfy(r -> {
+                assertThat(r.getFirstRow()).isEqualTo(0);
+                assertThat(r.getLastRow()).isEqualTo(0);
+                assertThat(r.getFirstColumn()).isEqualTo(1);
+                assertThat(r.getLastColumn()).isEqualTo(2);
+            });
+        }
+    }
+
+    // -- 3-depth nesting -----------------------------------------------
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class TeamSection {
+        public String teamLead;
+        public int memberCount;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class DepartmentSection {
+        public String deptName;
+        @DataColumnGroup("Team") public TeamSection team;
+    }
+
+    @DataGrid
+    static class CountryReport {
+        public String country;
+        @DataColumnGroup("Department") public DepartmentSection dept;
+        public CountryReport() {}
+        public CountryReport(String country, DepartmentSection dept) {
+            this.country = country;
+            this.dept = dept;
+        }
+    }
+
+    /**
+     * Verifies the multi-row header algorithm scales to 3-depth nesting:
+     * outer flat column, mid-level group, inner group with leaves.
+     * Header row count = max group depth + 1 = 3.
+     */
+    @Test
+    void threeDepthNesting_layoutAndMerges() throws Exception {
+        File file = tempFile("group-3depth.xlsx");
+        mapper.writeValue(file, new CountryReport(
+                "KR", new DepartmentSection("Eng",
+                        new TeamSection("Alice", 7))));
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+
+            // Row 0: top-level — flat column "country" + outermost group "Department".
+            assertThat(sheet.getRow(0).getCell(0).getStringCellValue()).isEqualTo("country");
+            assertThat(sheet.getRow(0).getCell(1).getStringCellValue()).isEqualTo("Department");
+
+            // Row 1: mid-level — leaf inside Department, plus inner group "Team".
+            assertThat(sheet.getRow(1).getCell(1).getStringCellValue()).isEqualTo("dept/deptName");
+            assertThat(sheet.getRow(1).getCell(2).getStringCellValue()).isEqualTo("Team");
+
+            // Row 2: leaves inside Team.
+            assertThat(sheet.getRow(2).getCell(2).getStringCellValue()).isEqualTo("dept/team/teamLead");
+            assertThat(sheet.getRow(2).getCell(3).getStringCellValue()).isEqualTo("dept/team/memberCount");
+
+            List<CellRangeAddress> merged = sheet.getMergedRegions();
+            // "country" vertical merge across all 3 header rows (col 0).
+            assertThat(merged).anySatisfy(r -> {
+                assertThat(r.getFirstRow()).isEqualTo(0);
+                assertThat(r.getLastRow()).isEqualTo(2);
+                assertThat(r.getFirstColumn()).isEqualTo(0);
+                assertThat(r.getLastColumn()).isEqualTo(0);
+            });
+            // "Department" horizontal merge cols 1..3 at row 0.
+            assertThat(merged).anySatisfy(r -> {
+                assertThat(r.getFirstRow()).isEqualTo(0);
+                assertThat(r.getLastRow()).isEqualTo(0);
+                assertThat(r.getFirstColumn()).isEqualTo(1);
+                assertThat(r.getLastColumn()).isEqualTo(3);
+            });
+            // "dept/deptName" vertical merge rows 1..2 (col 1).
+            assertThat(merged).anySatisfy(r -> {
+                assertThat(r.getFirstRow()).isEqualTo(1);
+                assertThat(r.getLastRow()).isEqualTo(2);
+                assertThat(r.getFirstColumn()).isEqualTo(1);
+                assertThat(r.getLastColumn()).isEqualTo(1);
+            });
+            // "Team" horizontal merge cols 2..3 at row 1.
+            assertThat(merged).anySatisfy(r -> {
+                assertThat(r.getFirstRow()).isEqualTo(1);
+                assertThat(r.getLastRow()).isEqualTo(1);
+                assertThat(r.getFirstColumn()).isEqualTo(2);
+                assertThat(r.getLastColumn()).isEqualTo(3);
+            });
+
+            // Data row at row 3.
+            Row dataRow = sheet.getRow(3);
+            assertThat(dataRow.getCell(0).getStringCellValue()).isEqualTo("KR");
+            assertThat(dataRow.getCell(1).getStringCellValue()).isEqualTo("Eng");
+            assertThat(dataRow.getCell(2).getStringCellValue()).isEqualTo("Alice");
+            assertThat((int) dataRow.getCell(3).getNumericCellValue()).isEqualTo(7);
+        }
+    }
+
+    // -- @JsonIgnore inner field + @DataColumnGroup --------------------
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class ProfileWithSecret {
+        public String name;
+        @JsonIgnore public String passwordHash;
+        public int age;
+    }
+
+    @DataGrid
+    static class UserWithProfile {
+        public int id;
+        @DataColumnGroup("Profile")
+        public ProfileWithSecret profile;
+        public UserWithProfile() {}
+        public UserWithProfile(int id, ProfileWithSecret profile) {
+            this.id = id;
+            this.profile = profile;
+        }
+    }
+
+    /**
+     * Verifies {@code @JsonIgnore} on an inner field excludes that field
+     * from the group: the group header still spans only the visible
+     * leaf columns, with the ignored field absent.
+     */
+    @Test
+    void jsonIgnoreInnerField_groupSpansVisibleOnly() throws Exception {
+        File file = tempFile("group-ignore.xlsx");
+        mapper.writeValue(file, new UserWithProfile(
+                1, new ProfileWithSecret("Alice", "secret", 30)));
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            assertThat(sheet.getRow(0).getCell(0).getStringCellValue()).isEqualTo("id");
+            assertThat(sheet.getRow(0).getCell(1).getStringCellValue()).isEqualTo("Profile");
+            // Only "name" and "age" appear under Profile.
+            assertThat(sheet.getRow(1).getCell(1).getStringCellValue()).isEqualTo("profile/name");
+            assertThat(sheet.getRow(1).getCell(2).getStringCellValue()).isEqualTo("profile/age");
+            assertThat(sheet.getRow(1).getCell(3)).isNull();
+
+            // Group "Profile" spans cols 1..2 (passwordHash filtered out).
+            assertThat(sheet.getMergedRegions()).anySatisfy(r -> {
+                assertThat(r.getFirstRow()).isEqualTo(0);
+                assertThat(r.getLastRow()).isEqualTo(0);
+                assertThat(r.getFirstColumn()).isEqualTo(1);
+                assertThat(r.getLastColumn()).isEqualTo(2);
+            });
+
+            Row dataRow = sheet.getRow(2);
+            assertThat((int) dataRow.getCell(0).getNumericCellValue()).isEqualTo(1);
+            assertThat(dataRow.getCell(1).getStringCellValue()).isEqualTo("Alice");
+            assertThat((int) dataRow.getCell(2).getNumericCellValue()).isEqualTo(30);
+        }
+    }
+
+    // -- @JsonProperty rename inner field + @DataColumnGroup -----------
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class RenamedDetails {
+        @JsonProperty("Display Code") public String code;
+        public int qty;
+    }
+
+    @DataGrid
+    static class WithRenamedInner {
+        public int id;
+        @DataColumnGroup("Item")
+        public RenamedDetails item;
+        public WithRenamedInner() {}
+        public WithRenamedInner(int id, RenamedDetails item) {
+            this.id = id;
+            this.item = item;
+        }
+    }
+
+    /**
+     * Verifies {@code @JsonProperty} on an inner field changes the leaf
+     * column path inside the group. Jackson's renamed property name flows
+     * through to the pointer used as the column header fallback.
+     */
+    @Test
+    void jsonPropertyRenameInner_appliesToLeafPath() throws Exception {
+        File file = tempFile("group-rename.xlsx");
+        mapper.writeValue(file, new WithRenamedInner(
+                1, new RenamedDetails("ABC", 3)));
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            assertThat(sheet.getRow(0).getCell(0).getStringCellValue()).isEqualTo("id");
+            assertThat(sheet.getRow(0).getCell(1).getStringCellValue()).isEqualTo("Item");
+
+            // Both leaf columns appear under the group; rename applied to "code".
+            // Order is decided by Jackson's bean introspection and is not asserted here.
+            Set<String> leafNames = new HashSet<>();
+            leafNames.add(sheet.getRow(1).getCell(1).getStringCellValue());
+            leafNames.add(sheet.getRow(1).getCell(2).getStringCellValue());
+            assertThat(leafNames).containsExactlyInAnyOrder(
+                    "item/Display Code", "item/qty");
+
+            assertThat(sheet.getMergedRegions()).anySatisfy(r -> {
+                assertThat(r.getFirstRow()).isEqualTo(0);
+                assertThat(r.getLastRow()).isEqualTo(0);
+                assertThat(r.getFirstColumn()).isEqualTo(1);
+                assertThat(r.getLastColumn()).isEqualTo(2);
+            });
+
+            // Data row at row 2: id at col 0; inner cells at cols 1/2 in
+            // whichever order Jackson emitted the leaves. Pair leaves to
+            // their data values to verify rename round-trip.
+            Row dataRow = sheet.getRow(2);
+            assertThat((int) dataRow.getCell(0).getNumericCellValue()).isEqualTo(1);
+            Map<String, String> leafToData = new HashMap<>();
+            for (int c = 1; c <= 2; c++) {
+                String header = sheet.getRow(1).getCell(c).getStringCellValue();
+                Cell cell = dataRow.getCell(c);
+                String value = cell.getCellType() == CellType.STRING
+                        ? cell.getStringCellValue()
+                        : String.valueOf((int) cell.getNumericCellValue());
+                leafToData.put(header, value);
+            }
+            assertThat(leafToData).containsEntry("item/Display Code", "ABC");
+            assertThat(leafToData).containsEntry("item/qty", "3");
+        }
+    }
+
+    // -- @JsonInclude(NON_NULL) inner + @DataColumnGroup ---------------
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    static class NonNullInner {
+        public String present;
+        public String optional;
+    }
+
+    @DataGrid
+    static class WithNonNullGroup {
+        public int id;
+        @DataColumnGroup("Data")
+        public NonNullInner data;
+        public WithNonNullGroup() {}
+        public WithNonNullGroup(int id, NonNullInner data) {
+            this.id = id;
+            this.data = data;
+        }
+    }
+
+    /**
+     * {@code @JsonInclude(NON_NULL)} on the inner type skips null fields
+     * during serialization — the corresponding cell is empty. The schema
+     * (header layout, group span) is unchanged because it is built from
+     * the type, not from instance values.
+     */
+    @Test
+    void jsonIncludeNonNullInner_skipsNullCellOnly() throws Exception {
+        File file = tempFile("group-nonnull.xlsx");
+        mapper.writeValue(file, new WithNonNullGroup(
+                1, new NonNullInner("X", null)));
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            // Headers unchanged: both inner properties always reserved.
+            assertThat(sheet.getRow(0).getCell(0).getStringCellValue()).isEqualTo("id");
+            assertThat(sheet.getRow(0).getCell(1).getStringCellValue()).isEqualTo("Data");
+            assertThat(sheet.getRow(1).getCell(1).getStringCellValue()).isEqualTo("data/present");
+            assertThat(sheet.getRow(1).getCell(2).getStringCellValue()).isEqualTo("data/optional");
+
+            assertThat(sheet.getMergedRegions()).anySatisfy(r -> {
+                assertThat(r.getFirstRow()).isEqualTo(0);
+                assertThat(r.getLastRow()).isEqualTo(0);
+                assertThat(r.getFirstColumn()).isEqualTo(1);
+                assertThat(r.getLastColumn()).isEqualTo(2);
+            });
+
+            // Data row: present has value, optional is skipped.
+            Row dataRow = sheet.getRow(2);
+            assertThat((int) dataRow.getCell(0).getNumericCellValue()).isEqualTo(1);
+            assertThat(dataRow.getCell(1).getStringCellValue()).isEqualTo("X");
+            assertThat(dataRow.getCell(2)).isNull();
+        }
     }
 
     private File tempFile(String name) {

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/DataColumnGroupTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/DataColumnGroupTest.java
@@ -1,0 +1,391 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.util.CellRangeAddress;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+
+/**
+ * PoC smoke tests for {@link DataColumnGroup} multi-row header support.
+ * Covers 1-depth (Employee + Address) and 2-depth (Company + Year + Quarter)
+ * via the POI User Model write path.
+ */
+class DataColumnGroupTest {
+
+    SpreadsheetMapper mapper;
+    @TempDir Path tempDir;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new SpreadsheetMapper(
+                new SpreadsheetFactory(SXSSFWorkbook::new,
+                        SpreadsheetFactory.DEFAULT_SHEET_PARSER_FEATURE_FLAGS)
+                        .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL));
+    }
+
+    // -- 1-depth ---------------------------------------------------------
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class Employee {
+        @DataColumn("ID") int id;
+        @DataColumn("Name") String name;
+        @DataColumnGroup("Address") Address address;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class Address {
+        @DataColumn("City") String city;
+        @DataColumn("Zip") String zip;
+    }
+
+    @Test
+    void singleDepthGroup_headerLayoutAndMerge() throws Exception {
+        File file = tempFile("group-1depth.xlsx");
+
+        Employee value = new Employee(1, "Alice", new Address("Seoul", "12345"));
+        mapper.writeValue(file, value);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+
+            // Two header rows. Each column writes its text at row = origin + hierarchy depth.
+            //   ID/Name (h=0):     row 0 (top of vertical merge → actually rendered)
+            //   Address (group):    row 0 (horizontal merge across cols 2-3)
+            //   City/Zip (h=1):    row 1 (leaf)
+            assertThat(sheet.getRow(0).getCell(0).getStringCellValue()).isEqualTo("ID");
+            assertThat(sheet.getRow(0).getCell(1).getStringCellValue()).isEqualTo("Name");
+            assertThat(sheet.getRow(0).getCell(2).getStringCellValue()).isEqualTo("Address");
+            assertThat(sheet.getRow(1).getCell(2).getStringCellValue()).isEqualTo("City");
+            assertThat(sheet.getRow(1).getCell(3).getStringCellValue()).isEqualTo("Zip");
+
+            // Data row at row 2
+            assertThat((int) sheet.getRow(2).getCell(0).getNumericCellValue()).isEqualTo(1);
+            assertThat(sheet.getRow(2).getCell(1).getStringCellValue()).isEqualTo("Alice");
+            assertThat(sheet.getRow(2).getCell(2).getStringCellValue()).isEqualTo("Seoul");
+            assertThat(sheet.getRow(2).getCell(3).getStringCellValue()).isEqualTo("12345");
+
+            // Merges:
+            //   - "Address" horizontal merge (row 0, cols 2-3)
+            //   - "ID" vertical merge (rows 0-1, col 0)
+            //   - "Name" vertical merge (rows 0-1, col 1)
+            List<CellRangeAddress> merged = sheet.getMergedRegions();
+
+            assertThat(merged).anySatisfy(r -> {
+                assertThat(r.getFirstRow()).isEqualTo(0);
+                assertThat(r.getLastRow()).isEqualTo(0);
+                assertThat(r.getFirstColumn()).isEqualTo(2);
+                assertThat(r.getLastColumn()).isEqualTo(3);
+            });
+            assertThat(merged).anySatisfy(r -> {
+                assertThat(r.getFirstRow()).isEqualTo(0);
+                assertThat(r.getLastRow()).isEqualTo(1);
+                assertThat(r.getFirstColumn()).isEqualTo(0);
+                assertThat(r.getLastColumn()).isEqualTo(0);
+            });
+            assertThat(merged).anySatisfy(r -> {
+                assertThat(r.getFirstRow()).isEqualTo(0);
+                assertThat(r.getLastRow()).isEqualTo(1);
+                assertThat(r.getFirstColumn()).isEqualTo(1);
+                assertThat(r.getLastColumn()).isEqualTo(1);
+            });
+        }
+    }
+
+    // -- 2-depth ---------------------------------------------------------
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class Company {
+        @DataColumn("Company") String company;
+        @DataColumnGroup("2024") YearMetrics year2024;
+        @DataColumnGroup("2025") YearMetrics year2025;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class YearMetrics {
+        @DataColumnGroup("Q1") QuarterMetrics q1;
+        @DataColumnGroup("Q2") QuarterMetrics q2;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class QuarterMetrics {
+        @DataColumn("Sales") int sales;
+        @DataColumn("Profit") int profit;
+    }
+
+    @Test
+    void twoDepthGroup_headerLayoutAndMerge() throws Exception {
+        File file = tempFile("group-2depth.xlsx");
+
+        Company value = new Company("Acme",
+                new YearMetrics(new QuarterMetrics(100, 20), new QuarterMetrics(110, 22)),
+                new YearMetrics(new QuarterMetrics(120, 25), new QuarterMetrics(130, 28)));
+        mapper.writeValue(file, value);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+
+            // Three header rows. Each column writes its text at row = origin + hierarchy depth.
+            //   Company (h=0):        row 0 (top of A1:A3 vertical merge)
+            //   2024/2025 (groups):   row 0 (horizontal merge across child cols)
+            //   Q1/Q2 (groups):       row 1
+            //   Sales/Profit (h=2):   row 2 (leaf)
+            assertThat(sheet.getRow(0).getCell(0).getStringCellValue()).isEqualTo("Company");
+            assertThat(sheet.getRow(0).getCell(1).getStringCellValue()).isEqualTo("2024");
+            assertThat(sheet.getRow(0).getCell(5).getStringCellValue()).isEqualTo("2025");
+            assertThat(sheet.getRow(1).getCell(1).getStringCellValue()).isEqualTo("Q1");
+            assertThat(sheet.getRow(1).getCell(3).getStringCellValue()).isEqualTo("Q2");
+            assertThat(sheet.getRow(1).getCell(5).getStringCellValue()).isEqualTo("Q1");
+            assertThat(sheet.getRow(1).getCell(7).getStringCellValue()).isEqualTo("Q2");
+            assertThat(sheet.getRow(2).getCell(1).getStringCellValue()).isEqualTo("Sales");
+            assertThat(sheet.getRow(2).getCell(2).getStringCellValue()).isEqualTo("Profit");
+            assertThat(sheet.getRow(2).getCell(8).getStringCellValue()).isEqualTo("Profit");
+
+            // Data row 3
+            assertThat(sheet.getRow(3).getCell(0).getStringCellValue()).isEqualTo("Acme");
+            assertThat((int) sheet.getRow(3).getCell(1).getNumericCellValue()).isEqualTo(100);
+            assertThat((int) sheet.getRow(3).getCell(8).getNumericCellValue()).isEqualTo(28);
+
+            List<CellRangeAddress> merged = sheet.getMergedRegions();
+
+            // "2024" group: row 0, cols 1-4
+            assertThat(merged).anySatisfy(r -> {
+                assertThat(r.getFirstRow()).isEqualTo(0);
+                assertThat(r.getLastRow()).isEqualTo(0);
+                assertThat(r.getFirstColumn()).isEqualTo(1);
+                assertThat(r.getLastColumn()).isEqualTo(4);
+            });
+            // "2025" group: row 0, cols 5-8
+            assertThat(merged).anySatisfy(r -> {
+                assertThat(r.getFirstRow()).isEqualTo(0);
+                assertThat(r.getLastRow()).isEqualTo(0);
+                assertThat(r.getFirstColumn()).isEqualTo(5);
+                assertThat(r.getLastColumn()).isEqualTo(8);
+            });
+            // "Q1" under 2024: row 1, cols 1-2
+            assertThat(merged).anySatisfy(r -> {
+                assertThat(r.getFirstRow()).isEqualTo(1);
+                assertThat(r.getLastRow()).isEqualTo(1);
+                assertThat(r.getFirstColumn()).isEqualTo(1);
+                assertThat(r.getLastColumn()).isEqualTo(2);
+            });
+            // "Q1" under 2025: row 1, cols 5-6 (separate cell, despite same name — different parent)
+            assertThat(merged).anySatisfy(r -> {
+                assertThat(r.getFirstRow()).isEqualTo(1);
+                assertThat(r.getLastRow()).isEqualTo(1);
+                assertThat(r.getFirstColumn()).isEqualTo(5);
+                assertThat(r.getLastColumn()).isEqualTo(6);
+            });
+            // "Company" flat column: rows 0-2, col 0 (vertical merge spanning all header rows)
+            assertThat(merged).anySatisfy(r -> {
+                assertThat(r.getFirstRow()).isEqualTo(0);
+                assertThat(r.getLastRow()).isEqualTo(2);
+                assertThat(r.getFirstColumn()).isEqualTo(0);
+                assertThat(r.getLastColumn()).isEqualTo(0);
+            });
+        }
+    }
+
+    // -- SSML path (default streaming) -----------------------------------
+
+    @Test
+    void singleDepthGroup_ssml() throws Exception {
+        SpreadsheetMapper ssmlMapper = new SpreadsheetMapper();
+        File file = tempFile("group-1depth-ssml.xlsx");
+
+        Employee value = new Employee(1, "Alice", new Address("Seoul", "12345"));
+        ssmlMapper.writeValue(file, value);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+
+            assertThat(sheet.getRow(0).getCell(0).getStringCellValue()).isEqualTo("ID");
+            assertThat(sheet.getRow(0).getCell(1).getStringCellValue()).isEqualTo("Name");
+            assertThat(sheet.getRow(0).getCell(2).getStringCellValue()).isEqualTo("Address");
+            assertThat(sheet.getRow(1).getCell(2).getStringCellValue()).isEqualTo("City");
+            assertThat(sheet.getRow(1).getCell(3).getStringCellValue()).isEqualTo("Zip");
+
+            assertThat((int) sheet.getRow(2).getCell(0).getNumericCellValue()).isEqualTo(1);
+            assertThat(sheet.getRow(2).getCell(1).getStringCellValue()).isEqualTo("Alice");
+
+            List<CellRangeAddress> merged = sheet.getMergedRegions();
+            // Address horizontal merge (row 0, cols 2-3)
+            assertThat(merged).anySatisfy(r -> {
+                assertThat(r.getFirstRow()).isEqualTo(0);
+                assertThat(r.getLastRow()).isEqualTo(0);
+                assertThat(r.getFirstColumn()).isEqualTo(2);
+                assertThat(r.getLastColumn()).isEqualTo(3);
+            });
+            // ID vertical merge (rows 0-1, col 0)
+            assertThat(merged).anySatisfy(r -> {
+                assertThat(r.getFirstRow()).isEqualTo(0);
+                assertThat(r.getLastRow()).isEqualTo(1);
+                assertThat(r.getFirstColumn()).isEqualTo(0);
+                assertThat(r.getLastColumn()).isEqualTo(0);
+            });
+            // Name vertical merge (rows 0-1, col 1)
+            assertThat(merged).anySatisfy(r -> {
+                assertThat(r.getFirstRow()).isEqualTo(0);
+                assertThat(r.getLastRow()).isEqualTo(1);
+                assertThat(r.getFirstColumn()).isEqualTo(1);
+                assertThat(r.getLastColumn()).isEqualTo(1);
+            });
+        }
+    }
+
+    @Test
+    void twoDepthGroup_ssml() throws Exception {
+        SpreadsheetMapper ssmlMapper = new SpreadsheetMapper();
+        File file = tempFile("group-2depth-ssml.xlsx");
+
+        Company value = new Company("Acme",
+                new YearMetrics(new QuarterMetrics(100, 20), new QuarterMetrics(110, 22)),
+                new YearMetrics(new QuarterMetrics(120, 25), new QuarterMetrics(130, 28)));
+        ssmlMapper.writeValue(file, value);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+
+            assertThat(sheet.getRow(0).getCell(0).getStringCellValue()).isEqualTo("Company");
+            assertThat(sheet.getRow(0).getCell(1).getStringCellValue()).isEqualTo("2024");
+            assertThat(sheet.getRow(0).getCell(5).getStringCellValue()).isEqualTo("2025");
+            assertThat(sheet.getRow(1).getCell(1).getStringCellValue()).isEqualTo("Q1");
+            assertThat(sheet.getRow(2).getCell(1).getStringCellValue()).isEqualTo("Sales");
+
+            assertThat(sheet.getRow(3).getCell(0).getStringCellValue()).isEqualTo("Acme");
+            assertThat((int) sheet.getRow(3).getCell(1).getNumericCellValue()).isEqualTo(100);
+
+            List<CellRangeAddress> merged = sheet.getMergedRegions();
+            // 2024 horizontal merge (row 0, cols 1-4)
+            assertThat(merged).anySatisfy(r -> {
+                assertThat(r.getFirstRow()).isEqualTo(0);
+                assertThat(r.getLastRow()).isEqualTo(0);
+                assertThat(r.getFirstColumn()).isEqualTo(1);
+                assertThat(r.getLastColumn()).isEqualTo(4);
+            });
+            // Company vertical merge (rows 0-2, col 0)
+            assertThat(merged).anySatisfy(r -> {
+                assertThat(r.getFirstRow()).isEqualTo(0);
+                assertThat(r.getLastRow()).isEqualTo(2);
+                assertThat(r.getFirstColumn()).isEqualTo(0);
+                assertThat(r.getLastColumn()).isEqualTo(0);
+            });
+        }
+    }
+
+    // -- Round-trip (write → read) ---------------------------------------
+
+    @Test
+    void singleDepthGroup_roundTrip_poi() throws Exception {
+        File file = tempFile("group-1depth-rt.xlsx");
+        Employee in = new Employee(1, "Alice", new Address("Seoul", "12345"));
+        mapper.writeValue(file, in);
+        Employee out = mapper.readValue(file, Employee.class);
+        assertThat(out).usingRecursiveComparison().isEqualTo(in);
+    }
+
+    @Test
+    void twoDepthGroup_roundTrip_poi() throws Exception {
+        File file = tempFile("group-2depth-rt.xlsx");
+        Company in = new Company("Acme",
+                new YearMetrics(new QuarterMetrics(100, 20), new QuarterMetrics(110, 22)),
+                new YearMetrics(new QuarterMetrics(120, 25), new QuarterMetrics(130, 28)));
+        mapper.writeValue(file, in);
+        Company out = mapper.readValue(file, Company.class);
+        assertThat(out).usingRecursiveComparison().isEqualTo(in);
+    }
+
+    @Test
+    void singleDepthGroup_roundTrip_ssml() throws Exception {
+        SpreadsheetMapper ssmlMapper = new SpreadsheetMapper();
+        File file = tempFile("group-1depth-rt-ssml.xlsx");
+        Employee in = new Employee(1, "Alice", new Address("Seoul", "12345"));
+        ssmlMapper.writeValue(file, in);
+        Employee out = ssmlMapper.readValue(file, Employee.class);
+        assertThat(out).usingRecursiveComparison().isEqualTo(in);
+    }
+
+    @Test
+    void twoDepthGroup_roundTrip_ssml() throws Exception {
+        SpreadsheetMapper ssmlMapper = new SpreadsheetMapper();
+        File file = tempFile("group-2depth-rt-ssml.xlsx");
+        Company in = new Company("Acme",
+                new YearMetrics(new QuarterMetrics(100, 20), new QuarterMetrics(110, 22)),
+                new YearMetrics(new QuarterMetrics(120, 25), new QuarterMetrics(130, 28)));
+        ssmlMapper.writeValue(file, in);
+        Company out = ssmlMapper.readValue(file, Company.class);
+        assertThat(out).usingRecursiveComparison().isEqualTo(in);
+    }
+
+    // -- Reorder + multi-row header --------------------------------------
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class EmployeeWriteOrder {
+        @DataColumn("Name") String name;
+        @DataColumn("ID") int id;
+        @DataColumnGroup("Address") Address address;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class EmployeeReadOrder {
+        @DataColumn("ID") int id;
+        @DataColumn("Name") String name;
+        @DataColumnGroup("Address") Address address;
+    }
+
+    @Test
+    void multiRowHeader_reorder_failsFast_poi() throws Exception {
+        File file = tempFile("group-reorder.xlsx");
+        EmployeeWriteOrder writeValue = new EmployeeWriteOrder(
+                "Alice", 1, new Address("Seoul", "12345"));
+        mapper.writeValue(file, writeValue);
+
+        SpreadsheetMapper reorderMapper = new SpreadsheetMapper(
+                new SpreadsheetFactory(SXSSFWorkbook::new,
+                        SpreadsheetFactory.DEFAULT_SHEET_PARSER_FEATURE_FLAGS)
+                        .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL))
+                .setColumnReordering(true);
+
+        assertThatThrownBy(() -> reorderMapper.readValue(file, EmployeeReadOrder.class))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Column reordering is not supported with multi-row headers");
+    }
+
+    @Test
+    void multiRowHeader_reorder_failsFast_ssml() throws Exception {
+        SpreadsheetMapper writeMapper = new SpreadsheetMapper();
+        File file = tempFile("group-reorder-ssml.xlsx");
+        EmployeeWriteOrder writeValue = new EmployeeWriteOrder(
+                "Alice", 1, new Address("Seoul", "12345"));
+        writeMapper.writeValue(file, writeValue);
+
+        SpreadsheetMapper reorderMapper = new SpreadsheetMapper().setColumnReordering(true);
+
+        assertThatThrownBy(() -> reorderMapper.readValue(file, EmployeeReadOrder.class))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Column reordering is not supported with multi-row headers");
+    }
+
+    private File tempFile(String name) {
+        return tempDir.resolve(name).toFile();
+    }
+}

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/SSMLSheetWriterDomEquivalenceTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/SSMLSheetWriterDomEquivalenceTest.java
@@ -16,12 +16,14 @@ import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import com.fasterxml.jackson.annotation.OptBoolean;
 
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -52,12 +54,6 @@ class SSMLSheetWriterDomEquivalenceTest {
 
     @Test
     void sheetXmlDomEquivalent() throws Exception {
-        // SSML writer always emits <c s="0">, matching POI 5.2.3+ (bug-51037 fix).
-        // POI 4.x ~ 5.2.2 omit default s, so DOM equality only holds on POI 5.2.3+.
-        // Library policy: follow latest POI behavior; older-version drift is ignored. (#96)
-        Assumptions.assumeTrue(PoiVersionProbe.isPoi523OrLater(),
-                "DOM equivalence asserted only on POI 5.2.3+ — see #96");
-
         File ssmlFile = _debugFile("dom-sheet-ssml.xlsx");
         File poiFile = _debugFile("dom-sheet-poi.xlsx");
 
@@ -248,6 +244,36 @@ class SSMLSheetWriterDomEquivalenceTest {
         _assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
     }
 
+    // -- Multi-row header (@DataColumnGroup) -----------------------------
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class GroupedAddress {
+        String city;
+        String zip;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class GroupedEntry {
+        int id;
+        String name;
+        @DataColumnGroup("Address") GroupedAddress address;
+    }
+
+    private static final List<GroupedEntry> GROUPED_DATA = Arrays.asList(
+            new GroupedEntry(1, "Alice", new GroupedAddress("Seoul", "12345")),
+            new GroupedEntry(2, "Bob", new GroupedAddress("Busan", "23456")));
+
+    @Test
+    void sheetXmlDomEquivalent_multiRowHeader() throws Exception {
+        File ssmlFile = _debugFile("dom-multirow-ssml.xlsx");
+        File poiFile = _debugFile("dom-multirow-poi.xlsx");
+
+        new SpreadsheetMapper().writeValue(ssmlFile, GROUPED_DATA, GroupedEntry.class);
+        _poiMapper().writeValue(poiFile, GROUPED_DATA, GroupedEntry.class);
+
+        _assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
+    }
+
     @Test
     void sharedStringsXmlDomEquivalent() throws Exception {
         File ssmlFile = _debugFile("dom-sst-ssml.xlsx");
@@ -280,6 +306,13 @@ class SSMLSheetWriterDomEquivalenceTest {
             _removeDimensionElements(expectedDoc);
             _removeDimensionElements(actualDoc);
 
+            // POI 4.x ~ 5.2.2 omit default s="0" on cells; SSML writer always emits.
+            // Strip on the SSML side so byte-equal comparison holds across versions.
+            // On POI 5.2.3+ both sides emit, and the strict check is preserved.
+            if (!PoiVersionProbe.isPoi523OrLater()) {
+                _stripDefaultStyleAttribute(actualDoc);
+            }
+
             assertThat(actualDoc.getDocumentElement().isEqualNode(
                     expectedDoc.getDocumentElement()))
                     .as("%s DOM equality (ignoring dimension)", partName)
@@ -308,6 +341,17 @@ class SSMLSheetWriterDomEquivalenceTest {
         for (int i = dimensions.getLength() - 1; i >= 0; i--) {
             final Node node = dimensions.item(i);
             node.getParentNode().removeChild(node);
+        }
+    }
+
+    private static void _stripDefaultStyleAttribute(final Document doc) {
+        final NodeList cells = doc.getElementsByTagNameNS(
+                "http://schemas.openxmlformats.org/spreadsheetml/2006/main", "c");
+        for (int i = 0; i < cells.getLength(); i++) {
+            final Element cell = (Element) cells.item(i);
+            if ("0".equals(cell.getAttribute("s"))) {
+                cell.removeAttribute("s");
+            }
         }
     }
 


### PR DESCRIPTION
Adds the @DataColumnGroup annotation: a nested POJO field rendered
as a column group header above the flattened leaf headers, with the
group cell horizontally merged across its children and flat sibling
columns vertically merged down to the leaf header row. Works for
single fields, list elements, and arbitrary nesting depth — verified
by DataColumnGroupTest's Jackson interop matrix (polymorphic types,
@JsonView, @JsonNaming, @JsonPropertyOrder, @JsonProperty rename,
@JsonInclude(NON_NULL), @JsonIgnore, mix-in, List<NestedType>,
3-depth nesting).

The header layout walk extracted into HeaderLayoutVisitor is shared
by POISheetWriter and SSMLSheetWriter so both paths emit identical
multi-row structures (DOM equivalence test confirms).