### PR TITLE
Stream SSML cells via SoA buffer; tighten back-write limit

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -450,7 +450,7 @@ mapper.writeValue(output, order);
 +----------+---------+-----+-------+
 ```
 
-In the default streaming write path, outer fields declared after a nested list are buffered and back-written into earlier rows. The buffer is heap-aware — `max(4 MB, heap/32)`. The library logs a warning at schema build time if the projected inner-row XML would exceed this bound; raise the JVM heap (`-Xmx`) for larger lists.
+In the default streaming write path, outer fields declared after a nested list are buffered and back-written into earlier rows. The buffer is heap-aware — `max(1 MB, heap/128)`. The library logs a warning at schema build time if the projected inner-row XML would exceed this bound; raise the JVM heap (`-Xmx`) for larger lists.
 
 The [SXSSFWorkbook row access window](https://poi.apache.org/apidocs/4.1/org/apache/poi/xssf/streaming/SXSSFWorkbook.html#SXSSFWorkbook-int-) is adjusted automatically to fit the list size. If you see `"Cannot write to row N (already flushed)"`, the nested list expanded beyond the window. Increase it:
 

--- a/src/jmh/java/io/github/scndry/jackson/dataformat/spreadsheet/internal/BackWriteBenchmark.java
+++ b/src/jmh/java/io/github/scndry/jackson/dataformat/spreadsheet/internal/BackWriteBenchmark.java
@@ -1,0 +1,84 @@
+package io.github.scndry.jackson.dataformat.spreadsheet.internal;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import com.fasterxml.jackson.annotation.OptBoolean;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.SpreadsheetMapper;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+
+/**
+ * Internal profiling benchmark — measures the back-write scenario
+ * (outer field declared after a nested list). Exercises the
+ * SheetDataBuffer row-linked window: the {@code total} field lands
+ * at the row already emitted for {@code items[0]}. Used for
+ * optimization work; not documented in BENCHMARK.md.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(value = 1, jvmArgs = {"-Xmx4g"})
+public class BackWriteBenchmark {
+
+    @Param({"1000", "10000", "100000"})
+    int innerCount;
+
+    Order order;
+    File file;
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid(mergeColumn = OptBoolean.TRUE)
+    public static class Order {
+        @DataColumn("id") int id;
+        @DataColumn("customer") String customer;
+        @DataColumnGroup("items") List<Item> items;
+        @DataColumn("total") double total;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    public static class Item {
+        @DataColumn("product") String product;
+        @DataColumn("qty") int qty;
+        @DataColumn("amount") double amount;
+    }
+
+    @Setup(Level.Trial)
+    public void setUp() {
+        final List<Item> items = new ArrayList<>(innerCount);
+        for (int i = 0; i < innerCount; i++) {
+            items.add(new Item("sku-" + i, i, i * 1.5));
+        }
+        order = new Order(1, "Alice", items, 99_999.99);
+    }
+
+    @Setup(Level.Invocation)
+    public void setUpFile() throws IOException {
+        file = File.createTempFile("bench-backwrite-", ".xlsx");
+        file.deleteOnExit();
+    }
+
+    @TearDown(Level.Invocation)
+    public void tearDown() {
+        file.delete();
+    }
+
+    @Benchmark
+    public void jacksonSpreadsheet(Blackhole bh) throws IOException {
+        SpreadsheetMapper mapper = new SpreadsheetMapper();
+        mapper.writeValue(file, order, Order.class);
+        bh.consume(file);
+    }
+}

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLSheetWriter.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLSheetWriter.java
@@ -39,6 +39,10 @@ import io.github.scndry.jackson.dataformat.spreadsheet.ser.SheetWriter;
  * Builds a temporary {@link XSSFWorkbook} scaffold for package compatibility, then rewrites worksheet and
  * sharedStrings parts directly while copying the remaining package entries from the scaffold.
  *
+ * <p>Cell writes accumulate in a {@link SheetDataBuffer} (SoA), which preserves row ordering even
+ * across back-write into past rows. Buffered cells are emitted in row order on every forward row
+ * jump (outside an array scope) and once more on {@code write()} for the trailing record.
+ *
  * @see io.github.scndry.jackson.dataformat.spreadsheet.poi.ss.POISheetWriter
  */
 @Slf4j
@@ -58,8 +62,7 @@ public final class SSMLSheetWriter implements SheetWriter {
 
     private SpreadsheetSchema _schema;
     private CellAddress _reference;
-    private int _currentRow = -1;
-    private boolean _currentRowOpen;
+    private SheetDataBuffer _data;
     private int _arrayScopeDepth;
 
     // SharedStrings
@@ -105,6 +108,7 @@ public final class SSMLSheetWriter implements SheetWriter {
     @Override
     public void setSchema(final SpreadsheetSchema schema) {
         _schema = schema;
+        _data = new SheetDataBuffer(schema.getOriginColumn() + schema.columnCount());
         try {
             _wb = _sheet.getWorkbook();
             final Styles styles = _schema.buildStyles(_wb);
@@ -139,23 +143,6 @@ public final class SSMLSheetWriter implements SheetWriter {
     @Override
     public void setReference(final CellAddress reference) {
         _reference = reference;
-        try {
-            final int row = reference.getRow();
-            if (row > _currentRow) {
-                _closeCurrentRowIfOpen();
-                _currentRow = row;
-                _currentRowOpen = false;
-            }
-        } catch (IOException e) {
-            throw new IllegalStateException(e);
-        }
-    }
-
-    private void _ensureRowOpen() throws IOException {
-        if (!_currentRowOpen) {
-            _append("<row r=\"").append(_currentRow + 1).append("\">");
-            _currentRowOpen = true;
-        }
     }
 
     @Override
@@ -186,99 +173,66 @@ public final class SSMLSheetWriter implements SheetWriter {
 
     @Override
     public void writeNumeric(final double value) {
-        try {
-            if (_isBackReference()) {
-                _insertCellIntoEmittedRow(_buildCellXml("n", String.valueOf(value)));
-                return;
-            }
-            _appendCellStart("n").append(value);
-            _appendCellEnd();
-        } catch (IOException e) {
-            throw new IllegalStateException(e);
-        }
+        _flushIfForwardJump();
+        _data.appendNumeric(_reference.getRow(), _reference.getColumn(), _resolveStyleIndex(), value);
+        _checkBufferLimitInArrayScope();
     }
 
     @Override
     public void writeString(final String value) {
-        try {
-            final int index = _cacheString(value);
-            if (_isBackReference()) {
-                _insertCellIntoEmittedRow(_buildCellXml("s", String.valueOf(index)));
-                return;
-            }
-            _appendCellStart("s").append(index);
-            _appendCellEnd();
-        } catch (IOException e) {
-            throw new IllegalStateException(e);
-        }
+        final int index = _cacheString(value);
+        _flushIfForwardJump();
+        _data.appendString(_reference.getRow(), _reference.getColumn(), _resolveStyleIndex(), index);
+        _checkBufferLimitInArrayScope();
     }
 
     @Override
     public void writeBoolean(final boolean value) {
-        try {
-            if (_isBackReference()) {
-                _insertCellIntoEmittedRow(_buildCellXml("b", value ? "1" : "0"));
-                return;
-            }
-            _appendCellStart("b").append(value ? '1' : '0');
-            _appendCellEnd();
-        } catch (IOException e) {
-            throw new IllegalStateException(e);
-        }
+        _flushIfForwardJump();
+        _data.appendBoolean(_reference.getRow(), _reference.getColumn(), _resolveStyleIndex(), value);
+        _checkBufferLimitInArrayScope();
     }
 
     @Override
     public void writeBlank() {
+        _flushIfForwardJump();
+        _data.appendBlank(_reference.getRow(), _reference.getColumn(), _resolveStyleIndex());
+        _checkBufferLimitInArrayScope();
+    }
+
+    /** Drains buffered rows to the zip stream when the new cell's row is
+     *  past every row the buffer is currently holding, AND we are not
+     *  inside an array scope (where the outer field may yet need to
+     *  back-write into a past row). */
+    private void _flushIfForwardJump() {
+        if (_arrayScopeDepth > 0) return;
+        if (_data.isEmpty()) return;
+        if (_reference.getRow() <= _data.maxRowSeen()) return;
         try {
-            if (_isBackReference()) {
-                _insertCellIntoEmittedRow(_buildBlankCellXml());
-                return;
-            }
-            _ensureRowOpen();
-            _append("<c r=\"").append(_cellRef())
-                    .append("\" s=\"").append(_resolveStyleIndex())
-                    .append("\"/>");
+            _data.flushTo(_sb);
+            _checkSbFlush();
         } catch (IOException e) {
             throw new IllegalStateException(e);
         }
     }
 
-    private boolean _isBackReference() {
-        return _reference.getRow() < _currentRow;
-    }
-
-    private String _buildCellXml(final String type, final String value) {
-        return "<c r=\"" + _cellRef()
-                + "\" s=\"" + _resolveStyleIndex()
-                + "\" t=\"" + type + "\"><v>" + value + "</v></c>";
-    }
-
-    private String _buildBlankCellXml() {
-        return "<c r=\"" + _cellRef()
-                + "\" s=\"" + _resolveStyleIndex() + "\"/>";
-    }
-
-    private void _insertCellIntoEmittedRow(final String cellXml) {
-        // Back-write invariant: while _arrayScopeDepth > 0 the runtime
-        // monitor (_checkFlush) holds the limit so the target <row r="N">
-        // is always present in _sb when this is called. The guards below
-        // catch a refactor regression — not a user-recoverable condition.
-        final String rowOpen = "<row r=\"" + (_reference.getRow() + 1) + "\">";
-        final int openIdx = _sb.indexOf(rowOpen);
-        if (openIdx < 0) {
+    /** Runtime back-write buffer monitor — fails fast before OOM when the
+     *  list size was unknown (-1) at writeStartArray so the build-time
+     *  projection could not pre-check (Iterator / Stream sources). */
+    private void _checkBufferLimitInArrayScope() {
+        if (_arrayScopeDepth == 0) return;
+        final long size = _data.byteSize();
+        final long limit = BackWriteProjection.backWriteBufferLimit();
+        if (size > limit) {
             throw new IllegalStateException(
-                    "Back-write target <row r=\""
-                    + (_reference.getRow() + 1) + "\"> missing from _sb at "
-                    + _reference + " — should never happen.");
+                    "Nested list scope buffer reached "
+                            + BackWriteProjection.formatBytes(size)
+                            + ", exceeds limit " + BackWriteProjection.formatBytes(limit)
+                            + ". Runtime monitor triggered before OOM (list size"
+                            + " was not known up-front). Either reduce the list"
+                            + " size, switch to USE_POI_USER_MODEL, or declare the"
+                            + " outer field before the list.");
         }
-        final int closeIdx = _sb.indexOf("</row>", openIdx);
-        if (closeIdx < 0) {
-            throw new IllegalStateException(
-                    "Back-write target <row r=\""
-                    + (_reference.getRow() + 1) + "\"> has no closing tag"
-                    + " — should never happen.");
-        }
-        _sb.insert(closeIdx, cellXml);
     }
 
     @Override
@@ -386,67 +340,19 @@ public final class SSMLSheetWriter implements SheetWriter {
 
     private StringBuilder _append(final String s) throws IOException {
         _sb.append(s);
-        _checkFlush();
+        _checkSbFlush();
         return _sb;
     }
 
-    private StringBuilder _appendCellStart(final String type) throws IOException {
-        _ensureRowOpen();
-        return _append("<c r=\"").append(_cellRef())
-                .append("\" s=\"").append(_resolveStyleIndex())
-                .append("\" t=\"").append(type).append("\"><v>");
-    }
-
-    private void _appendCellEnd() throws IOException {
-        _append("</v></c>");
-    }
-
-    private void _checkFlush() throws IOException {
-        if (_arrayScopeDepth > 0) {
-            // Runtime back-write buffer monitor — covers the case where the
-            // list size was unknown (-1) at writeStartArray so the build-time
-            // projection could not pre-check (Iterator / Stream sources).
-            // Fail-fast with a clear error before OutOfMemoryError.
-            //
-            // Unit invariant: _sb.length() (chars) vs limit (bytes).
-            // The comparison is unit-safe because every fragment appended to
-            // _sb inside an array scope is pure ASCII:
-            //   - row tag:        "<row r=\"N\">" / "</row>"
-            //   - cell tag:       "<c r=\"...\" s=\"...\" t=\"...\"><v>...</v></c>"
-            //   - numeric value:  StringBuilder.append(double) → Double.toString
-            //   - shared-string:  StringBuilder.append(int)    → Integer.toString
-            //   - boolean value:  '1' | '0'
-            // Header column names (non-ASCII possible) are emitted only outside
-            // array scope, and string content always routes through
-            // SharedStringsStore — only the int index appears in _sb. So
-            // _sb.length() == UTF-8 byte length here.
-            final long limit = BackWriteProjection.backWriteBufferLimit();
-            if (_sb.length() > limit) {
-                throw new IOException(
-                        "Nested list scope buffer reached "
-                        + BackWriteProjection.formatBytes(_sb.length())
-                        + ", exceeds limit " + BackWriteProjection.formatBytes(limit)
-                        + ". Runtime monitor triggered before OOM (list size"
-                        + " was not known up-front). Either reduce the list"
-                        + " size, switch to USE_POI_USER_MODEL, or declare the"
-                        + " outer field before the list.");
-            }
-            return;
-        }
+    private void _checkSbFlush() throws IOException {
         if (_sb.capacity() - _sb.length() < FLUSH_THRESHOLD) {
             _flush();
         }
     }
 
-
     private void _flush() throws IOException {
         _zip.write(_sb.toString().getBytes(StandardCharsets.UTF_8));
         _sb.setLength(0);
-    }
-
-    private String _cellRef() {
-        return CellReference.convertNumToColString(_reference.getColumn())
-            + (_reference.getRow() + 1);
     }
 
     private static String _cellRef(final int row, final int col) {
@@ -501,18 +407,14 @@ public final class SSMLSheetWriter implements SheetWriter {
 
     private void _finishSheetXmlEntry() throws IOException {
         _startSheetData();
-        _closeCurrentRowIfOpen();
+        if (_data != null && !_data.isEmpty()) {
+            _data.flushTo(_sb);
+            _checkSbFlush();
+        }
         _append("</sheetData>");
         _appendMergeCellsIntoSuffix();
         _flush();
         _zip.closeEntry();
-    }
-
-    private void _closeCurrentRowIfOpen() throws IOException {
-        if (_currentRowOpen) {
-            _append("</row>");
-            _currentRowOpen = false;
-        }
     }
 
     private void _writeSharedStringsEntry() throws IOException {
@@ -659,7 +561,7 @@ public final class SSMLSheetWriter implements SheetWriter {
             .append("\" uniqueCount=\"").append(_sst.size()).append("\">");
         for (int i = 0; i < _sst.size(); i++) {
             _appendSharedStringItem(i);
-            _checkFlush();
+            _checkSbFlush();
         }
         _append("</sst>");
         _flush();

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SheetDataBuffer.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SheetDataBuffer.java
@@ -47,8 +47,13 @@ final class SheetDataBuffer {
     private static final int MAX_CELL_BYTES = 68;
     private static final int ROW_TAG_BYTES = 23;
 
-    private static final int INITIAL_CELL_CAPACITY = 64;
-    private static final int INITIAL_ROW_CAPACITY = 16;
+    // Lazy capacity inflated on first append, then grown 1.5× — same shape
+    // as java.util.ArrayList. Excel binding inner lists are typically small,
+    // so a 5-slot floor keeps idle buffers minimal.
+    private static final int DEFAULT_CAPACITY = 5;
+
+    private static final long[] EMPTY_LONG_ARRAY = new long[0];
+    private static final int[] EMPTY_INT_ARRAY = new int[0];
 
     private static final int TYPE_BITS = 3;
     private static final int STYLE_BITS = 15;
@@ -65,15 +70,15 @@ final class SheetDataBuffer {
     private static final long COL_MASK = (1L << COL_BITS) - 1;
     private static final long ROW_MASK = (1L << ROW_BITS) - 1;
 
-    private long[] _packed;
-    private long[] _values;
-    private int[] _next;
+    private long[] _packed = EMPTY_LONG_ARRAY;
+    private long[] _values = EMPTY_LONG_ARRAY;
+    private int[] _next = EMPTY_INT_ARRAY;
     private int _size;
 
     private int _rowBase;
     private int _rowSpan;
-    private int[] _rowHead;
-    private int[] _rowTail;
+    private int[] _rowHead = EMPTY_INT_ARRAY;
+    private int[] _rowTail = EMPTY_INT_ARRAY;
 
     private final String[] _colLetters;
 
@@ -82,11 +87,6 @@ final class SheetDataBuffer {
             throw new IllegalArgumentException(
                     "colLetterCacheSize must be >= 1, got " + colLetterCacheSize);
         }
-        _packed = new long[INITIAL_CELL_CAPACITY];
-        _values = new long[INITIAL_CELL_CAPACITY];
-        _next = new int[INITIAL_CELL_CAPACITY];
-        _rowHead = new int[INITIAL_ROW_CAPACITY];
-        _rowTail = new int[INITIAL_ROW_CAPACITY];
         _colLetters = new String[colLetterCacheSize];
     }
 
@@ -242,22 +242,23 @@ final class SheetDataBuffer {
 
     private void _ensureCellCapacity(final int required) {
         if (required <= _packed.length) return;
-        int next = _packed.length;
-        while (next < required) {
-            next = next + (next >> 1) + 1;
-        }
-        _packed = Arrays.copyOf(_packed, next);
-        _values = Arrays.copyOf(_values, next);
-        _next = Arrays.copyOf(_next, next);
+        final int newCap = _grow(_packed.length, required);
+        _packed = Arrays.copyOf(_packed, newCap);
+        _values = Arrays.copyOf(_values, newCap);
+        _next = Arrays.copyOf(_next, newCap);
     }
 
     private void _ensureRowCapacity(final int required) {
         if (required <= _rowHead.length) return;
-        int next = _rowHead.length;
-        while (next < required) {
-            next = next + (next >> 1) + 1;
+        final int newCap = _grow(_rowHead.length, required);
+        _rowHead = Arrays.copyOf(_rowHead, newCap);
+        _rowTail = Arrays.copyOf(_rowTail, newCap);
+    }
+
+    private static int _grow(final int oldCap, final int required) {
+        if (oldCap == 0) {
+            return Math.max(DEFAULT_CAPACITY, required);
         }
-        _rowHead = Arrays.copyOf(_rowHead, next);
-        _rowTail = Arrays.copyOf(_rowTail, next);
+        return Math.max(oldCap + (oldCap >> 1), required);
     }
 }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SheetDataBuffer.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SheetDataBuffer.java
@@ -1,0 +1,263 @@
+package io.github.scndry.jackson.dataformat.spreadsheet.poi.ooxml;
+
+import java.util.Arrays;
+
+import org.apache.poi.ss.util.CellReference;
+
+/**
+ * Sheet-data accumulator using Structure of Arrays layout.
+ *
+ * <p>Cell metadata packs into 16 bytes ({@code long _packed} + {@code long _values}),
+ * with a row-linked list ({@code int _next}) for O(1) back-write insertion into
+ * past rows. A rolling row directory tracks per-row head/tail cell indices, so
+ * cells appended out-of-row-order (back-write) land at the row's tail without
+ * scanning the buffer.
+ *
+ * <p>Bit layout of {@code _packed}:
+ * <pre>
+ *   bit 63..44  row     (20 bits, Excel max 1,048,576)
+ *   bit 43..30  col     (14 bits, Excel max 16,384)
+ *   bit 29..15  style   (15 bits, Excel max 32,767)
+ *   bit 14..12  type    (3 bits, matches org.apache.poi.ss.usermodel.CellType.code)
+ *   bit 11..0   reserved
+ * </pre>
+ *
+ * <p>{@code _values}:
+ * <ul>
+ *   <li>{@link #TYPE_NUMERIC}: {@link Double#doubleToRawLongBits(double)} of the value</li>
+ *   <li>{@link #TYPE_STRING}: shared-string index (low 32 bits)</li>
+ *   <li>{@link #TYPE_BOOLEAN}: 0 or 1</li>
+ *   <li>{@link #TYPE_BLANK}: 0 (slot unused)</li>
+ * </ul>
+ *
+ * <p>Package-private — implementation detail of {@link SSMLSheetWriter}.
+ */
+final class SheetDataBuffer {
+
+    // matches org.apache.poi.ss.usermodel.CellType.code (POI 3.15 beta 3+).
+    // FORMULA (2) and ERROR (5) are reserved — not emitted by the streaming writer.
+    static final byte TYPE_NUMERIC = 0;
+    static final byte TYPE_STRING  = 1;
+    static final byte TYPE_BLANK   = 3;
+    static final byte TYPE_BOOLEAN = 4;
+
+    // Upper bounds aligned with BackWriteProjection — must stay in sync.
+    // <c r="REF" s="STYLE" t="TYPE"><v>VALUE</v></c>
+    //   fixed (27) + ref (10) + style (5) + type (1) + value max (25) = 68
+    private static final int MAX_CELL_BYTES = 68;
+    private static final int ROW_TAG_BYTES = 23;
+
+    private static final int INITIAL_CELL_CAPACITY = 64;
+    private static final int INITIAL_ROW_CAPACITY = 16;
+
+    private static final int TYPE_BITS = 3;
+    private static final int STYLE_BITS = 15;
+    private static final int COL_BITS = 14;
+    private static final int ROW_BITS = 20;
+
+    private static final int TYPE_SHIFT = 12;
+    private static final int STYLE_SHIFT = TYPE_SHIFT + TYPE_BITS;        // 15
+    private static final int COL_SHIFT = STYLE_SHIFT + STYLE_BITS;        // 30
+    private static final int ROW_SHIFT = COL_SHIFT + COL_BITS;            // 44
+
+    private static final long TYPE_MASK = (1L << TYPE_BITS) - 1;
+    private static final long STYLE_MASK = (1L << STYLE_BITS) - 1;
+    private static final long COL_MASK = (1L << COL_BITS) - 1;
+    private static final long ROW_MASK = (1L << ROW_BITS) - 1;
+
+    private long[] _packed;
+    private long[] _values;
+    private int[] _next;
+    private int _size;
+
+    private int _rowBase;
+    private int _rowSpan;
+    private int[] _rowHead;
+    private int[] _rowTail;
+
+    private final String[] _colLetters;
+
+    SheetDataBuffer(final int colLetterCacheSize) {
+        if (colLetterCacheSize < 1) {
+            throw new IllegalArgumentException(
+                    "colLetterCacheSize must be >= 1, got " + colLetterCacheSize);
+        }
+        _packed = new long[INITIAL_CELL_CAPACITY];
+        _values = new long[INITIAL_CELL_CAPACITY];
+        _next = new int[INITIAL_CELL_CAPACITY];
+        _rowHead = new int[INITIAL_ROW_CAPACITY];
+        _rowTail = new int[INITIAL_ROW_CAPACITY];
+        _colLetters = new String[colLetterCacheSize];
+    }
+
+    void appendNumeric(final int row, final int col, final int style, final double value) {
+        _append(row, col, style, TYPE_NUMERIC, Double.doubleToRawLongBits(value));
+    }
+
+    void appendString(final int row, final int col, final int style, final int sstIndex) {
+        // Low 32 bits of the value slot hold the index; high 32 bits remain reserved.
+        _append(row, col, style, TYPE_STRING, sstIndex);
+    }
+
+    void appendBoolean(final int row, final int col, final int style, final boolean value) {
+        _append(row, col, style, TYPE_BOOLEAN, value ? 1L : 0L);
+    }
+
+    void appendBlank(final int row, final int col, final int style) {
+        _append(row, col, style, TYPE_BLANK, 0L);
+    }
+
+    int size() {
+        return _size;
+    }
+
+    boolean isEmpty() {
+        return _size == 0;
+    }
+
+    int maxRowSeen() {
+        return _rowSpan == 0 ? -1 : _rowBase + _rowSpan - 1;
+    }
+
+    /** Upper-bound byte length of the XML this buffer will produce on
+     *  {@link #flushTo(StringBuilder)}. Used by the back-write runtime
+     *  monitor as a fail-fast guard against unbounded accumulation. */
+    long byteSize() {
+        return (long) _size * MAX_CELL_BYTES + (long) _rowSpan * ROW_TAG_BYTES;
+    }
+
+    /** Emit all buffered cells, row by row, into {@code sb}, then reset. */
+    void flushTo(final StringBuilder sb) {
+        for (int offset = 0; offset < _rowSpan; offset++) {
+            int cellIdx = _rowHead[offset];
+            if (cellIdx < 0) continue;
+            final int row = _rowBase + offset;
+            sb.append("<row r=\"").append(row + 1).append("\">");
+            while (cellIdx >= 0) {
+                _appendCell(sb, _packed[cellIdx], _values[cellIdx]);
+                cellIdx = _next[cellIdx];
+            }
+            sb.append("</row>");
+        }
+        _reset();
+    }
+
+    private void _append(final int row, final int col, final int style,
+                         final byte type, final long valueSlot) {
+        final long packed =
+                ((long) row << ROW_SHIFT)
+                        | ((long) col << COL_SHIFT)
+                        | ((long) style << STYLE_SHIFT)
+                        | ((long) type << TYPE_SHIFT);
+
+        final int cellIdx = _size;
+        _ensureCellCapacity(cellIdx + 1);
+        _packed[cellIdx] = packed;
+        _values[cellIdx] = valueSlot;
+        _next[cellIdx] = -1;
+
+        if (_rowSpan == 0) {
+            _rowBase = row;
+            _ensureRowCapacity(1);
+            _rowHead[0] = cellIdx;
+            _rowTail[0] = cellIdx;
+            _rowSpan = 1;
+        } else if (row < _rowBase) {
+            throw new IllegalStateException(
+                    "Row " + row + " precedes rowBase " + _rowBase
+                            + " — back-write target was flushed prematurely");
+        } else {
+            final int rowOffset = row - _rowBase;
+            if (rowOffset >= _rowSpan) {
+                _ensureRowCapacity(rowOffset + 1);
+                for (int i = _rowSpan; i <= rowOffset; i++) {
+                    _rowHead[i] = -1;
+                    _rowTail[i] = -1;
+                }
+                _rowSpan = rowOffset + 1;
+            }
+            if (_rowHead[rowOffset] < 0) {
+                _rowHead[rowOffset] = cellIdx;
+                _rowTail[rowOffset] = cellIdx;
+            } else {
+                _next[_rowTail[rowOffset]] = cellIdx;
+                _rowTail[rowOffset] = cellIdx;
+            }
+        }
+        _size++;
+    }
+
+    private void _appendCell(final StringBuilder sb, final long packed, final long value) {
+        final int row = (int) ((packed >>> ROW_SHIFT) & ROW_MASK);
+        final int col = (int) ((packed >>> COL_SHIFT) & COL_MASK);
+        final int style = (int) ((packed >>> STYLE_SHIFT) & STYLE_MASK);
+        final byte type = (byte) ((packed >>> TYPE_SHIFT) & TYPE_MASK);
+
+        sb.append("<c r=\"")
+                .append(_colLetter(col))
+                .append(row + 1)
+                .append("\" s=\"")
+                .append(style);
+        switch (type) {
+            case TYPE_NUMERIC:
+                sb.append("\" t=\"n\"><v>")
+                        .append(Double.longBitsToDouble(value))
+                        .append("</v></c>");
+                break;
+            case TYPE_STRING:
+                sb.append("\" t=\"s\"><v>")
+                        .append((int) value)
+                        .append("</v></c>");
+                break;
+            case TYPE_BOOLEAN:
+                sb.append("\" t=\"b\"><v>")
+                        .append(value == 0L ? '0' : '1')
+                        .append("</v></c>");
+                break;
+            case TYPE_BLANK:
+                sb.append("\"/>");
+                break;
+            default:
+                throw new IllegalStateException("Unknown cell type code " + type);
+        }
+    }
+
+    private String _colLetter(final int col) {
+        if (col < 0 || col >= _colLetters.length) {
+            return CellReference.convertNumToColString(col);
+        }
+        String letter = _colLetters[col];
+        if (letter == null) {
+            letter = CellReference.convertNumToColString(col);
+            _colLetters[col] = letter;
+        }
+        return letter;
+    }
+
+    private void _reset() {
+        _size = 0;
+        _rowBase = 0;
+        _rowSpan = 0;
+    }
+
+    private void _ensureCellCapacity(final int required) {
+        if (required <= _packed.length) return;
+        int next = _packed.length;
+        while (next < required) {
+            next = next + (next >> 1) + 1;
+        }
+        _packed = Arrays.copyOf(_packed, next);
+        _values = Arrays.copyOf(_values, next);
+        _next = Arrays.copyOf(_next, next);
+    }
+
+    private void _ensureRowCapacity(final int required) {
+        if (required <= _rowHead.length) return;
+        int next = _rowHead.length;
+        while (next < required) {
+            next = next + (next >> 1) + 1;
+        }
+        _rowHead = Arrays.copyOf(_rowHead, next);
+        _rowTail = Arrays.copyOf(_rowTail, next);
+    }
+}

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SheetDataBuffer.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SheetDataBuffer.java
@@ -48,9 +48,9 @@ final class SheetDataBuffer {
     private static final int ROW_TAG_BYTES = 23;
 
     // Lazy capacity inflated on first append, then grown 1.5× — same shape
-    // as java.util.ArrayList. Excel binding inner lists are typically small,
-    // so a 5-slot floor keeps idle buffers minimal.
-    private static final int DEFAULT_CAPACITY = 5;
+    // as java.util.ArrayList. Covers typical Excel schemas (≤ 16 columns)
+    // without grow, while keeping idle buffers minimal.
+    private static final int DEFAULT_CAPACITY = 16;
 
     private static final long[] EMPTY_LONG_ARRAY = new long[0];
     private static final int[] EMPTY_INT_ARRAY = new int[0];

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/BackWriteProjection.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/BackWriteProjection.java
@@ -14,8 +14,10 @@ import io.github.scndry.jackson.dataformat.spreadsheet.schema.ColumnPointer;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
 
 /**
- * Internal helpers for the SSML back-write buffer — cell-XML upper bound,
- * runtime limit, schema-level scope detection, and projected size.
+ * Internal helpers for the SSML back-write scenario — cell-XML upper bound,
+ * runtime limit, schema-level scope detection, and projected size. Used by
+ * {@code SheetDataBuffer} (byte upper bound for buffered cells) and
+ * {@code SheetGenerator} (pre-list fail-fast check on {@code writeStartArray}).
  *
  * <p>Not part of the public API. Classes under
  * {@code io.github.scndry.jackson.dataformat.spreadsheet.schema.internal}
@@ -111,22 +113,20 @@ public final class BackWriteProjection {
         return (long) listSize * innerRowMaxBytes(schema, arrayPointer);
     }
 
-    /** Back-write buffer limit (bytes). Default {@code max(4 MB, heap/32)}.
+    /** Back-write buffer limit (bytes). Default {@code max(1 MB, heap/128)}.
      *
-     *  <p>{@code StringBuilder.ensureCapacity} grows by doubling
-     *  ({@code Arrays.copyOf(value, newCapacity)}), so during a grow the old
-     *  and new arrays coexist — peak heap during a single grow ≈ 2 × current
-     *  buffer size. heap/32 limit + 2× grow peak = heap/16 transient peak,
-     *  leaving the remaining heap (≈ 15/16) for other allocations and GC
-     *  headroom. The 4 MB floor keeps the limit meaningful on small heaps
-     *  (Lambda / container).
+     *  <p>{@code SheetDataBuffer} grows its SoA arrays by 1.5×
+     *  ({@code Arrays.copyOf}), so during a grow the old (≈ ⅔ × limit) and
+     *  new (limit) arrays coexist — peak heap during a single grow
+     *  ≈ 1.667 × current buffer size. heap/128 limit + 1.667× grow peak
+     *  ≈ heap/77 transient peak, leaving the remaining heap (≈ 76/77) for
+     *  other allocations and GC headroom. The 1 MB floor keeps the limit
+     *  meaningful on small heaps (Lambda / container).
      *
-     *  <p>Conservative starting point modeled after Apache POI's SXSSF
-     *  default of 100 random-access rows. No external override knob is
-     *  exposed; a future need can introduce one on {@code SpreadsheetFactory}
-     *  without breaking callers. */
+     *  <p>No external override knob is exposed; a future need can introduce
+     *  one on {@code SpreadsheetFactory} without breaking callers. */
     public static long backWriteBufferLimit() {
-        return Math.max(4L * 1024 * 1024, Runtime.getRuntime().maxMemory() / 32);
+        return Math.max(1L * 1024 * 1024, Runtime.getRuntime().maxMemory() / 128);
     }
 
     /** Human-readable byte size formatting for diagnostics. */

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/BackWriteProjectionTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/BackWriteProjectionTest.java
@@ -137,23 +137,22 @@ class BackWriteProjectionTest {
     }
 
     // ----------------------------------------------------------------
-    // backWriteBufferLimit — max(4 MB, heap/32)
+    // backWriteBufferLimit — max(1 MB, heap/128)
     // ----------------------------------------------------------------
 
     @Test
-    void backWriteBufferLimit_isAtLeastFourMegaFloor() {
+    void backWriteBufferLimit_isAtLeastOneMegaFloor() {
         assertThat(BackWriteProjection.backWriteBufferLimit())
-                .isGreaterThanOrEqualTo(4L * 1024 * 1024);
+                .isGreaterThanOrEqualTo(1L * 1024 * 1024);
     }
 
     @Test
-    void backWriteBufferLimit_doesNotExceedHeapOverThirtyTwo() {
-        // Limit is max(4 MB, heap/32). The cap matches max — so the limit
-        // is never above heap/32 except when heap/32 < 4 MB (small heap),
-        // in which case the floor takes over. Verify the formula's upper
-        // half: limit ≤ max(floor, heap/32).
+    void backWriteBufferLimit_matchesHeapOver128Formula() {
+        // Limit is max(1 MB, heap/128). The cap matches max — so the limit
+        // is never above heap/128 except when heap/128 < 1 MB (small heap),
+        // in which case the floor takes over.
         final long heap = Runtime.getRuntime().maxMemory();
-        final long expected = Math.max(4L * 1024 * 1024, heap / 32);
+        final long expected = Math.max(1L * 1024 * 1024, heap / 128);
         assertThat(BackWriteProjection.backWriteBufferLimit()).isEqualTo(expected);
     }
 

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SheetDataBufferTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SheetDataBufferTest.java
@@ -180,8 +180,8 @@ class SheetDataBufferTest {
 
     @Test
     void growth_handles10000Cells() {
-        // Beyond INITIAL_CELL_CAPACITY (64) and INITIAL_ROW_CAPACITY (16) —
-        // exercises 1.5× growth on both cell arrays and row directory.
+        // Far beyond the DEFAULT_CAPACITY (5) lazy alloc — exercises
+        // repeated 1.5× growth on both cell arrays and row directory.
         SheetDataBuffer buf = new SheetDataBuffer(8);
         for (int row = 0; row < 1_000; row++) {
             for (int col = 0; col < 10; col++) {

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SheetDataBufferTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SheetDataBufferTest.java
@@ -1,0 +1,233 @@
+package io.github.scndry.jackson.dataformat.spreadsheet.poi.ooxml;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Direct tests for {@link SheetDataBuffer} — bit packing round-trip,
+ * row-linked back-write insertion, rolling row directory, and growth.
+ */
+class SheetDataBufferTest {
+
+    @Test
+    void appendNumeric_emitsCellWithValueAttribute() {
+        SheetDataBuffer buf = new SheetDataBuffer(4);
+        buf.appendNumeric(0, 0, 2, 3.5);
+
+        StringBuilder sb = new StringBuilder();
+        buf.flushTo(sb);
+        assertThat(sb.toString()).isEqualTo("<row r=\"1\"><c r=\"A1\" s=\"2\" t=\"n\"><v>3.5</v></c></row>");
+    }
+
+    @Test
+    void appendString_emitsSharedStringIndex() {
+        SheetDataBuffer buf = new SheetDataBuffer(4);
+        buf.appendString(1, 2, 0, 42);
+
+        StringBuilder sb = new StringBuilder();
+        buf.flushTo(sb);
+        assertThat(sb.toString()).isEqualTo("<row r=\"2\"><c r=\"C2\" s=\"0\" t=\"s\"><v>42</v></c></row>");
+    }
+
+    @Test
+    void appendBoolean_emitsZeroOrOne() {
+        SheetDataBuffer buf = new SheetDataBuffer(4);
+        buf.appendBoolean(0, 0, 0, true);
+        buf.appendBoolean(0, 1, 0, false);
+
+        StringBuilder sb = new StringBuilder();
+        buf.flushTo(sb);
+        assertThat(sb.toString()).isEqualTo(
+                "<row r=\"1\">"
+                        + "<c r=\"A1\" s=\"0\" t=\"b\"><v>1</v></c>"
+                        + "<c r=\"B1\" s=\"0\" t=\"b\"><v>0</v></c>"
+                        + "</row>");
+    }
+
+    @Test
+    void appendBlank_emitsSelfClosingCell() {
+        SheetDataBuffer buf = new SheetDataBuffer(4);
+        buf.appendBlank(0, 0, 5);
+
+        StringBuilder sb = new StringBuilder();
+        buf.flushTo(sb);
+        assertThat(sb.toString()).isEqualTo("<row r=\"1\"><c r=\"A1\" s=\"5\"/></row>");
+    }
+
+    @Test
+    void appendsSameRow_emitsCellsInAppendOrder() {
+        SheetDataBuffer buf = new SheetDataBuffer(4);
+        buf.appendNumeric(0, 0, 0, 1);
+        buf.appendNumeric(0, 1, 0, 2);
+        buf.appendNumeric(0, 2, 0, 3);
+
+        StringBuilder sb = new StringBuilder();
+        buf.flushTo(sb);
+        assertThat(sb.toString()).contains(
+                "<v>1.0</v></c><c r=\"B1\"",
+                "<v>2.0</v></c><c r=\"C1\"",
+                "<v>3.0</v></c></row>");
+    }
+
+    @Test
+    void appendsForwardRows_emitsRowsInOrder() {
+        SheetDataBuffer buf = new SheetDataBuffer(4);
+        buf.appendNumeric(0, 0, 0, 1);
+        buf.appendNumeric(1, 0, 0, 2);
+        buf.appendNumeric(2, 0, 0, 3);
+
+        StringBuilder sb = new StringBuilder();
+        buf.flushTo(sb);
+        assertThat(sb.toString()).isEqualTo(
+                "<row r=\"1\"><c r=\"A1\" s=\"0\" t=\"n\"><v>1.0</v></c></row>"
+                        + "<row r=\"2\"><c r=\"A2\" s=\"0\" t=\"n\"><v>2.0</v></c></row>"
+                        + "<row r=\"3\"><c r=\"A3\" s=\"0\" t=\"n\"><v>3.0</v></c></row>");
+    }
+
+    @Test
+    void backWrite_appendsToPastRowTail() {
+        // Simulates back-write: inner list rows 0..1, then outer cell on row 0
+        // lands at the tail of row 0 — emitted in cell-list order, not column order.
+        SheetDataBuffer buf = new SheetDataBuffer(4);
+        buf.appendNumeric(0, 1, 0, 10);   // inner row 0
+        buf.appendNumeric(1, 1, 0, 20);   // inner row 1
+        buf.appendNumeric(0, 3, 0, 99);   // back-write: outer cell on row 0
+
+        StringBuilder sb = new StringBuilder();
+        buf.flushTo(sb);
+        assertThat(sb.toString()).isEqualTo(
+                "<row r=\"1\">"
+                        + "<c r=\"B1\" s=\"0\" t=\"n\"><v>10.0</v></c>"
+                        + "<c r=\"D1\" s=\"0\" t=\"n\"><v>99.0</v></c>"
+                        + "</row>"
+                        + "<row r=\"2\">"
+                        + "<c r=\"B2\" s=\"0\" t=\"n\"><v>20.0</v></c>"
+                        + "</row>");
+    }
+
+    @Test
+    void rowBaseTracksFirstAppendedRow() {
+        SheetDataBuffer buf = new SheetDataBuffer(4);
+        buf.appendNumeric(5, 0, 0, 1);
+        assertThat(buf.maxRowSeen()).isEqualTo(5);
+
+        StringBuilder sb = new StringBuilder();
+        buf.flushTo(sb);
+        assertThat(sb.toString()).startsWith("<row r=\"6\">");
+    }
+
+    @Test
+    void rowBeforeBase_throwsIllegalStateException() {
+        SheetDataBuffer buf = new SheetDataBuffer(4);
+        buf.appendNumeric(5, 0, 0, 1);
+
+        assertThatThrownBy(() -> buf.appendNumeric(3, 0, 0, 2))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("precedes rowBase");
+    }
+
+    @Test
+    void emptyRowsInRange_skippedOnFlush() {
+        SheetDataBuffer buf = new SheetDataBuffer(4);
+        buf.appendNumeric(0, 0, 0, 1);
+        buf.appendNumeric(3, 0, 0, 2);   // rows 1, 2 stay empty
+
+        StringBuilder sb = new StringBuilder();
+        buf.flushTo(sb);
+        assertThat(sb.toString()).isEqualTo(
+                "<row r=\"1\"><c r=\"A1\" s=\"0\" t=\"n\"><v>1.0</v></c></row>"
+                        + "<row r=\"4\"><c r=\"A4\" s=\"0\" t=\"n\"><v>2.0</v></c></row>");
+    }
+
+    @Test
+    void byteSize_isUpperBoundOfFlushOutput() {
+        SheetDataBuffer buf = new SheetDataBuffer(4);
+        buf.appendNumeric(0, 0, 0, 1);
+        buf.appendNumeric(0, 1, 0, 2);
+        buf.appendNumeric(1, 0, 0, 3);
+
+        // 3 cells × 68 + 2 row tags × 23 = 250 — upper bound
+        final long predicted = buf.byteSize();
+        assertThat(predicted).isEqualTo(3L * 68 + 2L * 23);
+
+        StringBuilder sb = new StringBuilder();
+        buf.flushTo(sb);
+        assertThat((long) sb.length()).isLessThanOrEqualTo(predicted);
+    }
+
+    @Test
+    void flushTo_resetsBuffer() {
+        SheetDataBuffer buf = new SheetDataBuffer(4);
+        buf.appendNumeric(0, 0, 0, 1);
+        assertThat(buf.size()).isEqualTo(1);
+
+        buf.flushTo(new StringBuilder());
+
+        assertThat(buf.isEmpty()).isTrue();
+        assertThat(buf.size()).isZero();
+        assertThat(buf.maxRowSeen()).isEqualTo(-1);
+    }
+
+    @Test
+    void emptyBuffer_flushEmitsNothing() {
+        SheetDataBuffer buf = new SheetDataBuffer(4);
+        StringBuilder sb = new StringBuilder();
+        buf.flushTo(sb);
+        assertThat(sb.toString()).isEmpty();
+    }
+
+    @Test
+    void growth_handles10000Cells() {
+        // Beyond INITIAL_CELL_CAPACITY (64) and INITIAL_ROW_CAPACITY (16) —
+        // exercises 1.5× growth on both cell arrays and row directory.
+        SheetDataBuffer buf = new SheetDataBuffer(8);
+        for (int row = 0; row < 1_000; row++) {
+            for (int col = 0; col < 10; col++) {
+                buf.appendNumeric(row, col, 0, row + col);
+            }
+        }
+        assertThat(buf.size()).isEqualTo(10_000);
+        assertThat(buf.maxRowSeen()).isEqualTo(999);
+
+        StringBuilder sb = new StringBuilder();
+        buf.flushTo(sb);
+        assertThat(sb.toString()).startsWith("<row r=\"1\">");
+        assertThat(sb.toString()).endsWith("</row>");
+    }
+
+    @Test
+    void colLetterCache_handlesColumnsBeyondCacheSize() {
+        // cache size 2, col 5 falls back to direct convertNumToColString.
+        SheetDataBuffer buf = new SheetDataBuffer(2);
+        buf.appendNumeric(0, 5, 0, 1);
+
+        StringBuilder sb = new StringBuilder();
+        buf.flushTo(sb);
+        assertThat(sb.toString()).contains("r=\"F1\"");
+    }
+
+    @Test
+    void colLetterCache_reusesEntryAcrossCalls() {
+        SheetDataBuffer buf = new SheetDataBuffer(4);
+        buf.appendNumeric(0, 1, 0, 1);
+        buf.appendNumeric(1, 1, 0, 2);
+        buf.appendNumeric(2, 1, 0, 3);
+
+        StringBuilder sb = new StringBuilder();
+        buf.flushTo(sb);
+        // All three cells reference column B — cache hit on entries 2 and 3.
+        assertThat(sb.toString()).contains("r=\"B1\"", "r=\"B2\"", "r=\"B3\"");
+    }
+
+    @Test
+    void typeCodeMatchesPoiCellType() {
+        // POI CellType.code: NUMERIC=0, STRING=1, FORMULA=2, BLANK=3, BOOLEAN=4, ERROR=5
+        // Reserved codes (2, 5) are intentionally unmapped.
+        assertThat(SheetDataBuffer.TYPE_NUMERIC).isEqualTo((byte) 0);
+        assertThat(SheetDataBuffer.TYPE_STRING).isEqualTo((byte) 1);
+        assertThat(SheetDataBuffer.TYPE_BLANK).isEqualTo((byte) 3);
+        assertThat(SheetDataBuffer.TYPE_BOOLEAN).isEqualTo((byte) 4);
+    }
+}


### PR DESCRIPTION
## Summary

- Introduce `SheetDataBuffer` (SoA) — 16-byte packed cell record (`long _packed` + `long _values`) with a row-linked window (`int _next`, `_rowHead/_rowTail`) for O(1) back-write insertion into past rows. Capacity grows 1.5× from a 16-slot lazy floor (`java.util.ArrayList` shape).
- Route `SSMLSheetWriter.writeNumeric/String/Boolean/Blank` through the buffer; remove the two cell-XML build paths (`_appendCellStart`/`_appendCellEnd` streaming vs. `_buildCellXml`/`_insertCellIntoEmittedRow` single-shot) and the manual `<row>` bookkeeping. Net `-98 lines`.
- Tighten back-write buffer limit from `max(4 MB, heap/32)` to `max(1 MB, heap/128)`. SoA 1.5× grow keeps the transient peak at ~heap/77.

## Test plan

- `./gradlew test` — 371 tests pass (354 → 371), regression-free
- Internal JMH `BackWriteBenchmark` added under `src/jmh/.../internal/` for optimization profiling; not documented in BENCHMARK.md