### PR TITLE
Fix back-write buffer accounting and stream flush per fragment

### DIFF
--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLSheetWriter.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLSheetWriter.java
@@ -51,7 +51,7 @@ public final class SSMLSheetWriter implements SheetWriter {
     private static final String XML_DECL =
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
 
-    private static final int BUFFER_SIZE = 512 * 1024;
+    private static final int BUFFER_SIZE = 64 * 1024;
     private static final int FLUSH_THRESHOLD = 1024;
 
     private final String _entrySheet;
@@ -209,8 +209,7 @@ public final class SSMLSheetWriter implements SheetWriter {
         if (_data.isEmpty()) return;
         if (_reference.getRow() <= _data.maxRowSeen()) return;
         try {
-            _data.flushTo(_sb);
-            _checkSbFlush();
+            _data.flushTo(_sb, this::_checkSbFlush);
         } catch (IOException e) {
             throw new IllegalStateException(e);
         }
@@ -408,8 +407,7 @@ public final class SSMLSheetWriter implements SheetWriter {
     private void _finishSheetXmlEntry() throws IOException {
         _startSheetData();
         if (_data != null && !_data.isEmpty()) {
-            _data.flushTo(_sb);
-            _checkSbFlush();
+            _data.flushTo(_sb, this::_checkSbFlush);
         }
         _append("</sheetData>");
         _appendMergeCellsIntoSuffix();

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SheetDataBuffer.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SheetDataBuffer.java
@@ -1,5 +1,6 @@
 package io.github.scndry.jackson.dataformat.spreadsheet.poi.ooxml;
 
+import java.io.IOException;
 import java.util.Arrays;
 
 import org.apache.poi.ss.util.CellReference;
@@ -131,18 +132,45 @@ final class SheetDataBuffer {
         return (long) _size * CELL_MEMORY_BYTES + (long) _rowSpan * ROW_MEMORY_BYTES;
     }
 
-    /** Emit all buffered cells, row by row, into {@code sb}, then reset. */
+    /** Sink invoked after each XML fragment is appended to {@code sb} so
+     *  the writer can keep its buffer within its flush threshold. Matches
+     *  the existing fragment-level check pattern in
+     *  {@code SSMLSheetWriter._append}. */
+    @FunctionalInterface
+    interface FlushSink {
+        void afterFragment() throws IOException;
+    }
+
+    private static final FlushSink NO_OP_SINK = () -> {};
+
+    /** Convenience overload for callers that do not need per-fragment
+     *  draining (tests, in-memory accumulation). */
     void flushTo(final StringBuilder sb) {
+        try {
+            flushTo(sb, NO_OP_SINK);
+        } catch (IOException e) {
+            throw new AssertionError("NO_OP_SINK never throws", e);
+        }
+    }
+
+    /** Emit all buffered cells, row by row, into {@code sb}, invoking
+     *  {@code sink} after each cell or row-tag fragment so callers can
+     *  drain {@code sb} before it exceeds its flush threshold. Resets
+     *  the buffer on return. */
+    void flushTo(final StringBuilder sb, final FlushSink sink) throws IOException {
         for (int offset = 0; offset < _rowSpan; offset++) {
             int cellIdx = _rowHead[offset];
             if (cellIdx < 0) continue;
             final int row = _rowBase + offset;
             sb.append("<row r=\"").append(row + 1).append("\">");
+            sink.afterFragment();
             while (cellIdx >= 0) {
                 _appendCell(sb, _packed[cellIdx], _values[cellIdx]);
+                sink.afterFragment();
                 cellIdx = _next[cellIdx];
             }
             sb.append("</row>");
+            sink.afterFragment();
         }
         _reset();
     }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SheetDataBuffer.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SheetDataBuffer.java
@@ -41,11 +41,13 @@ final class SheetDataBuffer {
     static final byte TYPE_BLANK   = 3;
     static final byte TYPE_BOOLEAN = 4;
 
-    // Upper bounds aligned with BackWriteProjection — must stay in sync.
-    // <c r="REF" s="STYLE" t="TYPE"><v>VALUE</v></c>
-    //   fixed (27) + ref (10) + style (5) + type (1) + value max (25) = 68
-    private static final int MAX_CELL_BYTES = 68;
-    private static final int ROW_TAG_BYTES = 23;
+    // Internal memory footprint per cell / per row — used by byteSize()
+    // for back-write OOM monitoring. Must stay in sync with
+    // BackWriteProjection.{cellMemoryBytes, rowMemoryBytes}.
+    //   Cell SoA slots: long _packed (8) + long _values (8) + int _next (4) = 20 bytes
+    //   Row directory : int _rowHead (4) + int _rowTail (4)                 = 8 bytes
+    static final int CELL_MEMORY_BYTES = 20;
+    static final int ROW_MEMORY_BYTES = 8;
 
     // Lazy capacity inflated on first append, then grown 1.5× — same shape
     // as java.util.ArrayList. Covers typical Excel schemas (≤ 16 columns)
@@ -119,11 +121,14 @@ final class SheetDataBuffer {
         return _rowSpan == 0 ? -1 : _rowBase + _rowSpan - 1;
     }
 
-    /** Upper-bound byte length of the XML this buffer will produce on
-     *  {@link #flushTo(StringBuilder)}. Used by the back-write runtime
-     *  monitor as a fail-fast guard against unbounded accumulation. */
+    /** Upper-bound heap footprint of the cell SoA arrays and row directory.
+     *  Used by the back-write runtime monitor as a fail-fast guard against
+     *  unbounded accumulation while flush is suspended. The output XML is a
+     *  separate concern — its size is bounded by
+     *  {@link io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.BackWriteProjection}
+     *  on the same memory basis. */
     long byteSize() {
-        return (long) _size * MAX_CELL_BYTES + (long) _rowSpan * ROW_TAG_BYTES;
+        return (long) _size * CELL_MEMORY_BYTES + (long) _rowSpan * ROW_MEMORY_BYTES;
     }
 
     /** Emit all buffered cells, row by row, into {@code sb}, then reset. */

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/BackWriteProjection.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/BackWriteProjection.java
@@ -5,8 +5,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
 
-import com.fasterxml.jackson.databind.JavaType;
-
 import lombok.extern.slf4j.Slf4j;
 
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
@@ -14,10 +12,13 @@ import io.github.scndry.jackson.dataformat.spreadsheet.schema.ColumnPointer;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
 
 /**
- * Internal helpers for the SSML back-write scenario — cell-XML upper bound,
- * runtime limit, schema-level scope detection, and projected size. Used by
- * {@code SheetDataBuffer} (byte upper bound for buffered cells) and
- * {@code SheetGenerator} (pre-list fail-fast check on {@code writeStartArray}).
+ * Internal helpers for the SSML back-write scenario — per-cell heap
+ * footprint, runtime limit, schema-level scope detection, and projected
+ * size. All sizes are SoA <strong>internal memory</strong> bytes (not
+ * output XML bytes); the back-write limit's intent is heap protection
+ * while flush is suspended inside an array scope. Used by
+ * {@code SheetDataBuffer} (per-cell memory) and {@code SheetGenerator}
+ * (pre-list fail-fast check on {@code writeStartArray}).
  *
  * <p>Not part of the public API. Classes under
  * {@code io.github.scndry.jackson.dataformat.spreadsheet.schema.internal}
@@ -27,22 +28,11 @@ import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
 @Slf4j
 public final class BackWriteProjection {
 
-    // <c r="REF" s="STYLE" t="TYPE"><v>VALUE</v></c>
-    //   fixed = "<c r=\"" (6) + "\" s=\"" (4) + "\" t=\"" (4) + "\"><v>" (5)
-    //         + "</v></c>" (8) = 27 bytes
-    //   ref   max = "XFD1048576" = 10 chars
-    //   style max = 32767 digits = 5 chars
-    //   type      = "n" | "s" | "b" = 1 char (writeBlank emits no t attribute)
-    private static final int CELL_FIXED_TAGS_BYTES = 27;
-    private static final int CELL_REF_MAX = 10;
-    private static final int CELL_STYLE_MAX = 5;
-    private static final int CELL_TYPE_MAX = 1;
+    // SheetDataBuffer cell SoA: long _packed (8) + long _values (8) + int _next (4)
+    private static final int CELL_MEMORY_BYTES = 20;
 
-    // <row r="N">..</row>
-    //   open  = "<row r=\"" (8) + N digits + "\">" (2) = 10 + N
-    //   close = "</row>"                                    = 6
-    // Excel row max = 1048576 (7 digits) → worst total = 23 bytes.
-    private static final int ROW_TAG_BYTES = 23;
+    // SheetDataBuffer row directory: int _rowHead (4) + int _rowTail (4)
+    private static final int ROW_MEMORY_BYTES = 8;
 
     /** Cache for {@link #requiresBackWriteScope(SpreadsheetSchema)} keyed on
      *  schema identity. WeakHashMap so schemas reclaimed by GC drop their
@@ -55,50 +45,27 @@ public final class BackWriteProjection {
     private BackWriteProjection() {
     }
 
-    /** Upper-bound bytes for one cell XML of the given column.
+    /** SoA heap footprint of one buffered cell (constant across cell types).
      *
-     *  <p>Cell-XML output paths in this library:
-     *  <ul>
-     *    <li>All numeric overloads ({@code writeNumber(int|long|float|double)})
-     *        route through {@code SheetGenerator → _writer.writeNumeric(double)},
-     *        which calls {@code StringBuilder.append(double)} — every numeric
-     *        primitive emits a {@code Double.toString}-formatted value
-     *        (worst case ~25 chars), regardless of the source type.</li>
-     *    <li>{@code boolean} emits "0" or "1" (1 char).</li>
-     *    <li>{@code String} / {@code Enum} / {@code BigDecimal} /
-     *        {@code BigInteger} route through {@code SheetGenerator →
-     *        _writer.writeString → SharedStringsStore}, leaving only a
-     *        shared-string index in the cell (max 10 digits for
-     *        {@code Integer.MAX_VALUE}). Their content lives in
-     *        {@code sharedStrings.xml}, a separate stream not gated by
-     *        back-write buffer limits.</li>
-     *    <li>{@code Date} / {@code java.time.*} route through
-     *        {@code writeNumber(double serial)}, same 25-char bound.</li>
-     *  </ul>
-     *  Every supported Java type has a bounded cell XML size. */
+     *  <p>Every supported Java type writes a single cell into
+     *  {@code SheetDataBuffer}'s SoA arrays — numerics
+     *  ({@code writeNumber(int|long|float|double|BigDecimal)} and
+     *  {@code Date} / {@code java.time.*}) land via
+     *  {@code Double.doubleToRawLongBits}, strings / enums via the
+     *  shared-string index, booleans as 0/1, blanks as 0. Each occupies
+     *  one slot in {@code _packed}, {@code _values}, and {@code _next} —
+     *  20 bytes total. The {@code column} argument is kept for symmetry
+     *  with future per-type accounting and unused today. */
     public static int cellMaxBytes(final Column column) {
-        final JavaType type = column.getType();
-        final Class<?> raw = type.getRawClass();
-        final int valueMax;
-        if (raw == boolean.class || raw == Boolean.class) {
-            valueMax = 1;
-        } else if (raw == String.class || raw.isEnum()
-                || raw == java.math.BigDecimal.class
-                || raw == java.math.BigInteger.class) {
-            valueMax = 10;                                    // shared string index
-        } else {
-            valueMax = 25;
-        }
-        return CELL_FIXED_TAGS_BYTES + CELL_REF_MAX + CELL_STYLE_MAX + CELL_TYPE_MAX + valueMax;
+        return CELL_MEMORY_BYTES;
     }
 
-    /** Upper-bound bytes for one inner row (all columns inside the given
-     *  array pointer + the {@code <row>} tag overhead). Every supported
-     *  Java type has a bounded per-cell size — see {@link #cellMaxBytes}. */
+    /** SoA heap footprint of one inner row — every column's cell record
+     *  plus a row directory entry. */
     public static long innerRowMaxBytes(
             final SpreadsheetSchema schema, final ColumnPointer arrayPointer) {
         final List<Column> inners = schema.getColumns(arrayPointer);
-        long bytes = ROW_TAG_BYTES;
+        long bytes = ROW_MEMORY_BYTES;
         for (final Column c : inners) {
             bytes += cellMaxBytes(c);
         }
@@ -113,7 +80,8 @@ public final class BackWriteProjection {
         return (long) listSize * innerRowMaxBytes(schema, arrayPointer);
     }
 
-    /** Back-write buffer limit (bytes). Default {@code max(1 MB, heap/128)}.
+    /** Back-write buffer limit (bytes of SoA internal memory).
+     *  Default {@code max(1 MB, heap/128)}.
      *
      *  <p>{@code SheetDataBuffer} grows its SoA arrays by 1.5×
      *  ({@code Arrays.copyOf}), so during a grow the old (≈ ⅔ × limit) and
@@ -122,6 +90,11 @@ public final class BackWriteProjection {
      *  ≈ heap/77 transient peak, leaving the remaining heap (≈ 76/77) for
      *  other allocations and GC headroom. The 1 MB floor keeps the limit
      *  meaningful on small heaps (Lambda / container).
+     *
+     *  <p>The limit measures SoA cell records, not output XML. The output
+     *  XML stream ({@code _sb} in {@code SSMLSheetWriter}) is bounded by
+     *  its own flush threshold and is flushed cell-by-cell during
+     *  {@code flushTo} via a streaming sink.
      *
      *  <p>No external override knob is exposed; a future need can introduce
      *  one on {@code SpreadsheetFactory} without breaking callers. */

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/BackWriteProjectionTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/BackWriteProjectionTest.java
@@ -34,50 +34,29 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class BackWriteProjectionTest {
 
-    // Constants mirror BackWriteProjection — duplicated here as a test
-    // contract: if the writer-side numbers change, this test must change.
-    private static final int CELL_FIXED_OVERHEAD = 27 + 10 + 5 + 1;   // tags + ref + style + type
-    private static final int ROW_TAG_BYTES = 23;
+    // SoA internal memory units — must stay in sync with
+    // BackWriteProjection.{CELL_MEMORY_BYTES, ROW_MEMORY_BYTES}.
+    private static final int CELL_MEMORY_BYTES = 20;
+    private static final int ROW_MEMORY_BYTES = 8;
 
     // ----------------------------------------------------------------
-    // cellMaxBytes — every supported Java type has a bounded cell XML
+    // cellMaxBytes — SoA cell record is a fixed 20 bytes regardless of
+    // Java type (long _packed + long _values + int _next).
     // ----------------------------------------------------------------
 
     @Test
-    void cellMaxBytes_booleanIsOneCharValue() {
-        assertThat(BackWriteProjection.cellMaxBytes(_column(boolean.class)))
-                .isEqualTo(CELL_FIXED_OVERHEAD + 1);
-        assertThat(BackWriteProjection.cellMaxBytes(_column(Boolean.class)))
-                .isEqualTo(CELL_FIXED_OVERHEAD + 1);
-    }
-
-    @Test
-    void cellMaxBytes_sharedStringTypesAreTenCharIndex() {
-        // String / Enum / BigDecimal / BigInteger all route through
-        // SharedStringsStore, so only the int index (max 10 digits) lands
-        // in the cell XML.
-        final int expected = CELL_FIXED_OVERHEAD + 10;
-        assertThat(BackWriteProjection.cellMaxBytes(_column(String.class)))
-                .isEqualTo(expected);
-        assertThat(BackWriteProjection.cellMaxBytes(_column(SampleEnum.class)))
-                .isEqualTo(expected);
-        assertThat(BackWriteProjection.cellMaxBytes(_column(BigDecimal.class)))
-                .isEqualTo(expected);
-        assertThat(BackWriteProjection.cellMaxBytes(_column(BigInteger.class)))
-                .isEqualTo(expected);
-    }
-
-    @Test
-    void cellMaxBytes_numericAndDateUseDoubleWorstCase() {
-        // All numeric overloads route through writeNumeric(double) →
-        // StringBuilder.append(double) — Double.toString worst case 25 chars.
-        // Date / java.time.* route through writeNumber(double serial), same bound.
-        final int expected = CELL_FIXED_OVERHEAD + 25;
-        assertThat(BackWriteProjection.cellMaxBytes(_column(int.class))).isEqualTo(expected);
-        assertThat(BackWriteProjection.cellMaxBytes(_column(long.class))).isEqualTo(expected);
-        assertThat(BackWriteProjection.cellMaxBytes(_column(float.class))).isEqualTo(expected);
-        assertThat(BackWriteProjection.cellMaxBytes(_column(double.class))).isEqualTo(expected);
-        assertThat(BackWriteProjection.cellMaxBytes(_column(Date.class))).isEqualTo(expected);
+    void cellMaxBytes_isConstantAcrossAllSupportedTypes() {
+        assertThat(BackWriteProjection.cellMaxBytes(_column(boolean.class))).isEqualTo(CELL_MEMORY_BYTES);
+        assertThat(BackWriteProjection.cellMaxBytes(_column(Boolean.class))).isEqualTo(CELL_MEMORY_BYTES);
+        assertThat(BackWriteProjection.cellMaxBytes(_column(String.class))).isEqualTo(CELL_MEMORY_BYTES);
+        assertThat(BackWriteProjection.cellMaxBytes(_column(SampleEnum.class))).isEqualTo(CELL_MEMORY_BYTES);
+        assertThat(BackWriteProjection.cellMaxBytes(_column(BigDecimal.class))).isEqualTo(CELL_MEMORY_BYTES);
+        assertThat(BackWriteProjection.cellMaxBytes(_column(BigInteger.class))).isEqualTo(CELL_MEMORY_BYTES);
+        assertThat(BackWriteProjection.cellMaxBytes(_column(int.class))).isEqualTo(CELL_MEMORY_BYTES);
+        assertThat(BackWriteProjection.cellMaxBytes(_column(long.class))).isEqualTo(CELL_MEMORY_BYTES);
+        assertThat(BackWriteProjection.cellMaxBytes(_column(float.class))).isEqualTo(CELL_MEMORY_BYTES);
+        assertThat(BackWriteProjection.cellMaxBytes(_column(double.class))).isEqualTo(CELL_MEMORY_BYTES);
+        assertThat(BackWriteProjection.cellMaxBytes(_column(Date.class))).isEqualTo(CELL_MEMORY_BYTES);
     }
 
     enum SampleEnum { A }
@@ -110,9 +89,9 @@ class BackWriteProjectionTest {
         final SpreadsheetSchema schema = _schemaFor(Outer.class);
         final ColumnPointer arrayPointer = _findInnerArrayPointer(schema);
 
-        // Inner has 1 numeric column → cellMax 68 + row tag 23 = 91 bytes.
+        // Inner has 1 column → cellMemory 20 + rowMemory 8 = 28 bytes.
         final long projected = BackWriteProjection.project(schema, arrayPointer, 1);
-        assertThat(projected).isEqualTo(ROW_TAG_BYTES + (CELL_FIXED_OVERHEAD + 25));
+        assertThat(projected).isEqualTo(ROW_MEMORY_BYTES + CELL_MEMORY_BYTES);
     }
 
     @Test

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SheetDataBufferTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SheetDataBufferTest.java
@@ -175,6 +175,33 @@ class SheetDataBufferTest {
     }
 
     @Test
+    void flushTo_sinkFiresAfterEveryFragment() throws java.io.IOException {
+        SheetDataBuffer buf = new SheetDataBuffer(4);
+        buf.appendNumeric(0, 0, 0, 1);
+        buf.appendNumeric(0, 1, 0, 2);
+        buf.appendNumeric(1, 0, 0, 3);
+
+        // Fragments per row: row-open + 1 sink, per cell + 1 sink, row-close + 1 sink.
+        // Row 0: 1 open + 2 cells + 1 close = 4 fragments.
+        // Row 1: 1 open + 1 cell  + 1 close = 3 fragments.
+        // Total = 7 sink invocations.
+        final int[] count = {0};
+        StringBuilder sb = new StringBuilder();
+        buf.flushTo(sb, () -> count[0]++);
+        assertThat(count[0]).isEqualTo(7);
+    }
+
+    @Test
+    void flushTo_sinkPropagatesIOException() {
+        SheetDataBuffer buf = new SheetDataBuffer(4);
+        buf.appendNumeric(0, 0, 0, 1);
+
+        final java.io.IOException expected = new java.io.IOException("sink-failure");
+        assertThatThrownBy(() -> buf.flushTo(new StringBuilder(), () -> { throw expected; }))
+                .isSameAs(expected);
+    }
+
+    @Test
     void growth_handles10000Cells() {
         // Far beyond the DEFAULT_CAPACITY (5) lazy alloc — exercises
         // repeated 1.5× growth on both cell arrays and row directory.

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SheetDataBufferTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SheetDataBufferTest.java
@@ -142,19 +142,15 @@ class SheetDataBufferTest {
     }
 
     @Test
-    void byteSize_isUpperBoundOfFlushOutput() {
+    void byteSize_reflectsCellAndRowMemory() {
         SheetDataBuffer buf = new SheetDataBuffer(4);
         buf.appendNumeric(0, 0, 0, 1);
         buf.appendNumeric(0, 1, 0, 2);
         buf.appendNumeric(1, 0, 0, 3);
 
-        // 3 cells × 68 + 2 row tags × 23 = 250 — upper bound
-        final long predicted = buf.byteSize();
-        assertThat(predicted).isEqualTo(3L * 68 + 2L * 23);
-
-        StringBuilder sb = new StringBuilder();
-        buf.flushTo(sb);
-        assertThat((long) sb.length()).isLessThanOrEqualTo(predicted);
+        // 3 cells × 20 (long _packed + long _values + int _next)
+        //   + 2 rows × 8 (int _rowHead + int _rowTail) = 76 bytes
+        assertThat(buf.byteSize()).isEqualTo(3L * 20 + 2L * 8);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Account `backWriteBufferLimit` in SoA memory bytes (20/cell, 8/row), not output XML bytes (68/cell, 23/row). The limit's intent is heap protection while flush is suspended; the previous accounting was a 3.4× overestimate that did not reflect the actual SoA footprint.
- Introduce `FlushSink` callback on `SheetDataBuffer.flushTo` so `_sb` drains per fragment. Previously `flushTo` emitted the full buffer at once, letting `_sb` grow transiently to the entire back-write XML size (≈ 6.8 MB at 100K cells).
- Shrink `SSMLSheetWriter.BUFFER_SIZE` from 512 KB to 64 KB. With streaming flush the writer's `_sb` peaks at `BUFFER_SIZE` regardless of buffered cell count.

## Test plan

- `./gradlew test` — 371 tests pass, regression-free
- JMH `BackWriteBenchmark` 100K inner cells: `gc.alloc.rate.norm` 202.4 MB → 173.5 MB (−14%); time within variance
- JMH `WriteBenchmark` 100K rows: `gc.alloc.rate.norm` 129.9 MB → 123.4 MB (variance-bounded); time within variance