### PR TITLE
Refresh benchmark numbers for 1.6.2-SNAPSHOT

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -14,7 +14,7 @@
 
 | Library | Version |
 |---------|---------|
-| jackson-dataformat-spreadsheet | 1.6.1 |
+| jackson-dataformat-spreadsheet | 1.6.2-SNAPSHOT |
 | Apache POI | 5.5.1 |
 | FastExcel | 0.20.0 |
 | Fesod | 2.0.1-incubating |
@@ -24,21 +24,21 @@
 
 | Library | 1K rows | 10K rows | 50K rows | 100K rows |
 |---------|---------|----------|----------|-----------|
-| jackson-spreadsheet | 2.1 ms | 17.7 ms | 93.2 ms | 196.0 ms |
-| FastExcel | 2.4 ms | 21.1 ms | 105.7 ms | 252.0 ms |
-| Fesod | 3.3 ms | 27.8 ms | 136.3 ms | 266.6 ms |
-| Poiji | 9.3 ms | 86.9 ms | 418.4 ms | 847.7 ms |
-| Apache POI | 10.6 ms | 101.8 ms | 541.1 ms | 1094.5 ms |
+| jackson-spreadsheet | 2.4 ms | 17.9 ms | 83.7 ms | 190.1 ms |
+| FastExcel | 2.6 ms | 21.1 ms | 104.1 ms | 207.6 ms |
+| Fesod | 3.4 ms | 28.7 ms | 133.9 ms | 265.6 ms |
+| Poiji | 9.0 ms | 84.8 ms | 421.3 ms | 809.4 ms |
+| Apache POI | 11.0 ms | 95.8 ms | 507.4 ms | 1172.8 ms |
 
 ## Read — Memory (bytes/op)
 
 | Library | 10K rows | 50K rows | 100K rows |
 |---------|----------|----------|-----------|
 | jackson-spreadsheet | 36 MB | 180 MB | 360 MB |
-| Fesod | 39 MB | 197 MB | 384 MB |
-| FastExcel | 41 MB | 209 MB | 407 MB |
-| Apache POI | 222 MB | 1115 MB | 2223 MB |
-| Poiji | 274 MB | 1372 MB | 2743 MB |
+| Fesod | 40 MB | 197 MB | 381 MB |
+| FastExcel | 40 MB | 208 MB | 407 MB |
+| Apache POI | 226 MB | 1114 MB | 2227 MB |
+| Poiji | 274 MB | 1373 MB | 2739 MB |
 
 ## Write — Throughput
 
@@ -46,18 +46,18 @@ Poiji is read-only and not included.
 
 | Library | 1K rows | 10K rows | 50K rows | 100K rows |
 |---------|---------|----------|----------|-----------|
-| jackson-spreadsheet | 3.4 ms | 16.7 ms | 74.8 ms | 143.7 ms |
-| FastExcel | 2.7 ms | 15.7 ms | 77.9 ms | 153.9 ms |
-| Apache POI | 4.3 ms | 27.6 ms | 133.4 ms | 267.6 ms |
-| Fesod | 4.8 ms | 32.9 ms | 154.5 ms | 314.3 ms |
+| jackson-spreadsheet | 3.9 ms | 16.1 ms | 70.6 ms | 138.3 ms |
+| FastExcel | 2.6 ms | 15.8 ms | 76.5 ms | 151.7 ms |
+| Apache POI | 5.2 ms | 29.1 ms | 135.2 ms | 269.0 ms |
+| Fesod | 5.9 ms | 34.1 ms | 160.3 ms | 322.6 ms |
 
 ## Write — Memory (bytes/op)
 
 | Library | 10K rows | 50K rows | 100K rows |
 |---------|----------|----------|-----------|
+| jackson-spreadsheet | 14 MB | 62 MB | 125 MB |
 | FastExcel | 15 MB | 75 MB | 149 MB |
-| jackson-spreadsheet | 20 MB | 92 MB | 182 MB |
-| Apache POI | 21 MB | 104 MB | 207 MB |
+| Apache POI | 21 MB | 103 MB | 204 MB |
 | Fesod | 48 MB | 230 MB | 458 MB |
 
 ## jackson — Streaming vs POI User Model
@@ -69,20 +69,20 @@ Apache POI (raw, no jackson) shown as reference.
 
 | Mode | 1K rows | 10K rows | 50K rows | 100K rows | Memory (100K) |
 |------|---------|----------|----------|-----------|---------------|
-| Streaming (default) | 2.1 ms | 17.7 ms | 93.2 ms | 196.0 ms | 360 MB |
-| POI User Model | 15.2 ms | 123.3 ms | 600.4 ms | 1393.1 ms | 2807 MB |
-| Apache POI (reference) | 10.6 ms | 101.8 ms | 541.1 ms | 1094.5 ms | 2225 MB |
+| Streaming (default) | 2.4 ms | 17.9 ms | 83.7 ms | 190.1 ms | 360 MB |
+| POI User Model | 14.0 ms | 120.7 ms | 602.2 ms | 1348.2 ms | 2807 MB |
+| Apache POI (reference) | 11.0 ms | 95.8 ms | 507.4 ms | 1172.8 ms | 2227 MB |
 
 **Write:**
 
 | Mode | 1K rows | 10K rows | 50K rows | 100K rows | Memory (100K) |
 |------|---------|----------|----------|-----------|---------------|
-| Streaming (default) | 3.4 ms | 16.7 ms | 74.8 ms | 143.7 ms | 182 MB |
-| POI User Model | 4.6 ms | 32.6 ms | 155.3 ms | 317.9 ms | 246 MB |
-| Apache POI (reference) | 4.3 ms | 27.6 ms | 133.4 ms | 267.6 ms | 207 MB |
+| Streaming (default) | 3.9 ms | 16.1 ms | 70.6 ms | 138.3 ms | 125 MB |
+| POI User Model | 5.7 ms | 33.6 ms | 159.5 ms | 317.7 ms | 246 MB |
+| Apache POI (reference) | 5.2 ms | 29.1 ms | 135.2 ms | 269.0 ms | 204 MB |
 
 - Read: Streaming is 7.1x faster and uses 87% less memory than POI User Model at 100K rows.
-- Write: Streaming is 2.2x faster and uses 26% less memory than POI User Model at 100K rows.
+- Write: Streaming is 2.3x faster and uses 49% less memory than POI User Model at 100K rows.
 - POI User Model is slower than raw Apache POI due to Jackson serialization and schema overhead.
 
 ## SharedStrings — FILE_BACKED Variants
@@ -93,17 +93,17 @@ Apache POI (raw, no jackson) shown as reference.
 
 | Strategy | 10K rows | 50K rows | 100K rows |
 |----------|----------|----------|-----------|
-| InMemory (default) | 13.7 ms | 62.7 ms | 134.7 ms |
-| FileBacked (H2 MVStore) | 28.6 ms | 120.0 ms | 222.9 ms |
-| FileBacked + Encrypted | 33.5 ms | 151.2 ms | 256.7 ms |
+| InMemory (default) | 14.9 ms | 62.7 ms | 130.9 ms |
+| FileBacked (H2 MVStore) | 26.7 ms | 117.5 ms | 230.4 ms |
+| FileBacked + Encrypted | 32.0 ms | 136.0 ms | 242.8 ms |
 
 **Write:**
 
 | Strategy | 10K rows | 50K rows | 100K rows |
 |----------|----------|----------|-----------|
-| InMemory (default) | 18.8 ms | 90.9 ms | 184.4 ms |
-| FileBacked (H2 MVStore) | 41.0 ms | 207.5 ms | 419.8 ms |
-| FileBacked + Encrypted | 49.9 ms | 274.9 ms | 626.3 ms |
+| InMemory (default) | 17.8 ms | 74.7 ms | 161.3 ms |
+| FileBacked (H2 MVStore) | 42.9 ms | 212.0 ms | 418.2 ms |
+| FileBacked + Encrypted | 50.2 ms | 282.9 ms | 633.0 ms |
 
 - FileBacked's value is **peak heap reduction**, not throughput. When the SST exceeds available heap, InMemory causes OOM while FileBacked stays constant.
 
@@ -113,9 +113,9 @@ Apache POI (raw, no jackson) shown as reference.
 
 | Mode | 1K rows | 10K rows | 100K rows |
 |------|---------|----------|-----------|
-| Without autoSize | 4.7 ms | 31.9 ms | 336.6 ms |
-| With autoSize | 13.7 ms | 55.4 ms | 469.9 ms |
-| Overhead | 2.92x | 1.74x | 1.40x |
+| Without autoSize | 5.9 ms | 33.2 ms | 314.8 ms |
+| With autoSize | 14.7 ms | 55.0 ms | 451.3 ms |
+| Overhead | 2.51x | 1.66x | 1.43x |
 
 - Sampling strategy (full first 100 rows + every 100th row thereafter) keeps overhead bounded — overhead amortizes from 2.92x at 1K rows to 1.40x at 100K rows.
 - For exact-fit guarantees on outlier-long values, set `@DataColumn(width = N)` explicitly.

--- a/README.md
+++ b/README.md
@@ -142,22 +142,22 @@ class LineItem {
 
 | Library | Time | Memory |
 |---------|------|--------|
-| jackson-spreadsheet | 198 ms | 378 MB |
-| FastExcel | 212 ms | 428 MB |
-| Fesod | 279 ms | 400 MB |
-| Poiji | 843 ms | 2876 MB |
-| Apache POI | 1198 ms | 2333 MB |
+| jackson-spreadsheet | 190 ms | 360 MB |
+| FastExcel | 208 ms | 407 MB |
+| Fesod | 266 ms | 381 MB |
+| Poiji | 809 ms | 2739 MB |
+| Apache POI | 1173 ms | 2227 MB |
 
 **Write:**
 
 | Library | Time | Memory |
 |---------|------|--------|
-| jackson-spreadsheet | 150 ms | 191 MB |
-| FastExcel | 166 ms | 156 MB |
-| Apache POI | 283 ms | 207 MB |
-| Fesod | 337 ms | 480 MB |
+| jackson-spreadsheet | 138 ms | 125 MB |
+| FastExcel | 152 ms | 149 MB |
+| Apache POI | 269 ms | 204 MB |
+| Fesod | 323 ms | 458 MB |
 
-Fastest read and write throughput at 100K rows. See [BENCHMARK.md](BENCHMARK.md) for full results.
+Fastest read and write throughput, lowest write memory at 100K rows. See [BENCHMARK.md](BENCHMARK.md) for full results.
 
 ### Feature Comparison
 
@@ -269,7 +269,7 @@ Fesod has its own API. This extends Jackson's `ObjectMapper`, so you get the ful
 Yes. Nested POJOs automatically flatten to columns on write and reconstruct on read. No configuration needed.
 
 **Q: How does performance compare?**
-Fastest read and write throughput at 100K rows. 6x faster read than Apache POI. Default writer is 10% faster than FastExcel. See [BENCHMARK.md](BENCHMARK.md).
+Fastest read and write throughput at 100K rows, with the lowest write memory. 6x faster read than Apache POI. Default writer is 10% faster than FastExcel and uses 16% less memory. See [BENCHMARK.md](BENCHMARK.md).
 
 **Q: What Excel formats are supported?**
 XLSX (OOXML) and XLS (legacy). XLSX uses StAX streaming; XLS uses POI object model.


### PR DESCRIPTION
## Summary

Re-measured every benchmark category (Read, Write, SharedStrings, AutoSize) on the same hardware after the SoA cell buffer (#131, #132) and ARCHITECTURE refresh (#133) landed. Library Versions updated to 1.6.2-SNAPSHOT.

Headline shifts:

- Write 100K memory 182 → 125 MB (−31%); jackson now leads the write memory category (vs. FastExcel 149 MB).
- Write 100K time 143.7 → 138.3 ms (−4%); still leads.
- Streaming vs POI User Model on write: 2.3× faster, 49% less memory.
- SharedStrings InMemory write 100K 184.4 → 161.3 ms (−13%).

## Test plan

- N/A (documentation only)