### PR TITLE
Bump to 1.6.2

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -14,7 +14,7 @@
 
 | Library | Version |
 |---------|---------|
-| jackson-dataformat-spreadsheet | 1.6.2-SNAPSHOT |
+| jackson-dataformat-spreadsheet | 1.6.2 |
 | Apache POI | 5.5.1 |
 | FastExcel | 0.20.0 |
 | Fesod | 2.0.1-incubating |

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -57,13 +57,13 @@ But this is not a POI replacement. POI types (`Sheet`, `Workbook`) are first-cla
 <dependency>
     <groupId>io.github.scndry</groupId>
     <artifactId>jackson-dataformat-spreadsheet</artifactId>
-    <version>1.6.1</version>
+    <version>1.6.2</version>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-implementation "io.github.scndry:jackson-dataformat-spreadsheet:1.6.1"
+implementation "io.github.scndry:jackson-dataformat-spreadsheet:1.6.2"
 ```
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ Available on Maven Central:
 <dependency>
     <groupId>io.github.scndry</groupId>
     <artifactId>jackson-dataformat-spreadsheet</artifactId>
-    <version>1.6.1</version>
+    <version>1.6.2</version>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-implementation "io.github.scndry:jackson-dataformat-spreadsheet:1.6.1"
+implementation "io.github.scndry:jackson-dataformat-spreadsheet:1.6.2"
 ```
 
 ### Requirements
@@ -275,7 +275,7 @@ Fastest read and write throughput at 100K rows, with the lowest write memory. 6x
 XLSX (OOXML) and XLS (legacy). XLSX uses StAX streaming; XLS uses POI object model.
 
 **Q: Is it production-ready?**
-Yes. Version 1.6.1 on Maven Central. Java 8+, Jackson 2.14+, POI 4.1.1+. Listed as a [community data format module](https://github.com/FasterXML/jackson#data-format-modules) in the FasterXML jackson repository.
+Yes. Version 1.6.2 on Maven Central. Java 8+, Jackson 2.14+, POI 4.1.1+. Listed as a [community data format module](https://github.com/FasterXML/jackson#data-format-modules) in the FasterXML jackson repository.
 
 **Q: Is the mapper thread-safe?**
 The mapper instance is reusable across threads once configured (same rule as Jackson's `ObjectMapper`). Concurrent calls with `File` / `InputStream` / `OutputStream` inputs are safe — the library opens an isolated `Workbook` per call. If you pass a `Sheet` directly, POI's `Workbook`/`Sheet` are not thread-safe, so each thread needs its own.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "io.github.scndry"
-version = "1.6.2-SNAPSHOT"
+version = "1.6.2"
 description = "Support for reading and writing Excel (XLSX/XLS) via Jackson abstractions."
 
 val title = "Jackson dataformat: Spreadsheet"


### PR DESCRIPTION
Version bump for the 1.6.2 release.

- `build.gradle.kts`: `1.6.2-SNAPSHOT` → `1.6.2`
- `README.md`, `GUIDE.md`, `BENCHMARK.md`: installation snippets and Library Versions table updated to `1.6.2`

## Test plan

- `./gradlew test` — 371 tests pass