### PR TITLE
Bump to 1.6.3-SNAPSHOT

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "io.github.scndry"
-version = "1.6.2"
+version = "1.6.3-SNAPSHOT"
 description = "Support for reading and writing Excel (XLSX/XLS) via Jackson abstractions."
 
 val title = "Jackson dataformat: Spreadsheet"


### PR DESCRIPTION
Open the 1.6.3 development cycle.

- `build.gradle.kts`: `1.6.2` → `1.6.3-SNAPSHOT`

User-facing docs (README/GUIDE/BENCHMARK) keep their `1.6.2` references so installation snippets remain valid for the latest release.

## Test plan

- N/A (version bump only; covered by existing CI)