### PR TITLE
Mirror DataGrid cascade slots on @DataColumnGroup; add group header style

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -469,7 +469,8 @@ Marks the root type for schema generation. Attributes set class-level defaults f
 | Attribute | Default | Description |
 |-----------|---------|-------------|
 | `columnStyle` | `""` | Default cell style for data cells |
-| `columnHeaderStyle` | `""` | Default cell style for header cells |
+| `columnHeaderStyle` | `""` | Default cell style for leaf header cells |
+| `groupHeaderStyle` | `""` | Default cell style for `@DataColumnGroup` header cells |
 | `columnWidth` | `-1` (auto) | Default column width in character units |
 | `autoSizeColumn` | `DEFAULT` | Auto-size columns to fit content |
 | `minColumnWidth` | `-1` (none) | Minimum column width |
@@ -506,6 +507,7 @@ Renders flattened columns from a nested object field under a shared group header
 |-----------|---------|-------------|
 | `value` | field name | Column group header name |
 | `comment` | `""` | Group header cell comment text |
+| `headerStyle` | `""` | Cell style for the group header cell |
 
 ```java
 @DataGrid
@@ -566,6 +568,10 @@ Column attributes resolve in priority order:
 1. `@DataColumn` on the property
 2. `@DataGrid` on the declaring class
 3. `@DataGrid` on the enclosing (parent) class
+
+`@DataColumnGroup.headerStyle` follows the same chain, falling back to
+`@DataGrid.groupHeaderStyle` from the declaring class, then from the
+enclosing class.
 
 ```java
 @DataGrid(autoSizeColumn = OptBoolean.FALSE)

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/annotation/DataColumnGroup.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/annotation/DataColumnGroup.java
@@ -12,6 +12,7 @@ import java.util.List;
 import lombok.EqualsAndHashCode;
 
 import com.fasterxml.jackson.annotation.JacksonAnnotationValue;
+import com.fasterxml.jackson.annotation.OptBoolean;
 
 /**
  * Annotates a nested object field to render its flattened columns
@@ -30,6 +31,15 @@ import com.fasterxml.jackson.annotation.JacksonAnnotationValue;
  * <p>If combined with {@link com.fasterxml.jackson.annotation.JsonUnwrapped @JsonUnwrapped}
  * on the same field, the group is silently ignored.
  *
+ * <p>Unset {@link #headerStyle()} inherits {@link DataGrid#groupHeaderStyle()}
+ * from the declaring class, then the enclosing class.
+ *
+ * <p>The other attributes mirror {@link DataGrid}'s cascade slots and
+ * act as intermediate defaults for the child leaf columns of this
+ * group. Child {@link DataColumn} attributes resolve from the leaf
+ * itself, then from the innermost enclosing group, then outward, then
+ * from the {@link DataGrid} on the declaring/enclosing class.
+ *
  * @see DataGrid
  * @see DataColumn
  * @see io.github.scndry.jackson.dataformat.spreadsheet.schema.Column
@@ -45,21 +55,74 @@ public @interface DataColumnGroup {
     /** Comment text for the header cell of this column group. */
     String comment() default "";
 
+    /** Cell style name for the header cell of this column group. */
+    String headerStyle() default "";
+
+    /** Default cell style name for child data cells. */
+    String columnStyle() default "";
+
+    /** Default cell style name for child leaf header cells. */
+    String columnHeaderStyle() default "";
+
+    /** Default child column width in character units ({@code -1} = auto). */
+    int columnWidth() default DataGrid.DEFAULT_COLUMN_WIDTH;
+
+    /** Whether to auto-size child columns to fit content. */
+    OptBoolean autoSizeColumn() default OptBoolean.DEFAULT;
+
+    /** Minimum child column width ({@code -1} = no minimum). */
+    int minColumnWidth() default DataGrid.DEFAULT_MIN_COLUMN_WIDTH;
+
+    /** Maximum child column width (default 255). */
+    int maxColumnWidth() default DataGrid.DEFAULT_MAX_COLUMN_WIDTH;
+
+    /** Whether to merge child cells vertically for repeated values. */
+    OptBoolean mergeColumn() default OptBoolean.DEFAULT;
+
     @EqualsAndHashCode
     final class Value implements JacksonAnnotationValue<DataColumnGroup> {
 
-        private static final Value EMPTY = new Value("", "");
+        private static final Value EMPTY = new Value();
 
         private final String _name;
         private final String _comment;
+        private final String _headerStyle;
+        private final String _columnStyle;
+        private final String _columnHeaderStyle;
+        private final int _columnWidth;
+        private final OptBoolean _autoSizeColumn;
+        private final int _minColumnWidth;
+        private final int _maxColumnWidth;
+        private final OptBoolean _mergeColumn;
 
-        public Value(final String name, final String comment) {
+        public Value(final String name, final String comment, final String headerStyle,
+                     final String columnStyle, final String columnHeaderStyle,
+                     final int columnWidth, final OptBoolean autoSizeColumn,
+                     final int minColumnWidth, final int maxColumnWidth,
+                     final OptBoolean mergeColumn) {
             _name = name;
             _comment = comment;
+            _headerStyle = headerStyle;
+            _columnStyle = columnStyle;
+            _columnHeaderStyle = columnHeaderStyle;
+            _columnWidth = columnWidth;
+            _autoSizeColumn = autoSizeColumn;
+            _minColumnWidth = minColumnWidth;
+            _maxColumnWidth = maxColumnWidth;
+            _mergeColumn = mergeColumn;
+        }
+
+        private Value() {
+            this("", "", "", "", "", DataGrid.DEFAULT_COLUMN_WIDTH, OptBoolean.DEFAULT,
+                    DataGrid.DEFAULT_MIN_COLUMN_WIDTH, DataGrid.DEFAULT_MAX_COLUMN_WIDTH,
+                    OptBoolean.DEFAULT);
         }
 
         private Value(final DataColumnGroup ann) {
-            this(ann.value(), ann.comment());
+            this(ann.value(), ann.comment(), ann.headerStyle(),
+                    ann.columnStyle(), ann.columnHeaderStyle(),
+                    ann.columnWidth(), ann.autoSizeColumn(),
+                    ann.minColumnWidth(), ann.maxColumnWidth(), ann.mergeColumn());
         }
 
         public static Value empty() { return EMPTY; }
@@ -69,17 +132,51 @@ public @interface DataColumnGroup {
         }
 
         public String getName() { return _name; }
-
         public String getComment() { return _comment; }
+        public String getHeaderStyle() { return _headerStyle; }
+        public String getColumnStyle() { return _columnStyle; }
+        public String getColumnHeaderStyle() { return _columnHeaderStyle; }
+        public int getColumnWidth() { return _columnWidth; }
+        public OptBoolean getAutoSizeColumn() { return _autoSizeColumn; }
+        public int getMinColumnWidth() { return _minColumnWidth; }
+        public int getMaxColumnWidth() { return _maxColumnWidth; }
+        public OptBoolean getMergeColumn() { return _mergeColumn; }
 
         public boolean isEmpty() { return _name.isEmpty(); }
+
+        public Value withDefaults(final DataGrid.Value defaults) {
+            if (defaults.isEmpty()) return this;
+            return new Value(_name, _comment,
+                    _headerStyle.isEmpty() ? defaults.getGroupHeaderStyle() : _headerStyle,
+                    _columnStyle, _columnHeaderStyle,
+                    _columnWidth, _autoSizeColumn,
+                    _minColumnWidth, _maxColumnWidth, _mergeColumn);
+        }
+
+        /** Returns this group's child-column defaults as a
+         *  {@link DataGrid.Value} so the column cascade can layer them
+         *  between the leaf {@link DataColumn} and the {@link DataGrid}. */
+        public DataGrid.Value asChildDefaults() {
+            return new DataGrid.Value(_columnStyle, _columnHeaderStyle, "",
+                    _columnWidth, _autoSizeColumn,
+                    _minColumnWidth, _maxColumnWidth, _mergeColumn);
+        }
 
         @Override
         public Class<DataColumnGroup> valueFor() { return DataColumnGroup.class; }
 
         @Override
         public String toString() {
-            return "DataColumnGroup.Value(name=" + _name + ", comment=" + _comment + ")";
+            return "DataColumnGroup.Value(name=" + _name
+                    + ", comment=" + _comment
+                    + ", headerStyle=" + _headerStyle
+                    + ", columnStyle=" + _columnStyle
+                    + ", columnHeaderStyle=" + _columnHeaderStyle
+                    + ", columnWidth=" + _columnWidth
+                    + ", autoSizeColumn=" + _autoSizeColumn
+                    + ", minColumnWidth=" + _minColumnWidth
+                    + ", maxColumnWidth=" + _maxColumnWidth
+                    + ", mergeColumn=" + _mergeColumn + ")";
         }
     }
 

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/annotation/DataGrid.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/annotation/DataGrid.java
@@ -17,7 +17,12 @@ import com.fasterxml.jackson.annotation.OptBoolean;
  * generation. Attributes define default column styling, width
  * constraints, and merge behavior for all columns in the grid.
  *
+ * <p>{@link #columnHeaderStyle()} applies to leaf header cells (the
+ * row that carries column names). Group header cells in multi-row
+ * headers are styled by {@link #groupHeaderStyle()}.
+ *
  * @see DataColumn
+ * @see DataColumnGroup
  * @see io.github.scndry.jackson.dataformat.spreadsheet.SchemaGenerator
  */
 @Target(
@@ -36,8 +41,11 @@ public @interface DataGrid {
     /** Default cell style name for data cells. */
     String columnStyle() default "";
 
-    /** Default cell style name for header cells. */
+    /** Default cell style name for leaf header cells. */
     String columnHeaderStyle() default "";
+
+    /** Default cell style name for {@link DataColumnGroup} header cells. */
+    String groupHeaderStyle() default "";
 
     /** Default column width in character units ({@code -1} = auto). */
     int columnWidth() default DEFAULT_COLUMN_WIDTH;
@@ -61,6 +69,7 @@ public @interface DataGrid {
 
         private final String _columnStyle;
         private final String _columnHeaderStyle;
+        private final String _groupHeaderStyle;
         private final int _columnWidth;
         private final OptBoolean _autoSizeColumn;
         private final int _minColumnWidth;
@@ -68,11 +77,13 @@ public @interface DataGrid {
         private final OptBoolean _mergeColumn;
 
         public Value(final String columnStyle, final String columnHeaderStyle,
+                     final String groupHeaderStyle,
                      final int columnWidth, final OptBoolean autoSizeColumn,
                      final int minColumnWidth, final int maxColumnWidth,
                      final OptBoolean mergeColumn) {
             _columnStyle = columnStyle;
             _columnHeaderStyle = columnHeaderStyle;
+            _groupHeaderStyle = groupHeaderStyle;
             _columnWidth = columnWidth;
             _autoSizeColumn = autoSizeColumn;
             _minColumnWidth = minColumnWidth;
@@ -81,12 +92,13 @@ public @interface DataGrid {
         }
 
         private Value() {
-            this("", "", DEFAULT_COLUMN_WIDTH, OptBoolean.DEFAULT,
+            this("", "", "", DEFAULT_COLUMN_WIDTH, OptBoolean.DEFAULT,
                     DEFAULT_MIN_COLUMN_WIDTH, DEFAULT_MAX_COLUMN_WIDTH, OptBoolean.DEFAULT);
         }
 
         private Value(final DataGrid ann) {
-            this(ann.columnStyle(), ann.columnHeaderStyle(), ann.columnWidth(),
+            this(ann.columnStyle(), ann.columnHeaderStyle(), ann.groupHeaderStyle(),
+                    ann.columnWidth(),
                     ann.autoSizeColumn(), ann.minColumnWidth(), ann.maxColumnWidth(),
                     ann.mergeColumn());
         }
@@ -99,6 +111,7 @@ public @interface DataGrid {
 
         public String getColumnStyle() { return _columnStyle; }
         public String getColumnHeaderStyle() { return _columnHeaderStyle; }
+        public String getGroupHeaderStyle() { return _groupHeaderStyle; }
         public int getColumnWidth() { return _columnWidth; }
         public OptBoolean getAutoSizeColumn() { return _autoSizeColumn; }
         public int getMinColumnWidth() { return _minColumnWidth; }
@@ -114,6 +127,7 @@ public @interface DataGrid {
             return new Value(
                     _columnStyle.isEmpty() ? defaults._columnStyle : _columnStyle,
                     _columnHeaderStyle.isEmpty() ? defaults._columnHeaderStyle : _columnHeaderStyle,
+                    _groupHeaderStyle.isEmpty() ? defaults._groupHeaderStyle : _groupHeaderStyle,
                     _columnWidth == DEFAULT_COLUMN_WIDTH ? defaults._columnWidth : _columnWidth,
                     _autoSizeColumn == OptBoolean.DEFAULT
                             ? defaults._autoSizeColumn : _autoSizeColumn,
@@ -132,6 +146,7 @@ public @interface DataGrid {
         public String toString() {
             return "DataGrid.Value(columnStyle=" + _columnStyle
                     + ", columnHeaderStyle=" + _columnHeaderStyle
+                    + ", groupHeaderStyle=" + _groupHeaderStyle
                     + ", columnWidth=" + _columnWidth
                     + ", autoSizeColumn=" + _autoSizeColumn
                     + ", minColumnWidth=" + _minColumnWidth

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLSheetWriter.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLSheetWriter.java
@@ -71,6 +71,7 @@ public final class SSMLSheetWriter implements SheetWriter {
     // Styles — resolved from POI XSSFWorkbook
     private XSSFWorkbook _wb;
     private File _scaffold;
+    private Styles _styles;
     private int[] _columnStyleIndex;
     private int[] _headerColumnStyleIndex;
     private final List<MergeRange> _mergeRanges = new ArrayList<>();
@@ -111,13 +112,13 @@ public final class SSMLSheetWriter implements SheetWriter {
         _data = new SheetDataBuffer(schema.getOriginColumn() + schema.columnCount());
         try {
             _wb = _sheet.getWorkbook();
-            final Styles styles = _schema.buildStyles(_wb);
+            _styles = _schema.buildStyles(_wb);
             _schema.applyHeaderComments(_sheet);
-            _schema.configureSheet(_sheet, styles, -1);
+            _schema.configureSheet(_sheet, _styles, -1);
             _writeScaffoldWorkbook();
             _splitScaffoldSheetXml();
-            _columnStyleIndex = _resolveColumnStyleIndices(styles, false);
-            _headerColumnStyleIndex = _resolveColumnStyleIndices(styles, true);
+            _columnStyleIndex = _resolveColumnStyleIndices(_styles, false);
+            _headerColumnStyleIndex = _resolveColumnStyleIndices(_styles, true);
             _wb.close();
             _wb = null;
             _sheet = null;
@@ -158,7 +159,15 @@ public final class SSMLSheetWriter implements SheetWriter {
             public void visitGroupCell(final int row, final int firstCol, final int lastCol,
                                        final DataColumnGroup.Value group) {
                 setReference(new CellAddress(row, firstCol));
-                writeString(group.getName());
+                final CellStyle gs = _styles.getGroupHeaderStyle(group);
+                if (gs == null) {
+                    writeString(group.getName());
+                } else {
+                    final int sstIdx = _cacheString(group.getName());
+                    _flushIfForwardJump();
+                    _data.appendString(row, firstCol, gs.getIndex(), sstIdx);
+                    _checkBufferLimitInArrayScope();
+                }
                 if (firstCol < lastCol) {
                     _mergeRanges.add(new MergeRange(row, row, firstCol, lastCol));
                 }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ss/POISheetWriter.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ss/POISheetWriter.java
@@ -99,6 +99,10 @@ public final class POISheetWriter implements SheetWriter {
                                        final DataColumnGroup.Value group) {
                 setReference(new CellAddress(row, firstCol));
                 writeString(group.getName());
+                final CellStyle gs = _styles.getGroupHeaderStyle(group);
+                if (gs != null) {
+                    CellUtil.getCell(CellUtil.getRow(row, _sheet), firstCol).setCellStyle(gs);
+                }
                 if (firstCol < lastCol) {
                     _sheet.addMergedRegion(new CellRangeAddress(row, row, firstCol, lastCol));
                 }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/Styles.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/Styles.java
@@ -2,6 +2,8 @@ package io.github.scndry.jackson.dataformat.spreadsheet.schema;
 
 import org.apache.poi.ss.usermodel.CellStyle;
 
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
+
 /**
  * Resolves Apache POI {@link CellStyle} instances for data and
  * header cells. Built per-workbook by
@@ -19,4 +21,10 @@ public interface Styles {
     }
 
     CellStyle getStyle(String name);
+
+    /** Resolves the cell style for a {@code @DataColumnGroup} header cell.
+     *  Returns {@code null} when no style is registered for the group. */
+    default CellStyle getGroupHeaderStyle(final DataColumnGroup.Value group) {
+        return null;
+    }
 }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/generator/ObjectFormatVisitor.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/generator/ObjectFormatVisitor.java
@@ -56,8 +56,9 @@ final class ObjectFormatVisitor extends JsonObjectFormatVisitor.Base {
         }
         final ColumnPointer pointer = _wrapper.getPointer().resolve(prop.getName());
         final DataGrid.Value gridValue = _gridValue(prop);
-        final DataColumn.Value columnValue = _columnValue(prop, gridValue);
-        final DataColumnGroup.Value groupValue = _columnGroupValue(prop);
+        final DataColumn.Value columnValue =
+                _columnValue(prop, gridValue, _wrapper.getGroupHierarchy());
+        final DataColumnGroup.Value groupValue = _columnGroupValue(prop, gridValue);
 
         final DataColumnGroup.Hierarchy childHierarchy = _wrapper.getGroupHierarchy().append(groupValue);
 
@@ -152,16 +153,28 @@ final class ObjectFormatVisitor extends JsonObjectFormatVisitor.Base {
         return DataGrid.Value.from(ann).withDefaults(_wrapper.getSheet());
     }
 
-    private DataColumn.Value _columnValue(BeanProperty prop, DataGrid.Value grid) {
+    private DataColumn.Value _columnValue(BeanProperty prop, DataGrid.Value grid,
+                                          DataColumnGroup.Hierarchy enclosing) {
         final DataColumn ann = prop.getAnnotation(DataColumn.class);
-        return DataColumn.Value.from(ann).withDefaults(grid);
+        DataColumn.Value value = DataColumn.Value.from(ann);
+        // Cascade: leaf → innermost group → outer groups → DataGrid.
+        // withDefaults uses first-non-empty-wins, so layering innermost
+        // first lets unset slots fall through to the next outer level.
+        for (int i = enclosing.depth() - 1; i >= 0; i--) {
+            value = value.withDefaults(enclosing.at(i).asChildDefaults());
+        }
+        return value.withDefaults(grid);
     }
 
-    private DataColumnGroup.Value _columnGroupValue(BeanProperty prop) {
+    private DataColumnGroup.Value _columnGroupValue(BeanProperty prop, DataGrid.Value grid) {
         final DataColumnGroup ann = prop.getAnnotation(DataColumnGroup.class);
         if (ann == null) return DataColumnGroup.Value.empty();
         final String name = ann.value().isEmpty() ? prop.getName() : ann.value();
-        return new DataColumnGroup.Value(name, ann.comment());
+        return new DataColumnGroup.Value(name, ann.comment(), ann.headerStyle(),
+                ann.columnStyle(), ann.columnHeaderStyle(),
+                ann.columnWidth(), ann.autoSizeColumn(),
+                ann.minColumnWidth(), ann.maxColumnWidth(), ann.mergeColumn())
+                .withDefaults(grid);
     }
 
     private void _checkTypeSupported(

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/style/StylesBuilder.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/style/StylesBuilder.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.Workbook;
 
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.Styles;
 
@@ -107,6 +108,17 @@ public final class StylesBuilder implements Builder<Styles> {
         @Override
         public CellStyle getHeaderStyle(final Column column) {
             return _findStyle(column.getValue().getHeaderStyle(), column);
+        }
+
+        @Override
+        public CellStyle getGroupHeaderStyle(final DataColumnGroup.Value group) {
+            final String name = group.getHeaderStyle();
+            if (name.isEmpty()) return null;
+            final CellStyle style = _styles.get(name);
+            if (style == null) {
+                throw new IllegalStateException("Style '" + name + "' is not registered");
+            }
+            return style;
         }
 
         private CellStyle _findStyle(final String name, final Column column) {

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/AnnotationValueTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/AnnotationValueTest.java
@@ -81,7 +81,8 @@ class AnnotationValueTest {
     @Test
     void dataColumnWithDefaults() {
         DataColumn.Value field = new DataColumn.Value("field", "", "fieldStyle", "", 10, OptBoolean.DEFAULT, 0, 0, OptBoolean.DEFAULT);
-        DataGrid.Value grid = new DataGrid.Value("gridStyle", "gridHeaderStyle", 20, OptBoolean.TRUE, 5, 50, OptBoolean.TRUE);
+        DataGrid.Value grid = new DataGrid.Value("gridStyle", "gridHeaderStyle", "",
+                20, OptBoolean.TRUE, 5, 50, OptBoolean.TRUE);
         DataColumn.Value result = field.withDefaults(grid);
 
         assertThat(result.getStyle()).isEqualTo("fieldStyle");

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/AttributeResolutionTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/AttributeResolutionTest.java
@@ -1,0 +1,206 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.OptBoolean;
+
+import lombok.Data;
+import org.junit.jupiter.api.Test;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Attribute resolution order is cross-cutting across {@link DataColumn},
+ * {@link DataColumnGroup}, and {@link DataGrid}. Each leaf column
+ * attribute resolves in priority order:
+ *
+ * <ol>
+ *   <li>{@code @DataColumn} on the property</li>
+ *   <li>innermost enclosing {@code @DataColumnGroup}</li>
+ *   <li>outer enclosing {@code @DataColumnGroup} (recurse outward)</li>
+ *   <li>{@code @DataGrid} on the declaring class</li>
+ *   <li>{@code @DataGrid} on the root class</li>
+ * </ol>
+ *
+ * First-non-default value wins. Tests below pin the order at the
+ * Value layer (no schema) and at the {@link SpreadsheetSchema} layer.
+ */
+class AttributeResolutionTest {
+
+    // ----------------------------------------------------------------
+    // Value layer — withDefaults without going through schema build
+    // ----------------------------------------------------------------
+
+    private static DataColumnGroup.Value group(final String name, final String headerStyle) {
+        return new DataColumnGroup.Value(name, "", headerStyle,
+                "", "", DataGrid.DEFAULT_COLUMN_WIDTH, OptBoolean.DEFAULT,
+                DataGrid.DEFAULT_MIN_COLUMN_WIDTH, DataGrid.DEFAULT_MAX_COLUMN_WIDTH,
+                OptBoolean.DEFAULT);
+    }
+
+    private static DataColumnGroup.Value groupWithChildDefaults(
+            final String columnStyle, final String columnHeaderStyle,
+            final OptBoolean merge) {
+        return new DataColumnGroup.Value("g", "", "",
+                columnStyle, columnHeaderStyle,
+                DataGrid.DEFAULT_COLUMN_WIDTH, OptBoolean.DEFAULT,
+                DataGrid.DEFAULT_MIN_COLUMN_WIDTH, DataGrid.DEFAULT_MAX_COLUMN_WIDTH,
+                merge);
+    }
+
+    @Test
+    void groupOwnHeaderStyle_explicitWinsOverDataGrid() {
+        final DataGrid.Value grid = new DataGrid.Value("", "", "gridGroupBg",
+                DataGrid.DEFAULT_COLUMN_WIDTH, OptBoolean.DEFAULT,
+                DataGrid.DEFAULT_MIN_COLUMN_WIDTH, DataGrid.DEFAULT_MAX_COLUMN_WIDTH,
+                OptBoolean.DEFAULT);
+        final DataColumnGroup.Value g = group("Year", "annotationGroupBg").withDefaults(grid);
+        assertThat(g.getHeaderStyle()).isEqualTo("annotationGroupBg");
+    }
+
+    @Test
+    void groupOwnHeaderStyle_inheritsDataGridWhenUnset() {
+        final DataGrid.Value grid = new DataGrid.Value("", "", "gridGroupBg",
+                DataGrid.DEFAULT_COLUMN_WIDTH, OptBoolean.DEFAULT,
+                DataGrid.DEFAULT_MIN_COLUMN_WIDTH, DataGrid.DEFAULT_MAX_COLUMN_WIDTH,
+                OptBoolean.DEFAULT);
+        final DataColumnGroup.Value g = group("Year", "").withDefaults(grid);
+        assertThat(g.getHeaderStyle()).isEqualTo("gridGroupBg");
+    }
+
+    @Test
+    void childHeaderStyle_leafWinsOverGroup() {
+        final DataColumn.Value leaf = DataColumn.Value.from(null)
+                .withDefaults(groupWithChildDefaults("", "groupChildHeader",
+                        OptBoolean.DEFAULT).asChildDefaults());
+        assertThat(leaf.getHeaderStyle()).isEqualTo("groupChildHeader");
+    }
+
+    @Test
+    void childHeaderStyle_innermostGroupWinsOverOuter() {
+        final DataColumn.Value leaf = DataColumn.Value.from(null)
+                .withDefaults(groupWithChildDefaults("", "innerChild", OptBoolean.DEFAULT)
+                        .asChildDefaults())
+                .withDefaults(groupWithChildDefaults("", "outerChild", OptBoolean.DEFAULT)
+                        .asChildDefaults());
+        assertThat(leaf.getHeaderStyle()).isEqualTo("innerChild");
+    }
+
+    @Test
+    void childHeaderStyle_fallsThroughToDataGridWhenGroupUnset() {
+        final DataGrid.Value grid = new DataGrid.Value("", "gridHeader", "",
+                DataGrid.DEFAULT_COLUMN_WIDTH, OptBoolean.DEFAULT,
+                DataGrid.DEFAULT_MIN_COLUMN_WIDTH, DataGrid.DEFAULT_MAX_COLUMN_WIDTH,
+                OptBoolean.DEFAULT);
+        final DataColumn.Value leaf = DataColumn.Value.from(null)
+                .withDefaults(DataColumnGroup.Value.empty().asChildDefaults())
+                .withDefaults(grid);
+        assertThat(leaf.getHeaderStyle()).isEqualTo("gridHeader");
+    }
+
+    @Test
+    void childMerge_cascadesFromGroup() {
+        final DataColumn.Value leaf = DataColumn.Value.from(null)
+                .withDefaults(groupWithChildDefaults("", "", OptBoolean.TRUE).asChildDefaults());
+        assertThat(leaf.isMerge()).isTrue();
+    }
+
+    // ----------------------------------------------------------------
+    // Schema layer — full cascade through Outer / Group / Element.
+    //
+    //   Outer  @DataGrid(columnStyle=…, autoSizeColumn=TRUE)
+    //     ├ a                                                  (outside group)
+    //     ├ @DataColumnGroup(columnHeaderStyle=…) List<Group>
+    //     │    ├ b
+    //     │    ├ @DataColumnGroup(columnStyle=…) List<Element>
+    //     │    │    └ c  @DataColumn(style=…)
+    //     │    └ d
+    //     └ e                                                  (outside group)
+    // ----------------------------------------------------------------
+
+    @Data
+    @DataGrid(columnStyle = "Outer_columnStyle", autoSizeColumn = OptBoolean.TRUE)
+    static class Outer {
+        int a;
+        @DataColumnGroup(value = "groups", columnHeaderStyle = "Outer_groups_columnHeaderStyle")
+        List<Group> groups;
+        int e;
+    }
+
+    @Data
+    @DataGrid(columnHeaderStyle = "Group_columnHeaderStyle")
+    static class Group {
+        int b;
+        @DataColumnGroup(value = "elements", columnStyle = "Group_elements_columnStyle")
+        List<Element> elements;
+        int d;
+    }
+
+    @Data
+    @DataGrid(autoSizeColumn = OptBoolean.FALSE)
+    static class Element {
+        @DataColumn(style = "Element_c_style") int c;
+    }
+
+    private static SpreadsheetSchema _schemaFor(final Class<?> type) throws Exception {
+        return new SpreadsheetMapper().sheetSchemaFor(type);
+    }
+
+    private static Column _byName(final SpreadsheetSchema schema, final String name) {
+        for (final Column c : schema) {
+            if (c != null && name.equals(c.getName())) return c;
+        }
+        throw new AssertionError("No column named " + name);
+    }
+
+    @Test
+    void cascade_outerLeaf_outsideGroup_resolvesFromRootGrid() throws Exception {
+        final SpreadsheetSchema schema = _schemaFor(Outer.class);
+        final Column a = _byName(schema, "a");
+        // style: leaf/groups not in chain → Outer.grid wins
+        assertThat(a.getValue().getStyle()).isEqualTo("Outer_columnStyle");
+        assertThat(a.getValue().getHeaderStyle()).isEmpty();
+        assertThat(a.getValue().getAutoSize()).isEqualTo(OptBoolean.TRUE);
+
+        final Column e = _byName(schema, "e");
+        assertThat(e.getValue().getStyle()).isEqualTo("Outer_columnStyle");
+        assertThat(e.getValue().getHeaderStyle()).isEmpty();
+        assertThat(e.getValue().getAutoSize()).isEqualTo(OptBoolean.TRUE);
+    }
+
+    @Test
+    void cascade_middleLeaf_resolvesFromGroupAndRootGrid() throws Exception {
+        final SpreadsheetSchema schema = _schemaFor(Outer.class);
+        final Column b = _byName(schema, "groups/[]/b");
+        // style: leaf / "groups" / Group.grid all unset → Outer.grid wins
+        assertThat(b.getValue().getStyle()).isEqualTo("Outer_columnStyle");
+        // headerStyle: innermost "groups" wins — Group.grid never reached
+        assertThat(b.getValue().getHeaderStyle()).isEqualTo("Outer_groups_columnHeaderStyle");
+        // autoSize: all unset until Outer.grid → TRUE
+        assertThat(b.getValue().getAutoSize()).isEqualTo(OptBoolean.TRUE);
+
+        final Column d = _byName(schema, "groups/[]/d");
+        assertThat(d.getValue().getStyle()).isEqualTo("Outer_columnStyle");
+        assertThat(d.getValue().getHeaderStyle()).isEqualTo("Outer_groups_columnHeaderStyle");
+        assertThat(d.getValue().getAutoSize()).isEqualTo(OptBoolean.TRUE);
+    }
+
+    @Test
+    void cascade_innermostLeaf_walksAllLevels() throws Exception {
+        final SpreadsheetSchema schema = _schemaFor(Outer.class);
+        final Column c = _byName(schema, "groups/[]/elements/[]/c");
+        // style: leaf wins — "elements" / Element.grid / Outer.grid never reached
+        assertThat(c.getValue().getStyle()).isEqualTo("Element_c_style");
+        // headerStyle: "elements" unset → outer "groups" wins
+        assertThat(c.getValue().getHeaderStyle()).isEqualTo("Outer_groups_columnHeaderStyle");
+        // autoSize: leaf / "elements" / "groups" all unset → Element.grid (declaring) FALSE wins,
+        // Outer.grid TRUE never reached.
+        assertThat(c.getValue().getAutoSize()).isEqualTo(OptBoolean.FALSE);
+    }
+}

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/DataColumnGroupTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/DataColumnGroupTest.java
@@ -1,7 +1,10 @@
 package io.github.scndry.jackson.dataformat.spreadsheet;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -14,12 +17,16 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.CellType;
 import org.apache.poi.ss.usermodel.Comment;
+import org.apache.poi.ss.usermodel.FillPatternType;
+import org.apache.poi.ss.usermodel.IndexedColors;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.util.CellRangeAddress;
 import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+import org.apache.poi.xssf.usermodel.XSSFCellStyle;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -30,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.OptBoolean;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -43,6 +51,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.style.StylesBuilder;
 
 /**
  * PoC smoke tests for {@link DataColumnGroup} multi-row header support.
@@ -1182,7 +1191,278 @@ class DataColumnGroupTest {
         }
     }
 
+    // -- group header style (headerStyle + DataGrid.groupHeaderStyle cascade) ----
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class CompanyExplicitGroupStyle {
+        @DataColumn("Name") String name;
+        @DataColumnGroup(value = "2024", headerStyle = "groupBg") YearMetricsSmall year2024;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class YearMetricsSmall {
+        @DataColumn("Sales") int sales;
+        @DataColumn("Profit") int profit;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    @DataGrid(groupHeaderStyle = "groupBg")
+    static class CompanyGridDefaultGroupStyle {
+        @DataColumn("Name") String name;
+        @DataColumnGroup("2024") YearMetricsSmall year2024;
+    }
+
+    @Test
+    void groupHeaderStyle_explicit_appliedToGroupCellOnly_poi() throws Exception {
+        File file = tempFile("group-headerstyle-explicit.xlsx");
+        SpreadsheetMapper styled = SpreadsheetMapper.builder()
+                .stylesBuilder(new StylesBuilder()
+                        .cellStyle("groupBg")
+                            .fillForegroundColor(IndexedColors.GREY_25_PERCENT)
+                            .fillPattern().solidForeground()
+                            .end())
+                .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL)
+                .build();
+        styled.writeValue(file, new CompanyExplicitGroupStyle("Acme",
+                new YearMetricsSmall(100, 20)));
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            // Group cell at (0,1) carries the registered fill; leaf header
+            // cells below it (row 1) carry the default style without fill.
+            CellStyle groupStyle = sheet.getRow(0).getCell(1).getCellStyle();
+            CellStyle leafStyle = sheet.getRow(1).getCell(1).getCellStyle();
+            assertThat(groupStyle.getFillPattern())
+                    .isEqualTo(FillPatternType.SOLID_FOREGROUND);
+            assertThat(leafStyle.getFillPattern())
+                    .isNotEqualTo(FillPatternType.SOLID_FOREGROUND);
+        }
+    }
+
+    @Test
+    void groupHeaderStyle_explicit_appliedToGroupCellOnly_ssml() throws Exception {
+        SpreadsheetMapper styled = SpreadsheetMapper.builder()
+                .stylesBuilder(new StylesBuilder()
+                        .cellStyle("groupBg")
+                            .fillForegroundColor(IndexedColors.GREY_25_PERCENT)
+                            .fillPattern().solidForeground()
+                            .end())
+                .build();
+        File file = tempFile("group-headerstyle-explicit-ssml.xlsx");
+        styled.writeValue(file, new CompanyExplicitGroupStyle("Acme",
+                new YearMetricsSmall(100, 20)));
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            CellStyle groupStyle = sheet.getRow(0).getCell(1).getCellStyle();
+            CellStyle leafStyle = sheet.getRow(1).getCell(1).getCellStyle();
+            assertThat(groupStyle.getFillPattern())
+                    .isEqualTo(FillPatternType.SOLID_FOREGROUND);
+            assertThat(leafStyle.getFillPattern())
+                    .isNotEqualTo(FillPatternType.SOLID_FOREGROUND);
+        }
+    }
+
+    @Test
+    void groupHeaderStyle_cascadesFromDataGrid() throws Exception {
+        File file = tempFile("group-headerstyle-cascade.xlsx");
+        SpreadsheetMapper styled = SpreadsheetMapper.builder()
+                .stylesBuilder(new StylesBuilder()
+                        .cellStyle("groupBg")
+                            .fillForegroundColor(IndexedColors.GREY_25_PERCENT)
+                            .fillPattern().solidForeground()
+                            .end())
+                .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL)
+                .build();
+        styled.writeValue(file, new CompanyGridDefaultGroupStyle("Acme",
+                new YearMetricsSmall(100, 20)));
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            CellStyle groupStyle = sheet.getRow(0).getCell(1).getCellStyle();
+            assertThat(groupStyle.getFillPattern())
+                    .isEqualTo(FillPatternType.SOLID_FOREGROUND);
+        }
+    }
+
+    // -- group-level child defaults (columnStyle / columnHeaderStyle / width / merge) --
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class OrderWithGroupChildDefaults {
+        @DataColumn("id") int id;
+        @DataColumnGroup(value = "items", columnHeaderStyle = "itemHeaderBg")
+        List<ItemSmall> items;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class ItemSmall {
+        @DataColumn("sku") String sku;
+        @DataColumn("qty") int qty;
+    }
+
+    @Test
+    void groupColumnHeaderStyle_appliesToChildLeafHeaders() throws Exception {
+        File file = _debugFile("group-child-headerstyle-poi.xlsx");
+        SpreadsheetMapper styled = SpreadsheetMapper.builder()
+                .stylesBuilder(new StylesBuilder()
+                        .cellStyle("itemHeaderBg")
+                            .fillForegroundColor(IndexedColors.GREY_25_PERCENT)
+                            .fillPattern().solidForeground()
+                            .end())
+                .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL)
+                .build();
+        styled.writeValue(file, new OrderWithGroupChildDefaults(1,
+                Arrays.asList(new ItemSmall("A", 1), new ItemSmall("B", 2))));
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            // id leaf header (row 0, col 0) is outside the group — no group fill.
+            // id vertically merges across rows 0..1, so the text + style live at row 0.
+            assertThat(sheet.getRow(0).getCell(0).getCellStyle().getFillPattern())
+                    .isNotEqualTo(FillPatternType.SOLID_FOREGROUND);
+            // sku / qty leaf headers (row 1, cols 1, 2) inherit the group's
+            // columnHeaderStyle via the cascade.
+            assertThat(sheet.getRow(1).getCell(1).getCellStyle().getFillPattern())
+                    .isEqualTo(FillPatternType.SOLID_FOREGROUND);
+            assertThat(sheet.getRow(1).getCell(2).getCellStyle().getFillPattern())
+                    .isEqualTo(FillPatternType.SOLID_FOREGROUND);
+        }
+    }
+
+    @Test
+    void groupColumnHeaderStyle_appliesToChildLeafHeaders_ssml() throws Exception {
+        File file = _debugFile("group-child-headerstyle-ssml.xlsx");
+        SpreadsheetMapper styled = SpreadsheetMapper.builder()
+                .stylesBuilder(new StylesBuilder()
+                        .cellStyle("itemHeaderBg")
+                            .fillForegroundColor(IndexedColors.GREY_25_PERCENT)
+                            .fillPattern().solidForeground()
+                            .end())
+                .build();
+        styled.writeValue(file, new OrderWithGroupChildDefaults(1,
+                Arrays.asList(new ItemSmall("A", 1), new ItemSmall("B", 2))));
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            assertThat(sheet.getRow(0).getCell(0).getCellStyle().getFillPattern())
+                    .isNotEqualTo(FillPatternType.SOLID_FOREGROUND);
+            assertThat(sheet.getRow(1).getCell(1).getCellStyle().getFillPattern())
+                    .isEqualTo(FillPatternType.SOLID_FOREGROUND);
+            assertThat(sheet.getRow(1).getCell(2).getCellStyle().getFillPattern())
+                    .isEqualTo(FillPatternType.SOLID_FOREGROUND);
+        }
+    }
+
+    // -- group columnStyle / columnWidth / mergeColumn render (POI + SSML) --
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class OrderWithGroupColumnStyle {
+        @DataColumn("id") int id;
+        @DataColumnGroup(value = "items", columnStyle = "itemDataBg")
+        List<ItemSmall> items;
+    }
+
+    @Test
+    void groupColumnStyle_appliesToChildDataCells_poi() throws Exception {
+        File file = _debugFile("group-child-columnstyle-poi.xlsx");
+        SpreadsheetMapper styled = SpreadsheetMapper.builder()
+                .stylesBuilder(new StylesBuilder()
+                        .cellStyle("itemDataBg")
+                            .fillForegroundColor(IndexedColors.GREY_25_PERCENT)
+                            .fillPattern().solidForeground()
+                            .end())
+                .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL)
+                .build();
+        styled.writeValue(file, new OrderWithGroupColumnStyle(1,
+                Arrays.asList(new ItemSmall("A", 1))));
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            // Data row at row 2: id (col 0) has no fill; sku/qty (cols 1, 2) inherit columnStyle.
+            assertThat(sheet.getRow(2).getCell(0).getCellStyle().getFillPattern())
+                    .isNotEqualTo(FillPatternType.SOLID_FOREGROUND);
+            assertThat(sheet.getRow(2).getCell(1).getCellStyle().getFillPattern())
+                    .isEqualTo(FillPatternType.SOLID_FOREGROUND);
+            assertThat(sheet.getRow(2).getCell(2).getCellStyle().getFillPattern())
+                    .isEqualTo(FillPatternType.SOLID_FOREGROUND);
+        }
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class OrderWithGroupWidth {
+        @DataColumn("id") int id;
+        @DataColumnGroup(value = "items", columnWidth = 17)
+        List<ItemSmall> items;
+    }
+
+    @Test
+    void groupColumnWidth_appliesToChildColumns() throws Exception {
+        File file = _debugFile("group-child-width-ssml.xlsx");
+        new SpreadsheetMapper().writeValue(file, new OrderWithGroupWidth(1,
+                Arrays.asList(new ItemSmall("A", 1))));
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            // POI stores width in 1/256 of a character — multiply request by 256.
+            assertThat(sheet.getColumnWidth(1)).isEqualTo(17 * 256);
+            assertThat(sheet.getColumnWidth(2)).isEqualTo(17 * 256);
+        }
+    }
+
+
+    // -- leaf @DataColumn.style beats group columnStyle in real render --
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class OrderWithLeafStyleOverride {
+        @DataColumn("id") int id;
+        @DataColumnGroup(value = "items", columnStyle = "groupBg")
+        List<ItemWithExplicit> items;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class ItemWithExplicit {
+        @DataColumn(value = "x", style = "leafBg") String x;
+        @DataColumn("y") String y;
+    }
+
+    @Test
+    void leafColumnStyle_winsOverGroupColumnStyle_inRender() throws Exception {
+        File file = _debugFile("group-leaf-override-poi.xlsx");
+        SpreadsheetMapper styled = SpreadsheetMapper.builder()
+                .stylesBuilder(new StylesBuilder()
+                        .cellStyle("groupBg")
+                            .fillForegroundColor(IndexedColors.YELLOW)
+                            .fillPattern().solidForeground()
+                            .end()
+                        .cellStyle("leafBg")
+                            .fillForegroundColor(IndexedColors.GREY_25_PERCENT)
+                            .fillPattern().solidForeground()
+                            .end())
+                .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL)
+                .build();
+        styled.writeValue(file, new OrderWithLeafStyleOverride(1,
+                Arrays.asList(new ItemWithExplicit("a", "b"))));
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            // Data row 2: x (col 1) carries the leaf's style (GREY); y (col 2) inherits group (YELLOW).
+            String xFill = ((XSSFCellStyle) sheet.getRow(2).getCell(1).getCellStyle())
+                    .getFillForegroundXSSFColor().getARGBHex();
+            String yFill = ((XSSFCellStyle) sheet.getRow(2).getCell(2).getCellStyle())
+                    .getFillForegroundXSSFColor().getARGBHex();
+            assertThat(xFill).endsWithIgnoringCase("C0C0C0");
+            assertThat(yFill).endsWithIgnoringCase("FFFF00");
+        }
+    }
+
     private File tempFile(String name) {
         return tempDir.resolve(name).toFile();
+    }
+
+    private static final Path DEBUG_OUTPUT_DIR = Paths.get("build/debug-output");
+
+    private static File _debugFile(final String name) throws IOException {
+        Files.createDirectories(DEBUG_OUTPUT_DIR);
+        return DEBUG_OUTPUT_DIR.resolve(name).toFile();
     }
 }

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/SSMLSheetWriterDomEquivalenceTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/SSMLSheetWriterDomEquivalenceTest.java
@@ -13,6 +13,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.apache.poi.openxml4j.opc.OPCPackage;
+import org.apache.poi.ss.usermodel.IndexedColors;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
@@ -26,6 +27,7 @@ import com.fasterxml.jackson.annotation.OptBoolean;
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.style.StylesBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -275,6 +277,42 @@ class SSMLSheetWriterDomEquivalenceTest {
         _assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
     }
 
+    // -- @DataColumnGroup styled attributes: headerStyle on the group cell,
+    //    columnStyle / columnHeaderStyle cascading into the leaf children.
+    //    Verifies SSML applies the resolved styles at the same cell positions
+    //    that POI does (same style index for the same cell).
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class StyledLeaves {
+        @DataColumn("city") String city;
+        @DataColumn("zip") String zip;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class StyledGroupedEntry {
+        @DataColumn("id") int id;
+        @DataColumnGroup(value = "address",
+                headerStyle = "groupHdr",
+                columnStyle = "childData",
+                columnHeaderStyle = "childHdr")
+        StyledLeaves address;
+    }
+
+    @Test
+    void sheetXmlDomEquivalent_groupStyledAttributes() throws Exception {
+        File ssmlFile = _debugFile("dom-group-styled-ssml.xlsx");
+        File poiFile = _debugFile("dom-group-styled-poi.xlsx");
+
+        List<StyledGroupedEntry> data = Arrays.asList(
+                new StyledGroupedEntry(1, new StyledLeaves("Seoul", "12345")),
+                new StyledGroupedEntry(2, new StyledLeaves("Busan", "67890")));
+
+        _styledMapper().writeValue(ssmlFile, data, StyledGroupedEntry.class);
+        _styledPoiMapper().writeValue(poiFile, data, StyledGroupedEntry.class);
+
+        _assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
+    }
+
     // -- 2-level @DataColumnGroup (3 header rows) + nested List + outer
     //    fields with merge=TRUE after the list. Tests that back-write
     //    into the first record row resolves against schema.getDataRow()
@@ -363,6 +401,32 @@ class SSMLSheetWriterDomEquivalenceTest {
         return new SpreadsheetMapper(
                 new SpreadsheetFactory(XSSFWorkbook::new, SpreadsheetFactory.DEFAULT_SHEET_PARSER_FEATURE_FLAGS)
                         .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL));
+    }
+
+    private static StylesBuilder _groupStyles() {
+        return new StylesBuilder()
+                .cellStyle("groupHdr")
+                    .fillForegroundColor(IndexedColors.YELLOW)
+                    .fillPattern().solidForeground()
+                    .end()
+                .cellStyle("childHdr")
+                    .fillForegroundColor(IndexedColors.GREY_25_PERCENT)
+                    .fillPattern().solidForeground()
+                    .end()
+                .cellStyle("childData")
+                    .font().bold().end()
+                    .end();
+    }
+
+    private static SpreadsheetMapper _styledMapper() {
+        return SpreadsheetMapper.builder().stylesBuilder(_groupStyles()).build();
+    }
+
+    private static SpreadsheetMapper _styledPoiMapper() {
+        return SpreadsheetMapper.builder()
+                .stylesBuilder(_groupStyles())
+                .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL)
+                .build();
     }
 
     private static void _assertPartEqualIgnoringDimension(


### PR DESCRIPTION
## Summary

- `@DataColumnGroup` gains a `headerStyle` attribute (group header cell) plus seven child-default slots mirroring `@DataGrid`'s cascade defaults: `columnStyle` / `columnHeaderStyle` / `columnWidth` / `autoSizeColumn` / `minColumnWidth` / `maxColumnWidth` / `mergeColumn`.
- `@DataGrid` gains a matching `groupHeaderStyle` default; `@DataGrid.columnHeaderStyle` now explicitly applies to leaf header cells only.
- Cascade chain on a leaf `@DataColumn` attribute: leaf → innermost enclosing `@DataColumnGroup` → outer groups → `@DataGrid` (declaring) → `@DataGrid` (root). First-non-default wins.
- `Styles.getGroupHeaderStyle(DataColumnGroup.Value)` lookup; SSML and POI writers apply the resolved style on the group cell after the header text is written.

## Test plan

- `./gradlew test` — 389 tests pass
- New `AttributeResolutionTest` covers the cross-cutting resolution order at the Value and Schema layers (Outer / Group / Element with `int` leaves around each list).
- New DOM-equivalence case asserts SSML and POI emit identical `sheet1.xml` for a styled `@DataColumnGroup` (group cell + child header + child data).