### PR TITLE
Polish styles, schema and docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -351,4 +351,3 @@ By default, both XLSX read and write paths bypass POI's User Model — the read 
 Public API surface (types users typically import): `SpreadsheetMapper`, `@DataGrid`, `@DataColumn`, `SheetInput`, `SheetOutput`, `SpreadsheetSchema`, `StylesBuilder`, `GridConfigurer`, `SheetMappingIterator`, `SheetLocation`, `SheetParser.Feature`, `SpreadsheetFactory.Feature`.
 
 Everything under `poi/` is implementation detail — swappable without affecting the streaming contract.
-

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -137,4 +137,3 @@ Filter specific benchmarks (and route results to per-benchmark files for separat
 ```
 
 Run benchmarks separately to avoid system noise accumulation across categories. GC profiler is enabled by default.
-

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -163,4 +163,3 @@ If you can do it with Jackson for JSON, you can do it with this library for Exce
 Same annotations. Same API. Different format. That's the abstraction.
 
 If it doesn't pass this test — if the user has to learn a new API or write spreadsheet-specific code for something Jackson already handles — it's a design failure.
-

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -42,7 +42,7 @@ List<Product> products = mapper.readValues(file, Product.class);
 
 The column-to-field mapping is driven by the class structure. Add a field, the column appears. Rename a field, the column follows. Remove a field, the column disappears. No index to update.
 
-But this is not a POI replacement. POI types (`Sheet`, `Workbook`) are first-class I/O targets. Open a workbook with POI, pass a `Sheet` to the mapper for data binding, then continue using POI for charts, formulas, conditional formatting — whatever the mapper doesn't cover. Data binding on top of POI, not instead of it.
+POI types (`Sheet`, `Workbook`) are first-class I/O targets — see [POI Integration](#poi-integration).
 
 ## Requirements
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -640,6 +640,8 @@ Note: `mapper.writerWithView()` does not work — it bypasses schema generation.
 
 Register named cell styles with `StylesBuilder` and reference them from annotations. Each named style maps to exactly one POI `CellStyle` (`workbook.createCellStyle()` invoked once per name at build time), so the [64,000 cell-style per-workbook limit](https://learn.microsoft.com/en-us/office/troubleshoot/excel/excel-specifications-and-limits) is bound by style declarations rather than row count.
 
+`StylesBuilder.simple()` returns a starter builder with per-type defaults registered (comma-grouped number formats, date/datetime formats). Drop it in early to get sensible defaults, then replace with a fully custom builder as needs grow.
+
 ```java
 StylesBuilder styles = new StylesBuilder()
     .cellStyle("currency")
@@ -690,7 +692,7 @@ Excel stores dates as numeric serial values. `ExcelDateModule` is registered by 
 
 Supported: `Date`, `Calendar`, `LocalDate`, `LocalDateTime`.
 
-No configuration needed. Read an Excel date cell and get a `LocalDate`. Write a `LocalDate` and get an Excel-formatted date.
+No configuration needed. Read an Excel date cell and get a `LocalDate`. Write a `LocalDate` and get an Excel-formatted date — provided the cell carries a date format; otherwise the raw serial number shows (e.g. `46157`). `StylesBuilder.simple()` registers per-type defaults as a starter (see [Styling](#styling)).
 
 On read, the workbook's date system (1900 or 1904) is detected and applied automatically. Write defaults to 1900.
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -692,13 +692,9 @@ Custom patterns can be passed directly via `dataFormat(String)`. See [Number for
 
 ### Excel Dates
 
-Excel stores dates as numeric serial values. `ExcelDateModule` is registered by default, automatically converting between Java date types and Excel date numbers.
+`ExcelDateModule` is registered by default — `Date`, `Calendar`, `LocalDate`, `LocalDateTime` convert to/from Excel serial values automatically. Without a date format on the cell, Excel shows the raw serial (e.g. `46157`); `StylesBuilder.simple()` registers per-type defaults as a starter (see [Styling](#styling)).
 
-Supported: `Date`, `Calendar`, `LocalDate`, `LocalDateTime`.
-
-No configuration needed. Read an Excel date cell and get a `LocalDate`. Write a `LocalDate` and get an Excel-formatted date — provided the cell carries a date format; otherwise the raw serial number shows (e.g. `46157`). `StylesBuilder.simple()` registers per-type defaults as a starter (see [Styling](#styling)).
-
-On read, the workbook's date system (1900 or 1904) is detected and applied automatically. Write defaults to 1900.
+On read, the workbook's date system (1900 / 1904) is detected; write defaults to 1900.
 
 ## Sheet-Level Features
 
@@ -719,7 +715,7 @@ SpreadsheetMapper mapper = SpreadsheetMapper.builder()
     .build();
 ```
 
-`freezePane(colSplit, rowSplit)` delegates to POI `Sheet#createFreezePane` — the leftmost `colSplit` columns and topmost `rowSplit` rows stay fixed while scrolling. `autoFilter()` enables the filter dropdown across all schema columns; the range is computed from the schema and row count. Both the streaming default and `USE_POI_USER_MODEL` write paths apply these identically.
+`freezePane(colSplit, rowSplit)` freezes the leftmost columns / topmost rows. `autoFilter()` enables the filter dropdown across all schema columns. Both work identically on streaming and `USE_POI_USER_MODEL` write paths.
 
 ### Conditional Formatting
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -374,8 +374,8 @@ try (SXSSFWorkbook wb = new SXSSFWorkbook()) {
 
 Flat spreadsheets map to nested POJOs automatically. This is a unique feature — no other Excel library supports bidirectional nested object mapping.
 
-| id | name | zipcode | city | title | salary |
-|----|------|---------|------|-------|--------|
+| id | name | address/zipcode | address/city | employment/title | employment/salary |
+|----|------|-----------------|--------------|------------------|-------------------|
 | 1 | Alice | 12345 | Seoul | SRE | 80000 |
 
 ```java
@@ -418,13 +418,11 @@ By default, nested field headers use the path from the parent (e.g., `address/zi
 Nested lists are serialized into multi-row output. *Deserialization is not currently supported.*
 
 ```java
-@DataGrid
+@DataGrid(mergeColumn = OptBoolean.TRUE)
 class Order {
-    @DataColumn(value = "Order ID", merge = OptBoolean.TRUE)
-    int orderId;
+    @DataColumn("Order ID") int orderId;
     List<Item> items;
-    @DataColumn(value = "Total", merge = OptBoolean.TRUE)
-    int total;
+    @DataColumn("Total") int total;
 }
 
 class Item {
@@ -512,12 +510,15 @@ Renders flattened columns from a nested object field under a shared group header
 ```java
 @DataGrid
 class Employee {
-    int id;
-    String name;
+    @DataColumn("ID") int id;
+    @DataColumn("Name") String name;
     @DataColumnGroup(value = "Address", comment = "Customer billing address")
     Address address;
 }
-class Address { String city; String zip; }
+class Address {
+    @DataColumn("City") String city;
+    @DataColumn("Zip") String zip;
+}
 ```
 
 renders as:
@@ -538,7 +539,7 @@ For deeper hierarchies the annotation stacks naturally:
 
 ```java
 class Company {
-    String name;
+    @DataColumn("Name") String name;
     @DataColumnGroup("2024") YearMetrics year2024;
     @DataColumnGroup("2025") YearMetrics year2025;
 }
@@ -546,7 +547,10 @@ class YearMetrics {
     @DataColumnGroup("Q1") QuarterMetrics q1;
     @DataColumnGroup("Q2") QuarterMetrics q2;
 }
-class QuarterMetrics { int sales; int profit; }
+class QuarterMetrics {
+    @DataColumn("Sales") int sales;
+    @DataColumn("Profit") int profit;
+}
 ```
 
 ```
@@ -588,8 +592,8 @@ class Bar {
 
 | Column | style | autoSize |
 |--------|-------|----------|
-| bar.foo.a | `"highlight"` (from @DataColumn) | `FALSE` (from Foo's @DataGrid) |
-| bar.foo.b | `"base"` (from Bar's @DataGrid) | `FALSE` (from Foo's @DataGrid) |
+| foo/a | `"highlight"` (from @DataColumn) | `FALSE` (from Foo's @DataGrid) |
+| foo/b | `"base"` (from Bar's @DataGrid) | `FALSE` (from Foo's @DataGrid) |
 
 ### Jackson Annotations
 
@@ -929,32 +933,7 @@ SpreadsheetMapper mapper = SpreadsheetMapper.builder()
 List<Row> rows = mapper.readValues(inputStream, Row.class);
 ```
 
-## Performance
-
-At 100K rows (mixed types, shared string table):
-
-**Read:**
-
-| Library | Time | Memory |
-|---------|------|--------|
-| jackson-spreadsheet | 198 ms | 378 MB |
-| FastExcel | 212 ms | 428 MB |
-| Fesod | 279 ms | 400 MB |
-| Poiji | 843 ms | 2876 MB |
-| Apache POI | 1198 ms | 2333 MB |
-
-**Write:**
-
-| Library | Time | Memory |
-|---------|------|--------|
-| jackson-spreadsheet | 150 ms | 191 MB |
-| FastExcel | 166 ms | 156 MB |
-| Apache POI | 283 ms | 207 MB |
-| Fesod | 337 ms | 480 MB |
-
-Fastest read and write throughput among all libraries. See [BENCHMARK.md](BENCHMARK.md) for full results.
-
-### Low-Memory Mode for Large Files
+## Low-Memory Mode for Large Files
 
 For extremely large XLSX files that cause `OutOfMemoryError`:
 
@@ -985,7 +964,7 @@ Requires `com.h2database:h2` on the classpath:
 </dependency>
 ```
 
-Trades ~40% throughput for constant heap usage regardless of string table size. The temporary file is automatically deleted when the reader is closed.
+Trades throughput for constant heap usage regardless of string table size — see [BENCHMARK.md](BENCHMARK.md) for measured overhead. The temporary file is automatically deleted when the reader is closed.
 
 ## Logging
 
@@ -1017,4 +996,3 @@ Yes. Create a `SpreadsheetMapper` bean and inject it. It is thread-safe like `Ob
 - [BENCHMARK.md](BENCHMARK.md) — JMH benchmark results
 - [Jackson documentation](https://github.com/FasterXML/jackson-docs)
 - [Apache POI](https://poi.apache.org/components/spreadsheet/index.html)
-

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -729,7 +729,7 @@ SpreadsheetMapper mapper = SpreadsheetMapper.builder()
 import static io.github.scndry.jackson.dataformat.spreadsheet.schema.grid.ConditionalFormats.*;
 ```
 
-Column names resolve against `@DataColumn(value)`, the field name, or `@JsonAlias`. Style names resolve against `cellStyle(name)` in `StylesBuilder`. Both resolve at write time — typos throw `IllegalArgumentException` listing the available names.
+Column names resolve against `@DataColumn(value)`, the field name, or `@JsonAlias`. Style names resolve against `cellStyle(name)` in `StylesBuilder`. Both resolve at write time — typos throw `IllegalArgumentException` listing the available names. Alignment and wrap-text on a referenced style are silently dropped — DXF limitation.
 
 Comparison factories (`greaterThan`, `between`, `equalTo`, ...) accept typed values (numeric, boolean, string, date) or `Formula` for cell references and Excel expressions. String operands are auto-quoted; dates emit as `DATE(y,m,d)+TIME(h,m,s)`. The factory returns a `FormatCondition`; `.style(name)` finishes it as a `ConditionalFormatRule`.
 
@@ -793,10 +793,6 @@ Prefer `LocalDate` / `LocalDateTime` for deterministic CF rules. `Date` carries 
 #### Formula escape
 
 `formula(text)` is a power-user escape — the text is emitted verbatim into the OOXML `<formula>` element. The library does not validate Excel syntax. `columnRef(name)` resolves the schema column name to a row-relative reference (`$<col><dataStartRow>`) at write time, so Excel auto-shifts per cell in the formatting range.
-
-#### Style → DXF mapping
-
-Style names referenced by `.style(name)` resolve to a `cellStyle` in `StylesBuilder`. Fill, font, and border properties are translated into a DXF entry attached to the rule. Alignment and wrap-text are silently skipped (DXF doesn't support them).
 
 #### Color scale (3-color)
 

--- a/README.md
+++ b/README.md
@@ -109,10 +109,10 @@ Nested objects flatten into columns. Lists of nested objects expand into multipl
 ```java
 @DataGrid(mergeColumn = OptBoolean.TRUE)
 class Order {
-    @DataColumn("ID") int id;
-    @DataColumn("Customer") String customer;
+    @DataColumn("ID")         int id;
+    @DataColumn("Customer")   String customer;
     @DataColumnGroup("Items") List<LineItem> items;
-    @DataColumn("Total") BigDecimal total;
+    @DataColumn("Total")      BigDecimal total;
 }
 
 class LineItem {
@@ -285,4 +285,3 @@ The mapper instance is reusable across threads once configured (same rule as Jac
 ## License
 
 [Apache License 2.0](LICENSE)
-

--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ try (SheetMappingIterator<Product> iter = reader.readValues(input)) {
 
 ### Cell Styling
 
+`StylesBuilder.simple()` for a per-type starter set; build a `StylesBuilder` from scratch for full control.
+
 ```java
 StylesBuilder styles = new StylesBuilder()
     .cellStyle("currency")
@@ -233,7 +235,7 @@ SpreadsheetMapper mapper = SpreadsheetMapper.builder()
 
 ### Excel Date Handling
 
-Built-in conversion between Java date types and Excel serial numbers. Registered by default — no setup needed.
+Built-in conversion between Java date types and Excel serial numbers. Registered by default — no setup needed. Excel renders a date cell as a date only when it carries a date format; `StylesBuilder.simple()` registers per-type defaults as a starter.
 
 Supported: `Date`, `Calendar`, `LocalDate`, `LocalDateTime`
 

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLSheetWriter.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLSheetWriter.java
@@ -32,6 +32,7 @@ import io.github.scndry.jackson.dataformat.spreadsheet.schema.HeaderLayoutVisito
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.Styles;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.BackWriteProjection;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.HeaderComments;
 import io.github.scndry.jackson.dataformat.spreadsheet.ser.SheetWriter;
 
 /**
@@ -113,7 +114,7 @@ public final class SSMLSheetWriter implements SheetWriter {
         try {
             _wb = _sheet.getWorkbook();
             _styles = _schema.buildStyles(_wb);
-            _schema.applyHeaderComments(_sheet);
+            HeaderComments.apply(_sheet, _schema);
             _schema.configureSheet(_sheet, _styles, -1);
             _writeScaffoldWorkbook();
             _splitScaffoldSheetXml();

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLSheetWriter.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLSheetWriter.java
@@ -159,7 +159,7 @@ public final class SSMLSheetWriter implements SheetWriter {
             public void visitGroupCell(final int row, final int firstCol, final int lastCol,
                                        final DataColumnGroup.Value group) {
                 setReference(new CellAddress(row, firstCol));
-                final CellStyle gs = _styles.getGroupHeaderStyle(group);
+                final CellStyle gs = _styles.resolve(group.getHeaderStyle(), null);
                 if (gs == null) {
                     writeString(group.getName());
                 } else {
@@ -445,9 +445,11 @@ public final class SSMLSheetWriter implements SheetWriter {
 
         final int[] columnStyleIndex = new int[columns.size()];
         for (int i = 0; i < columns.size(); i++) {
-            final CellStyle cs = header
-                    ? styles.getHeaderStyle(columns.get(i))
-                    : styles.getStyle(columns.get(i));
+            final Column column = columns.get(i);
+            final String name = header
+                    ? column.getValue().getHeaderStyle()
+                    : column.getValue().getStyle();
+            final CellStyle cs = styles.resolve(name, column.getType().getRawClass());
             if (cs != null) {
                 columnStyleIndex[i] = cs.getIndex();
             }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ss/POISheetWriter.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ss/POISheetWriter.java
@@ -29,6 +29,7 @@ import io.github.scndry.jackson.dataformat.spreadsheet.schema.ColumnPointer;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.HeaderLayoutVisitor;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.Styles;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.HeaderComments;
 import io.github.scndry.jackson.dataformat.spreadsheet.ser.SheetWriter;
 
 /**
@@ -75,7 +76,7 @@ public final class POISheetWriter implements SheetWriter {
     public void setSchema(final SpreadsheetSchema schema) {
         _schema = schema;
         _styles = _schema.buildStyles(_sheet.getWorkbook());
-        _schema.applyHeaderComments(_sheet);
+        HeaderComments.apply(_sheet, _schema);
         _dataFormatter = new DataFormatter();
         _defaultCharWidth = SheetUtil.getDefaultCharWidth(_sheet.getWorkbook());
     }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ss/POISheetWriter.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ss/POISheetWriter.java
@@ -99,7 +99,7 @@ public final class POISheetWriter implements SheetWriter {
                                        final DataColumnGroup.Value group) {
                 setReference(new CellAddress(row, firstCol));
                 writeString(group.getName());
-                final CellStyle gs = _styles.getGroupHeaderStyle(group);
+                final CellStyle gs = _styles.resolve(group.getHeaderStyle(), null);
                 if (gs != null) {
                     CellUtil.getCell(CellUtil.getRow(row, _sheet), firstCol).setCellStyle(gs);
                 }
@@ -156,8 +156,10 @@ public final class POISheetWriter implements SheetWriter {
         consumer.accept(cell, value);
         final Column column = _schema.findColumn(_reference);
         if (column != null) {
-            final CellStyle style = _schema.getDataRow() > row
-                    ? _styles.getHeaderStyle(column) : _styles.getStyle(column);
+            final String name = _schema.getDataRow() > row
+                    ? column.getValue().getHeaderStyle()
+                    : column.getValue().getStyle();
+            final CellStyle style = _styles.resolve(name, column.getType().getRawClass());
             if (style != null) {
                 cell.setCellStyle(style);
             }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
@@ -5,10 +5,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.apache.poi.ss.usermodel.ClientAnchor;
-import org.apache.poi.ss.usermodel.Comment;
-import org.apache.poi.ss.usermodel.CreationHelper;
-import org.apache.poi.ss.usermodel.Drawing;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.util.CellAddress;
@@ -37,9 +33,6 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
     public static final int FEATURE_COLUMN_REORDERING = 0x0002;
 
     public static final int DEFAULT_FEATURES = FEATURE_USE_HEADER;
-
-    private static final int COMMENT_BOX_WIDTH_COLS = 2;
-    private static final int COMMENT_BOX_HEIGHT_ROWS = 3;
 
     private final List<Column> _columns;
     private final CellAddress _origin;
@@ -105,25 +98,15 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
         return _headerRowCount;
     }
 
-    /**
-     * Row index of the last (leaf) header row — the row carrying column
-     * names. Group header rows (when present) sit above this row. When
-     * {@link #usesHeader()} is disabled this collapses to the origin row.
-     */
+    /** Row index of the leaf header row (the row carrying column names).
+     *  Collapses to the origin row when {@link #usesHeader()} is disabled. */
     public int getLeafHeaderRow() {
         return _origin.getRow() + (usesHeader() ? _headerRowCount - 1 : 0);
     }
 
-    /**
-     * Walk every cell in the header region (column headers, group cells,
-     * vertical-merge regions) and invoke the visitor. Used by writers and
-     * comment application to share the run-identification algorithm.
-     *
-     * <p>Cell visit order: row-by-row top to bottom, then vertical merges
-     * after the last header row. Within a row, columns are visited in
-     * declaration order. Group cells emit the firstCol..lastCol range so
-     * callers can register horizontal merges.
-     */
+    /** Walks the header region (leaf headers, group cells, vertical merges)
+     *  and invokes the visitor for each. Used by writers and the comment
+     *  applicator to share the run-identification algorithm. */
     public void forEachHeaderCell(final HeaderLayoutVisitor visitor) {
         if (!usesHeader()) return;
         final int originRow = _origin.getRow();
@@ -248,38 +231,6 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
 
     public Styles buildStyles(final Workbook workbook) {
         return _stylesBuilder.build(workbook);
-    }
-
-    public void applyHeaderComments(final Sheet sheet) {
-        if (!usesHeader()) return;
-        final CreationHelper factory = sheet.getWorkbook().getCreationHelper();
-        forEachHeaderCell(new HeaderLayoutVisitor() {
-            private Drawing<?> drawing;
-
-            @Override
-            public void visitColumnHeader(final int row, final int col, final Column column) {
-                _addCommentIfPresent(row, col, column.getValue().getComment());
-            }
-
-            @Override
-            public void visitGroupCell(final int row, final int firstCol, final int lastCol,
-                                       final DataColumnGroup.Value group) {
-                _addCommentIfPresent(row, firstCol, group.getComment());
-            }
-
-            private void _addCommentIfPresent(final int row, final int col, final String text) {
-                if (text.isEmpty()) return;
-                if (drawing == null) drawing = sheet.createDrawingPatriarch();
-                final ClientAnchor anchor = factory.createClientAnchor();
-                anchor.setCol1(col);
-                anchor.setRow1(row);
-                anchor.setCol2(col + COMMENT_BOX_WIDTH_COLS);
-                anchor.setRow2(row + COMMENT_BOX_HEIGHT_ROWS);
-                final Comment c = drawing.createCellComment(anchor);
-                c.setString(factory.createRichTextString(text));
-                c.setAddress(row, col);
-            }
-        });
     }
 
     public void configureSheet(final Sheet sheet, final Styles styles, final int lastRow) {

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/Styles.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/Styles.java
@@ -1,30 +1,35 @@
 package io.github.scndry.jackson.dataformat.spreadsheet.schema;
 
+import java.util.NoSuchElementException;
+
 import org.apache.poi.ss.usermodel.CellStyle;
 
-import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
-
 /**
- * Resolves Apache POI {@link CellStyle} instances for data and
- * header cells. Built per-workbook by
+ * Lookup of POI {@link CellStyle} instances by registered name or by Java type.
+ * Built per-workbook by
  * {@link io.github.scndry.jackson.dataformat.spreadsheet.schema.style.StylesBuilder}.
  *
- * @see Column
  * @see SpreadsheetSchema
  */
 public interface Styles {
 
-    CellStyle getStyle(Column column);
+    /** Returns the style registered for {@code name}, or {@code null} if none. */
+    CellStyle byName(String name);
 
-    default CellStyle getHeaderStyle(final Column column) {
-        return getStyle(column);
-    }
+    /** Returns the style registered for {@code type}, or {@code null} if none. */
+    CellStyle byType(Class<?> type);
 
-    CellStyle getStyle(String name);
-
-    /** Resolves the cell style for a {@code @DataColumnGroup} header cell.
-     *  Returns {@code null} when no style is registered for the group. */
-    default CellStyle getGroupHeaderStyle(final DataColumnGroup.Value group) {
-        return null;
+    /** Resolves {@code name} via {@link #byName}, falling back to {@link #byType}
+     *  with {@code typeFallback} when {@code name} is empty. Throws
+     *  {@link NoSuchElementException} when {@code name} is non-empty and unregistered. */
+    default CellStyle resolve(final String name, final Class<?> typeFallback) {
+        if (!name.isEmpty()) {
+            final CellStyle cs = byName(name);
+            if (cs == null) {
+                throw new NoSuchElementException("Style '" + name + "' is not registered");
+            }
+            return cs;
+        }
+        return typeFallback == null ? null : byType(typeFallback);
     }
 }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/generator/ObjectFormatVisitor.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/generator/ObjectFormatVisitor.java
@@ -58,7 +58,7 @@ final class ObjectFormatVisitor extends JsonObjectFormatVisitor.Base {
         final DataGrid.Value gridValue = _gridValue(prop);
         final DataColumn.Value columnValue =
                 _columnValue(prop, gridValue, _wrapper.getGroupHierarchy());
-        final DataColumnGroup.Value groupValue = _columnGroupValue(prop, gridValue);
+        final DataColumnGroup.Value groupValue = _columnGroupValue(prop, pointer, gridValue);
 
         final DataColumnGroup.Hierarchy childHierarchy = _wrapper.getGroupHierarchy().append(groupValue);
 
@@ -166,10 +166,10 @@ final class ObjectFormatVisitor extends JsonObjectFormatVisitor.Base {
         return value.withDefaults(grid);
     }
 
-    private DataColumnGroup.Value _columnGroupValue(BeanProperty prop, DataGrid.Value grid) {
+    private DataColumnGroup.Value _columnGroupValue(BeanProperty prop, ColumnPointer pointer, DataGrid.Value grid) {
         final DataColumnGroup ann = prop.getAnnotation(DataColumnGroup.class);
         if (ann == null) return DataColumnGroup.Value.empty();
-        final String name = ann.value().isEmpty() ? prop.getName() : ann.value();
+        final String name = ann.value().isEmpty() ? pointer.toString() : ann.value();
         return new DataColumnGroup.Value(name, ann.comment(), ann.headerStyle(),
                 ann.columnStyle(), ann.columnHeaderStyle(),
                 ann.columnWidth(), ann.autoSizeColumn(),

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/grid/GridConfigurer.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/grid/GridConfigurer.java
@@ -169,7 +169,7 @@ public final class GridConfigurer {
 
     private static void _applyStyle(final ConditionalFormattingRule rule,
             final String styleName, final Styles styles, final Workbook wb) {
-        final CellStyle cs = styles.getStyle(styleName);
+        final CellStyle cs = styles.byName(styleName);
         if (cs == null) {
             throw new IllegalArgumentException("Style '" + styleName + "' not found");
         }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/HeaderComments.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/HeaderComments.java
@@ -1,0 +1,58 @@
+package io.github.scndry.jackson.dataformat.spreadsheet.schema.internal;
+
+import org.apache.poi.ss.usermodel.ClientAnchor;
+import org.apache.poi.ss.usermodel.Comment;
+import org.apache.poi.ss.usermodel.CreationHelper;
+import org.apache.poi.ss.usermodel.Drawing;
+import org.apache.poi.ss.usermodel.Sheet;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.HeaderLayoutVisitor;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
+
+/**
+ * Applies header-cell comments (from {@code @DataColumn(comment)} and
+ * {@code @DataColumnGroup(comment)}) to a POI {@link Sheet} for the given
+ * {@link SpreadsheetSchema}. Internal write-time helper — invoked by the
+ * sheet writers.
+ */
+public final class HeaderComments {
+
+    private static final int COMMENT_BOX_WIDTH_COLS = 2;
+    private static final int COMMENT_BOX_HEIGHT_ROWS = 3;
+
+    private HeaderComments() {}
+
+    public static void apply(final Sheet sheet, final SpreadsheetSchema schema) {
+        if (!schema.usesHeader()) return;
+        final CreationHelper factory = sheet.getWorkbook().getCreationHelper();
+        schema.forEachHeaderCell(new HeaderLayoutVisitor() {
+            private Drawing<?> drawing;
+
+            @Override
+            public void visitColumnHeader(final int row, final int col, final Column column) {
+                _addCommentIfPresent(row, col, column.getValue().getComment());
+            }
+
+            @Override
+            public void visitGroupCell(final int row, final int firstCol, final int lastCol,
+                                       final DataColumnGroup.Value group) {
+                _addCommentIfPresent(row, firstCol, group.getComment());
+            }
+
+            private void _addCommentIfPresent(final int row, final int col, final String text) {
+                if (text.isEmpty()) return;
+                if (drawing == null) drawing = sheet.createDrawingPatriarch();
+                final ClientAnchor anchor = factory.createClientAnchor();
+                anchor.setCol1(col);
+                anchor.setRow1(row);
+                anchor.setCol2(col + COMMENT_BOX_WIDTH_COLS);
+                anchor.setRow2(row + COMMENT_BOX_HEIGHT_ROWS);
+                final Comment c = drawing.createCellComment(anchor);
+                c.setString(factory.createRichTextString(text));
+                c.setAddress(row, col);
+            }
+        });
+    }
+}

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/style/StylesBuilder.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/style/StylesBuilder.java
@@ -12,8 +12,6 @@ import java.util.Map;
 import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.Workbook;
 
-import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
-import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.Styles;
 
 /**
@@ -21,7 +19,7 @@ import io.github.scndry.jackson.dataformat.spreadsheet.schema.Styles;
  */
 public final class StylesBuilder implements Builder<Styles> {
 
-    // Each name maps to one POI CellStyle — bounded by Excel's cell-style cap (4K HSSF / 64K XSSF).
+    // Each name/type maps to one POI CellStyle — bounded by Excel's cell-style cap (4K HSSF / 64K XSSF).
     private final Map<Object, CellStyleBuilder> _builders;
 
     public StylesBuilder() {
@@ -52,17 +50,11 @@ public final class StylesBuilder implements Builder<Styles> {
     }
 
     public CellStyleBuilder cellStyle(final Class<?> type) {
-        return cellStyle(type, new CellStyleBuilder());
-    }
-
-    private CellStyleBuilder cellStyle(final Object key, final CellStyleBuilder builder) {
-        builder.setBuilder(this);
-        _builders.put(key, builder);
-        return builder;
+        return _register(type, new CellStyleBuilder());
     }
 
     public CellStyleBuilder cellStyle(final String name) {
-        return cellStyle(name, new CellStyleBuilder());
+        return _register(name, new CellStyleBuilder());
     }
 
     public CellStyleBuilder cellStyle(final String name, final String cloneStyleFrom) {
@@ -70,13 +62,19 @@ public final class StylesBuilder implements Builder<Styles> {
         if (source == null) {
             throw new IllegalArgumentException("Style '" + cloneStyleFrom + "' is not registered");
         }
-        return cellStyle(name, source.copy());
+        return _register(name, source.copy());
+    }
+
+    private CellStyleBuilder _register(final Object key, final CellStyleBuilder builder) {
+        builder.setBuilder(this);
+        _builders.put(key, builder);
+        return builder;
     }
 
     @Override
     public Styles build(final Workbook workbook) {
         final StylesImpl styles = new StylesImpl();
-        _builders.forEach((key, builder) -> styles.register(key, builder.build(workbook)));
+        _builders.forEach((key, builder) -> styles._styles.put(key, builder.build(workbook)));
         return styles;
     }
 
@@ -91,45 +89,14 @@ public final class StylesBuilder implements Builder<Styles> {
 
         private final Map<Object, CellStyle> _styles = new HashMap<>();
 
-        public void register(final Object key, final CellStyle style) {
-            _styles.put(key, style);
-        }
-
         @Override
-        public CellStyle getStyle(final Column column) {
-            return _findStyle(column.getValue().getStyle(), column);
-        }
-
-        @Override
-        public CellStyle getStyle(final String name) {
+        public CellStyle byName(final String name) {
             return _styles.get(name);
         }
 
         @Override
-        public CellStyle getHeaderStyle(final Column column) {
-            return _findStyle(column.getValue().getHeaderStyle(), column);
-        }
-
-        @Override
-        public CellStyle getGroupHeaderStyle(final DataColumnGroup.Value group) {
-            final String name = group.getHeaderStyle();
-            if (name.isEmpty()) return null;
-            final CellStyle style = _styles.get(name);
-            if (style == null) {
-                throw new IllegalStateException("Style '" + name + "' is not registered");
-            }
-            return style;
-        }
-
-        private CellStyle _findStyle(final String name, final Column column) {
-            if (!name.isEmpty()) {
-                final CellStyle style = _styles.get(name);
-                if (style == null) {
-                    throw new IllegalStateException("Style '" + name + "' is not registered");
-                }
-                return style;
-            }
-            return _styles.get(column.getType().getRawClass());
+        public CellStyle byType(final Class<?> type) {
+            return _styles.get(type);
         }
     }
 }

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/StylesTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/StylesTest.java
@@ -14,6 +14,7 @@ import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -114,9 +115,9 @@ class StylesTest {
         File file = new File(tempDir, "bad.xlsx");
         assertThatThrownBy(() -> mapper.writeValue(file, new Bad()))
                 .satisfiesAnyOf(
-                        t -> assertThat(t).isInstanceOf(IllegalStateException.class)
+                        t -> assertThat(t).isInstanceOf(NoSuchElementException.class)
                                 .hasMessageContaining("Style 'missing' is not registered"),
-                        t -> assertThat(t).hasRootCauseInstanceOf(IllegalStateException.class)
+                        t -> assertThat(t).hasRootCauseInstanceOf(NoSuchElementException.class)
                                 .hasRootCauseMessage("Style 'missing' is not registered"));
     }
 


### PR DESCRIPTION
## Summary

- Distill `Styles` interface to two lookup primitives (`byName(String)` / `byType(Class<?>)`) plus a default `resolve(name, typeFallback)` helper. Missing-name lookup throws `NoSuchElementException`.
- Extract `HeaderComments` into `schema/internal` — `SpreadsheetSchema` no longer pulls in POI `Drawing` / `Comment` / `ClientAnchor` / `CreationHelper`.
- Fix `@DataColumnGroup` empty-value fallback to `ColumnPointer.toString()` so it matches `@DataColumn` (same progressive-disclosure intent).
- Document `StylesBuilder.simple()` as the starter pattern in GUIDE / README. Drop the stale Performance comparison from GUIDE (BENCHMARK.md is the single source of truth) and promote Low-Memory Mode. Trim positioning rhetoric, the DXF subsection, and the Excel-Dates / Sheet-Level-Features expansions for AI-agent readability. Rewrite Nested Lists / Nested Objects / `@DataColumnGroup` tables to match actual output. Fix the Attribute Resolution Order column-name notation.

## Test plan

- [x] `./gradlew test` — green
- [x] `./gradlew build` — green
- [x] No FQCN in changed code; Java 8 compatible