### PR TITLE
Assert DOM equality across POI versions

### DIFF
--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/DataColumnGroupTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/DataColumnGroupTest.java
@@ -1459,6 +1459,67 @@ class DataColumnGroupTest {
         return tempDir.resolve(name).toFile();
     }
 
+    // -- @DataColumnGroup empty value() falls back to column pointer path ----
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class FallbackRoot {
+        @DataColumnGroup FallbackInner address;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class FallbackInner {
+        @DataColumn("City") String city;
+        @DataColumn("Zip") String zip;
+    }
+
+    @Test
+    void groupValueEmpty_atRoot_usesFieldName() throws Exception {
+        File file = tempFile("group-fallback-root.xlsx");
+
+        mapper.writeValue(file, new FallbackRoot(new FallbackInner("Seoul", "12345")));
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            // Root field's pointer is the bare field name.
+            assertThat(sheet.getRow(0).getCell(0).getStringCellValue()).isEqualTo("address");
+            assertThat(sheet.getRow(1).getCell(0).getStringCellValue()).isEqualTo("City");
+            assertThat(sheet.getRow(1).getCell(1).getStringCellValue()).isEqualTo("Zip");
+        }
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class FallbackOuter {
+        @DataColumnGroup FallbackMid mid;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class FallbackMid {
+        @DataColumnGroup FallbackLeaf leaf;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class FallbackLeaf {
+        @DataColumn("v") int v;
+    }
+
+    @Test
+    void groupValueEmpty_atNested_usesColumnPointerPath() throws Exception {
+        File file = tempFile("group-fallback-nested.xlsx");
+
+        mapper.writeValue(file, new FallbackOuter(new FallbackMid(new FallbackLeaf(42))));
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            // Outer @DataColumnGroup with empty value → root pointer "mid".
+            assertThat(sheet.getRow(0).getCell(0).getStringCellValue()).isEqualTo("mid");
+            // Nested @DataColumnGroup with empty value → path "mid/leaf",
+            // not the bare field name "leaf".
+            assertThat(sheet.getRow(1).getCell(0).getStringCellValue()).isEqualTo("mid/leaf");
+            assertThat(sheet.getRow(2).getCell(0).getStringCellValue()).isEqualTo("v");
+            assertThat((int) sheet.getRow(3).getCell(0).getNumericCellValue()).isEqualTo(42);
+        }
+    }
+
     private static final Path DEBUG_OUTPUT_DIR = Paths.get("build/debug-output");
 
     private static File _debugFile(final String name) throws IOException {

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/RealisticAccuracyTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/RealisticAccuracyTest.java
@@ -18,19 +18,12 @@ import ch.qos.logback.classic.Logger;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.apache.poi.openxml4j.opc.OPCPackage;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
-import org.w3c.dom.Document;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Accuracy checks beyond the basic single-nested-list case. Each test asserts
@@ -70,9 +63,6 @@ class RealisticAccuracyTest {
 
     @Test
     void multipleListsPerRecord() throws Exception {
-        Assumptions.assumeTrue(PoiVersionProbe.isPoi523OrLater(),
-                "DOM equivalence asserted only on POI 5.2.3+ — see #96");
-
         OrderTwoLists order = new OrderTwoLists(
                 "ORD-001",
                 Arrays.asList(new Item("Apple", 3), new Item("Banana", 5)),
@@ -89,7 +79,7 @@ class RealisticAccuracyTest {
         _poiMapper().writeValue(poiFile,
                 Collections.singletonList(order), OrderTwoLists.class);
 
-        _assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
+        XlsxDomAssertions.assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
     }
 
     // ----------------------------------------------------------------
@@ -119,9 +109,6 @@ class RealisticAccuracyTest {
 
     @Test
     void deepNestedListOfList() throws Exception {
-        Assumptions.assumeTrue(PoiVersionProbe.isPoi523OrLater(),
-                "DOM equivalence asserted only on POI 5.2.3+ — see #96");
-
         GroupedOrder order = new GroupedOrder(1,
                 Arrays.asList(
                         new Group("X",
@@ -140,7 +127,7 @@ class RealisticAccuracyTest {
         _poiMapper().writeValue(poiFile,
                 Collections.singletonList(order), GroupedOrder.class);
 
-        _assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
+        XlsxDomAssertions.assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
     }
 
     // ----------------------------------------------------------------
@@ -184,9 +171,6 @@ class RealisticAccuracyTest {
 
     @Test
     void wideTable() throws Exception {
-        Assumptions.assumeTrue(PoiVersionProbe.isPoi523OrLater(),
-                "DOM equivalence asserted only on POI 5.2.3+ — see #96");
-
         WideRecord record = new WideRecord(
                 "h01v", "h02v", "h03v", "h04v", "h05v",
                 1, 2, 3, 4.0, 5.0,
@@ -203,7 +187,7 @@ class RealisticAccuracyTest {
         _poiMapper().writeValue(poiFile,
                 Collections.singletonList(record), WideRecord.class);
 
-        _assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
+        XlsxDomAssertions.assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
     }
 
     // ----------------------------------------------------------------
@@ -225,9 +209,6 @@ class RealisticAccuracyTest {
 
     @Test
     void veryLargeStrings() throws Exception {
-        Assumptions.assumeTrue(PoiVersionProbe.isPoi523OrLater(),
-                "DOM equivalence asserted only on POI 5.2.3+ — see #96");
-
         StringBuilder bigMemo = new StringBuilder(1024);
         for (int i = 0; i < 100; i++) bigMemo.append("long memo text segment ").append(i).append(" -- ");
         StringBuilder bigDesc = new StringBuilder(2048);
@@ -248,7 +229,7 @@ class RealisticAccuracyTest {
         _poiMapper().writeValue(poiFile,
                 Collections.singletonList(record), LargeStringRecord.class);
 
-        _assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
+        XlsxDomAssertions.assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
     }
 
     // ----------------------------------------------------------------
@@ -272,9 +253,6 @@ class RealisticAccuracyTest {
 
     @Test
     void sparseNullValues() throws Exception {
-        Assumptions.assumeTrue(PoiVersionProbe.isPoi523OrLater(),
-                "DOM equivalence asserted only on POI 5.2.3+ — see #96");
-
         NullableRecord record = new NullableRecord(
                 1, null,
                 Arrays.asList(new NullableInner("a", null),
@@ -289,7 +267,7 @@ class RealisticAccuracyTest {
         _poiMapper().writeValue(poiFile,
                 Collections.singletonList(record), NullableRecord.class);
 
-        _assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
+        XlsxDomAssertions.assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
     }
 
     // ----------------------------------------------------------------
@@ -300,9 +278,6 @@ class RealisticAccuracyTest {
 
     @Test
     void multiRecordDeepNested() throws Exception {
-        Assumptions.assumeTrue(PoiVersionProbe.isPoi523OrLater(),
-                "DOM equivalence asserted only on POI 5.2.3+ — see #96");
-
         java.util.ArrayList<GroupedOrder> data = new java.util.ArrayList<>();
         for (int r = 0; r < 5; r++) {
             data.add(new GroupedOrder(r,
@@ -324,7 +299,7 @@ class RealisticAccuracyTest {
         new SpreadsheetMapper().writeValue(ssmlFile, data, GroupedOrder.class);
         _poiMapper().writeValue(poiFile, data, GroupedOrder.class);
 
-        _assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
+        XlsxDomAssertions.assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
     }
 
     // ----------------------------------------------------------------
@@ -337,9 +312,6 @@ class RealisticAccuracyTest {
 
     @Test
     void largeSingleRecord_crossesBufferThreshold() throws Exception {
-        Assumptions.assumeTrue(PoiVersionProbe.isPoi523OrLater(),
-                "DOM equivalence asserted only on POI 5.2.3+ — see #96");
-
         // SheetGenerator emits a TRACE log per write/closeStruct — 20K inners
         // × 3 cells + struct events floods the IDE console buffer at the
         // suite-default TRACE level. Bound to DEBUG just for this case.
@@ -364,7 +336,7 @@ class RealisticAccuracyTest {
             _poiMapper().writeValue(poiFile,
                     Collections.singletonList(record), NestedListEntry.class);
 
-            _assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
+            XlsxDomAssertions.assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
         } finally {
             sheetGen.setLevel(prevLevel);
         }
@@ -411,9 +383,6 @@ class RealisticAccuracyTest {
 
     @Test
     void deepNestedLargeStrings() throws Exception {
-        Assumptions.assumeTrue(PoiVersionProbe.isPoi523OrLater(),
-                "DOM equivalence asserted only on POI 5.2.3+ — see #96");
-
         StringBuilder bigDesc = new StringBuilder(2048);
         for (int i = 0; i < 100; i++) bigDesc.append("description chunk ").append(i).append(" / ");
         StringBuilder bigNote = new StringBuilder(1024);
@@ -440,7 +409,7 @@ class RealisticAccuracyTest {
         _poiMapper().writeValue(poiFile,
                 Collections.singletonList(root), FatRoot.class);
 
-        _assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
+        XlsxDomAssertions.assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
     }
 
     // ----------------------------------------------------------------
@@ -451,9 +420,6 @@ class RealisticAccuracyTest {
 
     @Test
     void parentChildSameFirstRow() throws Exception {
-        Assumptions.assumeTrue(PoiVersionProbe.isPoi523OrLater(),
-                "DOM equivalence asserted only on POI 5.2.3+ — see #96");
-
         // Single group, two inners → row 0 is parent's, group's, and item[0]'s
         // firstRow simultaneously. Forward advance to row 1 must lock all three
         // entries that match firstRow=0 in the stack.
@@ -473,7 +439,7 @@ class RealisticAccuracyTest {
         _poiMapper().writeValue(poiFile,
                 Collections.singletonList(order), GroupedOrder.class);
 
-        _assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
+        XlsxDomAssertions.assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
     }
 
     // ----------------------------------------------------------------
@@ -484,33 +450,6 @@ class RealisticAccuracyTest {
         return new SpreadsheetMapper(
                 new SpreadsheetFactory(XSSFWorkbook::new, SpreadsheetFactory.DEFAULT_SHEET_PARSER_FEATURE_FLAGS)
                         .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL));
-    }
-
-    private static void _assertPartEqualIgnoringDimension(
-            final File expected, final File actual, final String partName) throws Exception {
-        try (OPCPackage expectedPkg = OPCPackage.open(expected);
-             OPCPackage actualPkg = OPCPackage.open(actual)) {
-
-            final Document expectedDoc = OpcXmlHelper.parsePart(expectedPkg, partName);
-            final Document actualDoc = OpcXmlHelper.parsePart(actualPkg, partName);
-
-            _removeDimensionElements(expectedDoc);
-            _removeDimensionElements(actualDoc);
-
-            assertThat(actualDoc.getDocumentElement().isEqualNode(
-                    expectedDoc.getDocumentElement()))
-                    .as("%s DOM equality (ignoring dimension)", partName)
-                    .isTrue();
-        }
-    }
-
-    private static void _removeDimensionElements(final Document doc) {
-        final NodeList dimensions = doc.getElementsByTagNameNS(
-                "http://schemas.openxmlformats.org/spreadsheetml/2006/main", "dimension");
-        for (int i = dimensions.getLength() - 1; i >= 0; i--) {
-            final Node node = dimensions.item(i);
-            node.getParentNode().removeChild(node);
-        }
     }
 
     private static File _debugFile(final String name) throws IOException {

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/SSMLSheetWriterDomEquivalenceTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/SSMLSheetWriterDomEquivalenceTest.java
@@ -12,15 +12,9 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.apache.poi.openxml4j.opc.OPCPackage;
 import org.apache.poi.ss.usermodel.IndexedColors;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 import com.fasterxml.jackson.annotation.OptBoolean;
 
@@ -28,8 +22,6 @@ import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.style.StylesBuilder;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * DOM-level equivalence tests: SSML writer output vs POI XSSFWorkbook output.
@@ -63,7 +55,7 @@ class SSMLSheetWriterDomEquivalenceTest {
         new SpreadsheetMapper().writeValue(ssmlFile, DATA, Entry.class);
         _poiMapper().writeValue(poiFile, DATA, Entry.class);
 
-        _assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
+        XlsxDomAssertions.assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
     }
 
     // -- Nested list with outer field declared after the list ------------
@@ -86,9 +78,6 @@ class SSMLSheetWriterDomEquivalenceTest {
 
     @Test
     void sheetXmlDomEquivalent_nestedList() throws Exception {
-        Assumptions.assumeTrue(PoiVersionProbe.isPoi523OrLater(),
-                "DOM equivalence asserted only on POI 5.2.3+ — see #96");
-
         List<NestedListEntry> data = Arrays.asList(
                 new NestedListEntry(1,
                         Arrays.asList(new NestedItem("Apple", 3), new NestedItem("Banana", 5)),
@@ -100,7 +89,7 @@ class SSMLSheetWriterDomEquivalenceTest {
         new SpreadsheetMapper().writeValue(ssmlFile, data, NestedListEntry.class);
         _poiMapper().writeValue(poiFile, data, NestedListEntry.class);
 
-        _assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
+        XlsxDomAssertions.assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
     }
 
     @Test
@@ -108,9 +97,6 @@ class SSMLSheetWriterDomEquivalenceTest {
         // List XML accumulation crosses the SSML buffer threshold (~512 KB).
         // Tests that flush suspension during nested array scope keeps the
         // first element row tag present for back-write of the outer field.
-        Assumptions.assumeTrue(PoiVersionProbe.isPoi523OrLater(),
-                "DOM equivalence asserted only on POI 5.2.3+ — see #96");
-
         int innerCount = 10000;
         NestedItem[] items = new NestedItem[innerCount];
         for (int i = 0; i < innerCount; i++) {
@@ -125,16 +111,13 @@ class SSMLSheetWriterDomEquivalenceTest {
         new SpreadsheetMapper().writeValue(ssmlFile, data, NestedListEntry.class);
         _poiMapper().writeValue(poiFile, data, NestedListEntry.class);
 
-        _assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
+        XlsxDomAssertions.assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
     }
 
     @Test
     void sheetXmlDomEquivalent_nestedList_multiRecord() throws Exception {
         // _arrayScopeDepth must cycle 0 → 1 → 0 across records when the
         // root is an array of records (mapper.writeValue(list, T.class)).
-        Assumptions.assumeTrue(PoiVersionProbe.isPoi523OrLater(),
-                "DOM equivalence asserted only on POI 5.2.3+ — see #96");
-
         List<NestedListEntry> data = Arrays.asList(
                 new NestedListEntry(1,
                         Arrays.asList(new NestedItem("Apple", 3), new NestedItem("Banana", 5)),
@@ -149,7 +132,7 @@ class SSMLSheetWriterDomEquivalenceTest {
         new SpreadsheetMapper().writeValue(ssmlFile, data, NestedListEntry.class);
         _poiMapper().writeValue(poiFile, data, NestedListEntry.class);
 
-        _assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
+        XlsxDomAssertions.assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
     }
 
     // -- Two nested lists in one record, outer fields between/after ------
@@ -176,9 +159,6 @@ class SSMLSheetWriterDomEquivalenceTest {
 
     @Test
     void sheetXmlDomEquivalent_twoNestedListsPerRecord() throws Exception {
-        Assumptions.assumeTrue(PoiVersionProbe.isPoi523OrLater(),
-                "DOM equivalence asserted only on POI 5.2.3+ — see #96");
-
         List<OrderWithTwoLists> data = Arrays.asList(
                 new OrderWithTwoLists(1,
                         Arrays.asList(new NestedItem("Apple", 3), new NestedItem("Banana", 5)),
@@ -192,7 +172,7 @@ class SSMLSheetWriterDomEquivalenceTest {
         new SpreadsheetMapper().writeValue(ssmlFile, data, OrderWithTwoLists.class);
         _poiMapper().writeValue(poiFile, data, OrderWithTwoLists.class);
 
-        _assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
+        XlsxDomAssertions.assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
     }
 
     // -- List-of-list with an outer field after the inner list -----------
@@ -224,9 +204,6 @@ class SSMLSheetWriterDomEquivalenceTest {
 
     @Test
     void sheetXmlDomEquivalent_listOfList_outerAfterInnerList() throws Exception {
-        Assumptions.assumeTrue(PoiVersionProbe.isPoi523OrLater(),
-                "DOM equivalence asserted only on POI 5.2.3+ — see #96");
-
         List<GroupedOrder> data = Arrays.asList(
                 new GroupedOrder(1,
                         Arrays.asList(
@@ -244,7 +221,7 @@ class SSMLSheetWriterDomEquivalenceTest {
         new SpreadsheetMapper().writeValue(ssmlFile, data, GroupedOrder.class);
         _poiMapper().writeValue(poiFile, data, GroupedOrder.class);
 
-        _assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
+        XlsxDomAssertions.assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
     }
 
     // -- Multi-row header (@DataColumnGroup) -----------------------------
@@ -274,7 +251,7 @@ class SSMLSheetWriterDomEquivalenceTest {
         new SpreadsheetMapper().writeValue(ssmlFile, GROUPED_DATA, GroupedEntry.class);
         _poiMapper().writeValue(poiFile, GROUPED_DATA, GroupedEntry.class);
 
-        _assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
+        XlsxDomAssertions.assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
     }
 
     // -- @DataColumnGroup styled attributes: headerStyle on the group cell,
@@ -310,7 +287,7 @@ class SSMLSheetWriterDomEquivalenceTest {
         _styledMapper().writeValue(ssmlFile, data, StyledGroupedEntry.class);
         _styledPoiMapper().writeValue(poiFile, data, StyledGroupedEntry.class);
 
-        _assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
+        XlsxDomAssertions.assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
     }
 
     // -- 2-level @DataColumnGroup (3 header rows) + nested List + outer
@@ -350,9 +327,6 @@ class SSMLSheetWriterDomEquivalenceTest {
 
     @Test
     void sheetXmlDomEquivalent_twoLevelGroup_nestedList_mergeTrue() throws Exception {
-        Assumptions.assumeTrue(PoiVersionProbe.isPoi523OrLater(),
-                "DOM equivalence asserted only on POI 5.2.3+ — see #96");
-
         List<OrderWith2LevelGroupAndList> data = Arrays.asList(
                 new OrderWith2LevelGroupAndList(1, "Alice",
                         Arrays.asList(
@@ -379,7 +353,7 @@ class SSMLSheetWriterDomEquivalenceTest {
         new SpreadsheetMapper().writeValue(ssmlFile, data, OrderWith2LevelGroupAndList.class);
         _poiMapper().writeValue(poiFile, data, OrderWith2LevelGroupAndList.class);
 
-        _assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
+        XlsxDomAssertions.assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
     }
 
     @Test
@@ -390,7 +364,7 @@ class SSMLSheetWriterDomEquivalenceTest {
         new SpreadsheetMapper().writeValue(ssmlFile, DATA, Entry.class);
         _poiMapper().writeValue(poiFile, DATA, Entry.class);
 
-        _assertPartEqual(poiFile, ssmlFile, "/xl/sharedStrings.xml");
+        XlsxDomAssertions.assertPartEqual(poiFile, ssmlFile, "/xl/sharedStrings.xml");
     }
 
     // ----------------------------------------------------------------
@@ -427,66 +401,6 @@ class SSMLSheetWriterDomEquivalenceTest {
                 .stylesBuilder(_groupStyles())
                 .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL)
                 .build();
-    }
-
-    private static void _assertPartEqualIgnoringDimension(
-            final File expected, final File actual, final String partName) throws Exception {
-        try (OPCPackage expectedPkg = OPCPackage.open(expected);
-             OPCPackage actualPkg = OPCPackage.open(actual)) {
-
-            final Document expectedDoc = OpcXmlHelper.parsePart(expectedPkg, partName);
-            final Document actualDoc = OpcXmlHelper.parsePart(actualPkg, partName);
-
-            _removeDimensionElements(expectedDoc);
-            _removeDimensionElements(actualDoc);
-
-            // POI 4.x ~ 5.2.2 omit default s="0" on cells; SSML writer always emits.
-            // Strip on the SSML side so byte-equal comparison holds across versions.
-            // On POI 5.2.3+ both sides emit, and the strict check is preserved.
-            if (!PoiVersionProbe.isPoi523OrLater()) {
-                _stripDefaultStyleAttribute(actualDoc);
-            }
-
-            assertThat(actualDoc.getDocumentElement().isEqualNode(
-                    expectedDoc.getDocumentElement()))
-                    .as("%s DOM equality (ignoring dimension)", partName)
-                    .isTrue();
-        }
-    }
-
-    private static void _assertPartEqual(
-            final File expected, final File actual, final String partName) throws Exception {
-        try (OPCPackage expectedPkg = OPCPackage.open(expected);
-             OPCPackage actualPkg = OPCPackage.open(actual)) {
-
-            final Document expectedDoc = OpcXmlHelper.parsePart(expectedPkg, partName);
-            final Document actualDoc = OpcXmlHelper.parsePart(actualPkg, partName);
-
-            assertThat(actualDoc.getDocumentElement().isEqualNode(
-                    expectedDoc.getDocumentElement()))
-                    .as("%s DOM equality", partName)
-                    .isTrue();
-        }
-    }
-
-    private static void _removeDimensionElements(final Document doc) {
-        final NodeList dimensions = doc.getElementsByTagNameNS(
-                "http://schemas.openxmlformats.org/spreadsheetml/2006/main", "dimension");
-        for (int i = dimensions.getLength() - 1; i >= 0; i--) {
-            final Node node = dimensions.item(i);
-            node.getParentNode().removeChild(node);
-        }
-    }
-
-    private static void _stripDefaultStyleAttribute(final Document doc) {
-        final NodeList cells = doc.getElementsByTagNameNS(
-                "http://schemas.openxmlformats.org/spreadsheetml/2006/main", "c");
-        for (int i = 0; i < cells.getLength(); i++) {
-            final Element cell = (Element) cells.item(i);
-            if ("0".equals(cell.getAttribute("s"))) {
-                cell.removeAttribute("s");
-            }
-        }
     }
 
     private static File _debugFile(final String name) throws IOException {

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/XlsxDomAssertions.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/XlsxDomAssertions.java
@@ -1,0 +1,86 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+
+import org.apache.poi.openxml4j.opc.OPCPackage;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * DOM-equality assertions for OOXML parts, normalising POI version-specific
+ * variance so the same assertion holds across POI 4.x ~ 5.5.x.
+ */
+final class XlsxDomAssertions {
+
+    private XlsxDomAssertions() {}
+
+    /**
+     * Asserts the named part is DOM-equal between {@code expected} and
+     * {@code actual}, ignoring the {@code <dimension>} element and the
+     * default {@code s="0"} cell-style attribute that POI 5.2.3+ emits
+     * unconditionally (bug-51037 fix in {@code XSSFRow.onDocumentWrite})
+     * while earlier POI versions omit. The SSML writer always emits
+     * {@code s="0"}; strip on that side when the POI side is the older
+     * one so byte-equal comparison holds across POI versions.
+     */
+    static void assertPartEqualIgnoringDimension(
+            final File expected, final File actual, final String partName) throws Exception {
+        try (OPCPackage expectedPkg = OPCPackage.open(expected);
+             OPCPackage actualPkg = OPCPackage.open(actual)) {
+
+            final Document expectedDoc = OpcXmlHelper.parsePart(expectedPkg, partName);
+            final Document actualDoc = OpcXmlHelper.parsePart(actualPkg, partName);
+
+            _removeDimensionElements(expectedDoc);
+            _removeDimensionElements(actualDoc);
+
+            if (!PoiVersionProbe.isPoi523OrLater()) {
+                _stripDefaultStyleAttribute(actualDoc);
+            }
+
+            assertThat(actualDoc.getDocumentElement().isEqualNode(
+                    expectedDoc.getDocumentElement()))
+                    .as("%s DOM equality (ignoring dimension)", partName)
+                    .isTrue();
+        }
+    }
+
+    static void assertPartEqual(
+            final File expected, final File actual, final String partName) throws Exception {
+        try (OPCPackage expectedPkg = OPCPackage.open(expected);
+             OPCPackage actualPkg = OPCPackage.open(actual)) {
+
+            final Document expectedDoc = OpcXmlHelper.parsePart(expectedPkg, partName);
+            final Document actualDoc = OpcXmlHelper.parsePart(actualPkg, partName);
+
+            assertThat(actualDoc.getDocumentElement().isEqualNode(
+                    expectedDoc.getDocumentElement()))
+                    .as("%s DOM equality", partName)
+                    .isTrue();
+        }
+    }
+
+    private static void _removeDimensionElements(final Document doc) {
+        final NodeList dimensions = doc.getElementsByTagNameNS(
+                OpcXmlHelper.NS_SPREADSHEETML, "dimension");
+        for (int i = dimensions.getLength() - 1; i >= 0; i--) {
+            final Node node = dimensions.item(i);
+            node.getParentNode().removeChild(node);
+        }
+    }
+
+    private static void _stripDefaultStyleAttribute(final Document doc) {
+        final NodeList cells = doc.getElementsByTagNameNS(
+                OpcXmlHelper.NS_SPREADSHEETML, "c");
+        for (int i = 0; i < cells.getLength(); i++) {
+            final Element cell = (Element) cells.item(i);
+            if ("0".equals(cell.getAttribute("s"))) {
+                cell.removeAttribute("s");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Extract `XlsxDomAssertions` from the inline DOM-equality helpers in `SSMLSheetWriterDomEquivalenceTest` / `RealisticAccuracyTest`. The `IgnoringDimension` variant strips the default `s="0"` attribute on the SSML side when running against POI <5.2.3, normalising the divergence introduced by POI 5.2.3's bug-51037 fix (`XSSFRow.onDocumentWrite`).
- Drop the 15 `Assumptions.assumeTrue(PoiVersionProbe.isPoi523OrLater(), ...)` guards that previously turned the compat-min CI job into a no-op for these cases. The strict-OOXML `assumeTrue(isPoi510OrLater)` in `SSMLSheetReaderTest` stays — that one is a genuine POI 5.1.0+ capability gate, not just output divergence.
- Add two regression tests for the `@DataColumnGroup` empty-value fallback fix in PR #138. The existing tree had no coverage for that path because every `@DataColumnGroup` usage sets `value()` explicitly.

## Verification

| Test class | Before (POI 4.1.1) | After (POI 4.1.1) |
|---|---|---|
| `SSMLSheetWriterDomEquivalenceTest` | skipped=6 | **skipped=0** |
| `RealisticAccuracyTest` | skipped=9 | **skipped=0** |
| `SSMLSheetReaderTest` | skipped=1 | skipped=1 (capability gate, intentional) |

- [x] `./gradlew test` — green
- [x] `./gradlew test -PpoiVersion=4.1.1 -PjacksonVersion=2.14.0` — green, 15 cases now actually assert