### PR TITLE
Polish SoA cell-metadata internals

### DIFF
--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SheetDataBuffer.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SheetDataBuffer.java
@@ -5,6 +5,8 @@ import java.util.Arrays;
 
 import org.apache.poi.ss.util.CellReference;
 
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.BackWriteProjection;
+
 /**
  * Sheet-data accumulator using Structure of Arrays layout.
  *
@@ -41,14 +43,6 @@ final class SheetDataBuffer {
     static final byte TYPE_STRING  = 1;
     static final byte TYPE_BLANK   = 3;
     static final byte TYPE_BOOLEAN = 4;
-
-    // Internal memory footprint per cell / per row — used by byteSize()
-    // for back-write OOM monitoring. Must stay in sync with
-    // BackWriteProjection.{cellMemoryBytes, rowMemoryBytes}.
-    //   Cell SoA slots: long _packed (8) + long _values (8) + int _next (4) = 20 bytes
-    //   Row directory : int _rowHead (4) + int _rowTail (4)                 = 8 bytes
-    static final int CELL_MEMORY_BYTES = 20;
-    static final int ROW_MEMORY_BYTES = 8;
 
     // Lazy capacity inflated on first append, then grown 1.5× — same shape
     // as java.util.ArrayList. Covers typical Excel schemas (≤ 16 columns)
@@ -129,7 +123,8 @@ final class SheetDataBuffer {
      *  {@link io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.BackWriteProjection}
      *  on the same memory basis. */
     long byteSize() {
-        return (long) _size * CELL_MEMORY_BYTES + (long) _rowSpan * ROW_MEMORY_BYTES;
+        return (long) _size * BackWriteProjection.CELL_MEMORY_BYTES
+                + (long) _rowSpan * BackWriteProjection.ROW_MEMORY_BYTES;
     }
 
     /** Sink invoked after each XML fragment is appended to {@code sb} so

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/BackWriteProjection.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/BackWriteProjection.java
@@ -28,11 +28,13 @@ import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
 @Slf4j
 public final class BackWriteProjection {
 
-    // SheetDataBuffer cell SoA: long _packed (8) + long _values (8) + int _next (4)
-    private static final int CELL_MEMORY_BYTES = 20;
+    /** SoA cell record footprint — {@code long _packed (8) + long _values (8) + int _next (4)}.
+     *  Single source of truth shared with {@code SheetDataBuffer.byteSize()}. */
+    public static final int CELL_MEMORY_BYTES = 20;
 
-    // SheetDataBuffer row directory: int _rowHead (4) + int _rowTail (4)
-    private static final int ROW_MEMORY_BYTES = 8;
+    /** SoA row directory entry footprint — {@code int _rowHead (4) + int _rowTail (4)}.
+     *  Single source of truth shared with {@code SheetDataBuffer.byteSize()}. */
+    public static final int ROW_MEMORY_BYTES = 8;
 
     /** Cache for {@link #requiresBackWriteScope(SpreadsheetSchema)} keyed on
      *  schema identity. WeakHashMap so schemas reclaimed by GC drop their
@@ -45,31 +47,13 @@ public final class BackWriteProjection {
     private BackWriteProjection() {
     }
 
-    /** SoA heap footprint of one buffered cell (constant across cell types).
-     *
-     *  <p>Every supported Java type writes a single cell into
-     *  {@code SheetDataBuffer}'s SoA arrays — numerics
-     *  ({@code writeNumber(int|long|float|double|BigDecimal)} and
-     *  {@code Date} / {@code java.time.*}) land via
-     *  {@code Double.doubleToRawLongBits}, strings / enums via the
-     *  shared-string index, booleans as 0/1, blanks as 0. Each occupies
-     *  one slot in {@code _packed}, {@code _values}, and {@code _next} —
-     *  20 bytes total. The {@code column} argument is kept for symmetry
-     *  with future per-type accounting and unused today. */
-    public static int cellMaxBytes(final Column column) {
-        return CELL_MEMORY_BYTES;
-    }
-
     /** SoA heap footprint of one inner row — every column's cell record
-     *  plus a row directory entry. */
+     *  ({@link #CELL_MEMORY_BYTES}) plus the row directory entry
+     *  ({@link #ROW_MEMORY_BYTES}). */
     public static long innerRowMaxBytes(
             final SpreadsheetSchema schema, final ColumnPointer arrayPointer) {
         final List<Column> inners = schema.getColumns(arrayPointer);
-        long bytes = ROW_MEMORY_BYTES;
-        for (final Column c : inners) {
-            bytes += cellMaxBytes(c);
-        }
-        return bytes;
+        return (long) ROW_MEMORY_BYTES + (long) inners.size() * CELL_MEMORY_BYTES;
     }
 
     /** Projected back-write buffer max for a nested list of

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/BackWriteProjectionTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/BackWriteProjectionTest.java
@@ -1,12 +1,8 @@
 package io.github.scndry.jackson.dataformat.spreadsheet;
 
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.util.Date;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.OptBoolean;
-import com.fasterxml.jackson.databind.type.SimpleType;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -20,53 +16,19 @@ import io.github.scndry.jackson.dataformat.spreadsheet.schema.ColumnPointer;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.BackWriteProjection;
 
+import static io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.BackWriteProjection.CELL_MEMORY_BYTES;
+import static io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.BackWriteProjection.ROW_MEMORY_BYTES;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Unit-level checks for the back-write projection — guards the
- * cell-XML upper bound, the linear scaling against list size, the
- * heap-aware limit defaults, and the schema-level scope detection.
+ * linear scaling of {@link BackWriteProjection#project} against list
+ * size, the heap-aware limit defaults, and the schema-level scope
+ * detection.
  *
- * <p>These rules are documented in
- * {@link BackWriteProjection#cellMaxBytes(Column)} and
- * {@link BackWriteProjection#backWriteBufferLimit()}; a regression here
- * would silently weaken the back-write OOM guard.
+ * <p>A regression here would silently weaken the back-write OOM guard.
  */
 class BackWriteProjectionTest {
-
-    // SoA internal memory units — must stay in sync with
-    // BackWriteProjection.{CELL_MEMORY_BYTES, ROW_MEMORY_BYTES}.
-    private static final int CELL_MEMORY_BYTES = 20;
-    private static final int ROW_MEMORY_BYTES = 8;
-
-    // ----------------------------------------------------------------
-    // cellMaxBytes — SoA cell record is a fixed 20 bytes regardless of
-    // Java type (long _packed + long _values + int _next).
-    // ----------------------------------------------------------------
-
-    @Test
-    void cellMaxBytes_isConstantAcrossAllSupportedTypes() {
-        assertThat(BackWriteProjection.cellMaxBytes(_column(boolean.class))).isEqualTo(CELL_MEMORY_BYTES);
-        assertThat(BackWriteProjection.cellMaxBytes(_column(Boolean.class))).isEqualTo(CELL_MEMORY_BYTES);
-        assertThat(BackWriteProjection.cellMaxBytes(_column(String.class))).isEqualTo(CELL_MEMORY_BYTES);
-        assertThat(BackWriteProjection.cellMaxBytes(_column(SampleEnum.class))).isEqualTo(CELL_MEMORY_BYTES);
-        assertThat(BackWriteProjection.cellMaxBytes(_column(BigDecimal.class))).isEqualTo(CELL_MEMORY_BYTES);
-        assertThat(BackWriteProjection.cellMaxBytes(_column(BigInteger.class))).isEqualTo(CELL_MEMORY_BYTES);
-        assertThat(BackWriteProjection.cellMaxBytes(_column(int.class))).isEqualTo(CELL_MEMORY_BYTES);
-        assertThat(BackWriteProjection.cellMaxBytes(_column(long.class))).isEqualTo(CELL_MEMORY_BYTES);
-        assertThat(BackWriteProjection.cellMaxBytes(_column(float.class))).isEqualTo(CELL_MEMORY_BYTES);
-        assertThat(BackWriteProjection.cellMaxBytes(_column(double.class))).isEqualTo(CELL_MEMORY_BYTES);
-        assertThat(BackWriteProjection.cellMaxBytes(_column(Date.class))).isEqualTo(CELL_MEMORY_BYTES);
-    }
-
-    enum SampleEnum { A }
-
-    private static Column _column(final Class<?> raw) {
-        return new Column(
-                ColumnPointer.empty().resolve("x"),
-                DataColumn.Value.empty(),
-                SimpleType.constructUnsafe(raw));
-    }
 
     // ----------------------------------------------------------------
     // project — linear in list size, sums every inner column's bound


### PR DESCRIPTION
## Summary

Two related back-write internals cleanups in `SheetDataBuffer` / `BackWriteProjection`:

- **Deduplicate `CELL_MEMORY_BYTES` / `ROW_MEMORY_BYTES`**. The two constants lived in both classes as package-private duplicates, kept in sync only by a *"must stay in sync"* comment. Promote `BackWriteProjection`'s pair to `public static final` and have `SheetDataBuffer.byteSize` reference them — single source of truth, compiler-checked.
- **Drop `BackWriteProjection.cellMaxBytes(Column)`**. The method ignored its `Column` argument and returned the same constant for every type. Its javadoc kept it *"for future per-type accounting"*, but the SoA layout is fixed-width by design (`long _packed + long _values + int _next`) — per-type accounting is not meaningful on top of this layout. `innerRowMaxBytes` now computes `ROW + inners.size() * CELL` directly.

`BackWriteProjectionTest` loses the redundant `cellMaxBytes_isConstantAcrossAllSupportedTypes` case and imports `CELL_MEMORY_BYTES` / `ROW_MEMORY_BYTES` statically from `BackWriteProjection`, so the assertions track the source.

## Test plan

- [x] `./gradlew test` — green
- [x] `./gradlew test -PpoiVersion=4.1.1 -PjacksonVersion=2.14.0` — green