### PR TITLE
Bump to 1.6.3

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -14,7 +14,7 @@
 
 | Library | Version |
 |---------|---------|
-| jackson-dataformat-spreadsheet | 1.6.2 |
+| jackson-dataformat-spreadsheet | 1.6.3 |
 | Apache POI | 5.5.1 |
 | FastExcel | 0.20.0 |
 | Fesod | 2.0.1-incubating |

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -57,13 +57,13 @@ POI types (`Sheet`, `Workbook`) are first-class I/O targets — see [POI Integra
 <dependency>
     <groupId>io.github.scndry</groupId>
     <artifactId>jackson-dataformat-spreadsheet</artifactId>
-    <version>1.6.2</version>
+    <version>1.6.3</version>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-implementation "io.github.scndry:jackson-dataformat-spreadsheet:1.6.2"
+implementation "io.github.scndry:jackson-dataformat-spreadsheet:1.6.3"
 ```
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ Available on Maven Central:
 <dependency>
     <groupId>io.github.scndry</groupId>
     <artifactId>jackson-dataformat-spreadsheet</artifactId>
-    <version>1.6.2</version>
+    <version>1.6.3</version>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-implementation "io.github.scndry:jackson-dataformat-spreadsheet:1.6.2"
+implementation "io.github.scndry:jackson-dataformat-spreadsheet:1.6.3"
 ```
 
 ### Requirements
@@ -277,7 +277,7 @@ Fastest read and write throughput at 100K rows, with the lowest write memory. 6x
 XLSX (OOXML) and XLS (legacy). XLSX uses StAX streaming; XLS uses POI object model.
 
 **Q: Is it production-ready?**
-Yes. Version 1.6.2 on Maven Central. Java 8+, Jackson 2.14+, POI 4.1.1+. Listed as a [community data format module](https://github.com/FasterXML/jackson#data-format-modules) in the FasterXML jackson repository.
+Yes. Version 1.6.3 on Maven Central. Java 8+, Jackson 2.14+, POI 4.1.1+. Listed as a [community data format module](https://github.com/FasterXML/jackson#data-format-modules) in the FasterXML jackson repository.
 
 **Q: Is the mapper thread-safe?**
 The mapper instance is reusable across threads once configured (same rule as Jackson's `ObjectMapper`). Concurrent calls with `File` / `InputStream` / `OutputStream` inputs are safe — the library opens an isolated `Workbook` per call. If you pass a `Sheet` directly, POI's `Workbook`/`Sheet` are not thread-safe, so each thread needs its own.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "io.github.scndry"
-version = "1.6.3-SNAPSHOT"
+version = "1.6.3"
 description = "Support for reading and writing Excel (XLSX/XLS) via Jackson abstractions."
 
 val title = "Jackson dataformat: Spreadsheet"


### PR DESCRIPTION
## Summary

Drop the `-SNAPSHOT` from the artifact and align the user-facing version snippets in README / GUIDE / BENCHMARK from 1.6.2 to 1.6.3 ahead of the v1.6.3 tag push.

## 1.6.3 highlights (since 1.6.2)

- #137 `@DataColumnGroup` mirrors the `@DataGrid` cascade slots and adds the group header style attribute.
- #138 `Styles` interface distilled to two lookup primitives (`byName` / `byType`) with a default `resolve` helper. `HeaderComments` extracted from `SpreadsheetSchema` (POI Drawing / Comment imports gone). `@DataColumnGroup` empty-value fallback now uses the column-pointer path (consistent with `@DataColumn`). GUIDE / README polished for AI-agent readability.
- #139 Cross-POI-version DOM equivalence — 15 cases that previously skipped on POI 4.1.1 now assert via a normalising `XlsxDomAssertions` helper. Regression test added for the `@DataColumnGroup` empty-value fallback.
- #140 SoA cell-metadata constants deduplicated; `BackWriteProjection.cellMaxBytes(Column)` simplified.

## Test plan

- [x] `./gradlew test` — green
- [x] `./gradlew test -PpoiVersion=4.1.1 -PjacksonVersion=2.14.0` — green