### PR TITLE
Close merge region inner cells for cell-by-cell viewers

### DIFF
--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLSheetWriter.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLSheetWriter.java
@@ -161,22 +161,27 @@ public final class SSMLSheetWriter implements SheetWriter {
                                        final DataColumnGroup.Value group) {
                 setReference(new CellAddress(row, firstCol));
                 final CellStyle gs = _styles.resolve(group.getHeaderStyle(), null);
+                final int groupStyleIdx;
                 if (gs == null) {
                     writeString(group.getName());
+                    groupStyleIdx = 0;
                 } else {
+                    groupStyleIdx = gs.getIndex();
                     final int sstIdx = _cacheString(group.getName());
                     _flushIfForwardJump();
-                    _data.appendString(row, firstCol, gs.getIndex(), sstIdx);
+                    _data.appendString(row, firstCol, groupStyleIdx, sstIdx);
                     _checkBufferLimitInArrayScope();
                 }
                 if (firstCol < lastCol) {
                     _mergeRanges.add(new MergeRange(row, row, firstCol, lastCol));
+                    _fillMergedInnerCellsHorizontal(row, firstCol, lastCol, groupStyleIdx);
                 }
             }
 
             @Override
             public void visitVerticalMerge(final int firstRow, final int lastRow, final int col) {
                 _mergeRanges.add(new MergeRange(firstRow, lastRow, col, col));
+                _fillMergedInnerCellsVertical(firstRow, lastRow, col, _headerStyleIndexForColumn(col));
             }
         });
     }
@@ -269,7 +274,46 @@ public final class SSMLSheetWriter implements SheetWriter {
             final int col = _schema.columnIndexOf(column);
             if (col < 0) continue;
             _mergeRanges.add(new MergeRange(row, row + size - 1, col, col));
+            _fillMergedInnerCellsVertical(row, row + size - 1, col, _dataStyleIndexForColumn(col));
         }
+    }
+
+    /** Fill the inner cells of a vertical merge with the same style as the
+     *  top cell so cell-by-cell viewers (LibreOffice / Numbers) render the
+     *  merged region as a closed rectangle. Only triggers when the column
+     *  has an explicit style index — without one, the inner cells are
+     *  left untouched, matching POI's writer (which also skips
+     *  {@code setCellStyle} in that case). */
+    private void _fillMergedInnerCellsVertical(final int firstRow, final int lastRow,
+                                               final int col, final int styleIdx) {
+        if (styleIdx <= 0) return;
+        for (int r = firstRow + 1; r <= lastRow; r++) {
+            _data.appendBlank(r, col, styleIdx);
+        }
+    }
+
+    /** Horizontal counterpart of
+     *  {@link #_fillMergedInnerCellsVertical} for group-header merges. */
+    private void _fillMergedInnerCellsHorizontal(final int row, final int firstCol,
+                                                 final int lastCol, final int styleIdx) {
+        if (styleIdx <= 0) return;
+        for (int c = firstCol + 1; c <= lastCol; c++) {
+            _data.appendBlank(row, c, styleIdx);
+        }
+    }
+
+    private int _dataStyleIndexForColumn(final int col) {
+        if (_columnStyleIndex == null) return 0;
+        final int idx = col - _schema.getOriginColumn();
+        if (idx < 0 || idx >= _columnStyleIndex.length) return 0;
+        return _columnStyleIndex[idx];
+    }
+
+    private int _headerStyleIndexForColumn(final int col) {
+        if (_headerColumnStyleIndex == null) return 0;
+        final int idx = col - _schema.getOriginColumn();
+        if (idx < 0 || idx >= _headerColumnStyleIndex.length) return 0;
+        return _headerColumnStyleIndex[idx];
     }
 
     @Override

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SheetDataBuffer.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SheetDataBuffer.java
@@ -208,8 +208,33 @@ final class SheetDataBuffer {
                 _rowHead[rowOffset] = cellIdx;
                 _rowTail[rowOffset] = cellIdx;
             } else {
-                _next[_rowTail[rowOffset]] = cellIdx;
-                _rowTail[rowOffset] = cellIdx;
+                final int tailCol = (int) ((_packed[_rowTail[rowOffset]] >>> COL_SHIFT) & COL_MASK);
+                if (col >= tailCol) {
+                    // Fast path — forward column-ascending append (typical case).
+                    _next[_rowTail[rowOffset]] = cellIdx;
+                    _rowTail[rowOffset] = cellIdx;
+                } else {
+                    // Slow path — out-of-order column insertion (merge inner-cell
+                    // fill emitted after inner items). OOXML strict readers
+                    // require ascending cell-reference order within a row.
+                    final int head = _rowHead[rowOffset];
+                    final int headCol = (int) ((_packed[head] >>> COL_SHIFT) & COL_MASK);
+                    if (col < headCol) {
+                        _next[cellIdx] = head;
+                        _rowHead[rowOffset] = cellIdx;
+                    } else {
+                        int prev = head;
+                        while (true) {
+                            final int nxt = _next[prev];
+                            if (nxt < 0) break;
+                            final int nxtCol = (int) ((_packed[nxt] >>> COL_SHIFT) & COL_MASK);
+                            if (col < nxtCol) break;
+                            prev = nxt;
+                        }
+                        _next[cellIdx] = _next[prev];
+                        _next[prev] = cellIdx;
+                    }
+                }
             }
         }
         _size++;

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ss/POISheetWriter.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ss/POISheetWriter.java
@@ -106,12 +106,18 @@ public final class POISheetWriter implements SheetWriter {
                 }
                 if (firstCol < lastCol) {
                     _sheet.addMergedRegion(new CellRangeAddress(row, row, firstCol, lastCol));
+                    _fillMergedInnerCellsHorizontal(row, firstCol, lastCol, gs);
                 }
             }
 
             @Override
             public void visitVerticalMerge(final int firstRow, final int lastRow, final int col) {
                 _sheet.addMergedRegion(new CellRangeAddress(firstRow, lastRow, col, col));
+                final Column column = _schema.findColumn(new CellAddress(firstRow, col));
+                final CellStyle hs = column == null ? null
+                        : _styles.resolve(column.getValue().getHeaderStyle(),
+                                column.getType().getRawClass());
+                _fillMergedInnerCellsVertical(firstRow, lastRow, col, hs);
             }
         });
     }
@@ -211,6 +217,32 @@ public final class POISheetWriter implements SheetWriter {
                 log.trace(region.formatAsString());
             }
             _sheet.addMergedRegion(region);
+            final CellStyle ds = _styles.resolve(column.getValue().getStyle(),
+                    column.getType().getRawClass());
+            _fillMergedInnerCellsVertical(row, row + size - 1, col, ds);
+        }
+    }
+
+    /** Fill the inner cells of a vertical merge with the same style as the
+     *  top cell so cell-by-cell viewers (LibreOffice / Numbers) render the
+     *  merged region as a closed rectangle. Only triggers when the column
+     *  has an explicit style — without one, the inner cells are left
+     *  untouched (no cell entry created), matching SSML's writer. */
+    private void _fillMergedInnerCellsVertical(final int firstRow, final int lastRow,
+                                               final int col, final CellStyle style) {
+        if (style == null) return;
+        for (int r = firstRow + 1; r <= lastRow; r++) {
+            CellUtil.getCell(CellUtil.getRow(r, _sheet), col).setCellStyle(style);
+        }
+    }
+
+    /** Horizontal counterpart of
+     *  {@link #_fillMergedInnerCellsVertical} for group-header merges. */
+    private void _fillMergedInnerCellsHorizontal(final int row, final int firstCol,
+                                                 final int lastCol, final CellStyle style) {
+        if (style == null) return;
+        for (int c = firstCol + 1; c <= lastCol; c++) {
+            CellUtil.getCell(CellUtil.getRow(row, _sheet), c).setCellStyle(style);
         }
     }
 

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/MergeRegionInnerCellsTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/MergeRegionInnerCellsTest.java
@@ -1,0 +1,149 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.OptBoolean;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.Test;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.style.StylesBuilder;
+
+/**
+ * Asserts SSML and POI writers produce byte-equal sheet1.xml for merge layouts
+ * that exercise the inner-cell fill paths — column merges, group-header
+ * merges, multi-row header merges, and nested-list outer-field merges, all
+ * with a border-bearing column style so {@code _fillMergedInnerCells*} fires
+ * on both writers. The existing {@code SSMLSheetWriterDomEquivalenceTest}
+ * scenarios skip inner-cell fill because their columns carry no style.
+ */
+class MergeRegionInnerCellsTest {
+
+    private static final Path DEBUG_OUTPUT_DIR = Paths.get("build/debug-output");
+
+    private static StylesBuilder _borderStyles() {
+        return new StylesBuilder().cellStyle("border").border().thin().end();
+    }
+
+    private static SpreadsheetMapper _ssmlMapper() {
+        return SpreadsheetMapper.builder().stylesBuilder(_borderStyles()).build();
+    }
+
+    private static SpreadsheetMapper _poiMapper() {
+        return SpreadsheetMapper.builder(
+                new SpreadsheetFactory(XSSFWorkbook::new,
+                        SpreadsheetFactory.DEFAULT_SHEET_PARSER_FEATURE_FLAGS)
+                        .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL))
+                .stylesBuilder(_borderStyles())
+                .build();
+    }
+
+    private static File _debugFile(final String name) throws IOException {
+        Files.createDirectories(DEBUG_OUTPUT_DIR);
+        return DEBUG_OUTPUT_DIR.resolve(name).toFile();
+    }
+
+    // (1) Vertical column merge — @DataColumn(merge = TRUE).
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    @DataGrid(columnStyle = "border", columnHeaderStyle = "border")
+    static class VerticalMergeRow {
+        @DataColumn(value = "group", merge = OptBoolean.TRUE) String group;
+        @DataColumn("value") int value;
+    }
+
+    @Test
+    void verticalColumnMerge_ssmlEqualsPoi() throws Exception {
+        final List<VerticalMergeRow> data = Arrays.asList(
+                new VerticalMergeRow("A", 1),
+                new VerticalMergeRow("A", 2),
+                new VerticalMergeRow("B", 3));
+
+        final File ssmlFile = _debugFile("merge-inner-vertical-ssml.xlsx");
+        final File poiFile = _debugFile("merge-inner-vertical-poi.xlsx");
+        _ssmlMapper().writeValue(ssmlFile, data, VerticalMergeRow.class);
+        _poiMapper().writeValue(poiFile, data, VerticalMergeRow.class);
+
+        XlsxDomAssertions.assertPartEqualIgnoringDimension(
+                poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
+    }
+
+    // (2) Horizontal group-header merge + (3) multi-row header vertical merge
+    // — same layout fires both paths: @DataColumnGroup horizontally merges
+    // "Address" across zipcode/city, while {@code id}/{@code name} columns
+    // vertically merge across the two-row header.
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    @DataGrid(columnStyle = "border", columnHeaderStyle = "border", groupHeaderStyle = "border")
+    static class MultiRowHeaderRow {
+        int id;
+        String name;
+        @DataColumnGroup("Address") Address address;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class Address {
+        @DataColumn("zipcode") String zipcode;
+        @DataColumn("city") String city;
+    }
+
+    @Test
+    void multiRowHeaderAndGroupMerge_ssmlEqualsPoi() throws Exception {
+        final List<MultiRowHeaderRow> data = Arrays.asList(
+                new MultiRowHeaderRow(1, "Alice", new Address("12345", "Seoul")),
+                new MultiRowHeaderRow(2, "Bob", new Address("67890", "Busan")));
+
+        final File ssmlFile = _debugFile("merge-inner-hdr-ssml.xlsx");
+        final File poiFile = _debugFile("merge-inner-hdr-poi.xlsx");
+        _ssmlMapper().writeValue(ssmlFile, data, MultiRowHeaderRow.class);
+        _poiMapper().writeValue(poiFile, data, MultiRowHeaderRow.class);
+
+        XlsxDomAssertions.assertPartEqualIgnoringDimension(
+                poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
+    }
+
+    // (4) Nested list outer-field merge — outer column merged across inner
+    // list rows via mergeScopedColumns; fires the back-write path so the
+    // inner-cell fill happens after inner items emit.
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    @DataGrid(columnStyle = "border", columnHeaderStyle = "border", groupHeaderStyle = "border")
+    static class NestedListOrder {
+        @DataColumn(value = "id", merge = OptBoolean.TRUE) int id;
+        @DataColumnGroup("Items") List<LineItem> items;
+        @DataColumn(value = "total", merge = OptBoolean.TRUE) double total;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class LineItem {
+        @DataColumn("sku") String sku;
+        @DataColumn("qty") int qty;
+    }
+
+    @Test
+    void nestedListOuterMerge_ssmlEqualsPoi() throws Exception {
+        final List<NestedListOrder> data = Arrays.asList(
+                new NestedListOrder(1,
+                        Arrays.asList(new LineItem("A1", 3), new LineItem("A2", 5)),
+                        80.0));
+
+        final File ssmlFile = _debugFile("merge-inner-nested-ssml.xlsx");
+        final File poiFile = _debugFile("merge-inner-nested-poi.xlsx");
+        _ssmlMapper().writeValue(ssmlFile, data, NestedListOrder.class);
+        _poiMapper().writeValue(poiFile, data, NestedListOrder.class);
+
+        XlsxDomAssertions.assertPartEqualIgnoringDimension(
+                poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
+    }
+}


### PR DESCRIPTION
## Summary
- Fill inner cells of merged regions with the anchor cell's style so
  cell-by-cell viewers (LibreOffice, Numbers) render the merge as a
  closed rectangle instead of leaving gaps along the boundary. POI's
  `RegionUtil` pattern requires application code to apply borders
  to inner cells manually — this brings the library to do that work
  itself on every merge path.
- Applies to the four merge-emission paths: vertical column merge
  (`mergeScopedColumns`), horizontal group-header merge
  (`visitGroupCell`), multi-row header vertical merge
  (`visitVerticalMerge`), and nested-list outer-field merge
  (back-write path) — on both SSML and POI writers.
- Skipped when the anchor has no explicit style, keeping DOM outputs
  aligned across both writers (POI's `setCellStyle` would not fire
  in that case either).
- `SheetDataBuffer._append` gains a column-ascending insertion-sort
  fast/slow path so out-of-order back-write appends — outer-field
  merge inner cells emitted after the inner items' cells — still emit
  in OOXML-required column-asc order within a row.

## Test plan
- [x] `MergeRegionInnerCellsTest` covers the four merge paths,
      SSML vs POI byte-equal `sheet1.xml` with a border-bearing column
      style; existing equivalence scenarios skip the inner-cell fill
      because their columns carry no style.
- [x] Full suite under POI 5.5.1 (default).
- [x] Full suite under POI 4.1.1 compat-min
      (`./gradlew test -PpoiVersion=4.1.1 -PjacksonVersion=2.14.0`).
- [x] LibreOffice visual check via examples `visualFixtures` —
      `data-column-group.png`, `data-column-group-list.png`,
      `data-column-group-cascade.png`, `merge-write.png` regenerated
      against a SNAPSHOT lib build; borders render closed in all four.