### PR TITLE
Inherit column header style on group cell inner-fill

### DIFF
--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLSheetWriter.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLSheetWriter.java
@@ -161,20 +161,20 @@ public final class SSMLSheetWriter implements SheetWriter {
                                        final DataColumnGroup.Value group) {
                 setReference(new CellAddress(row, firstCol));
                 final CellStyle gs = _styles.resolve(group.getHeaderStyle(), null);
-                final int groupStyleIdx;
+                final int anchorStyleIdx;
                 if (gs == null) {
                     writeString(group.getName());
-                    groupStyleIdx = 0;
+                    anchorStyleIdx = _headerStyleIndexForColumn(firstCol);
                 } else {
-                    groupStyleIdx = gs.getIndex();
+                    anchorStyleIdx = gs.getIndex();
                     final int sstIdx = _cacheString(group.getName());
                     _flushIfForwardJump();
-                    _data.appendString(row, firstCol, groupStyleIdx, sstIdx);
+                    _data.appendString(row, firstCol, anchorStyleIdx, sstIdx);
                     _checkBufferLimitInArrayScope();
                 }
                 if (firstCol < lastCol) {
                     _mergeRanges.add(new MergeRange(row, row, firstCol, lastCol));
-                    _fillMergedInnerCellsHorizontal(row, firstCol, lastCol, groupStyleIdx);
+                    _fillMergedInnerCellsHorizontal(row, firstCol, lastCol, anchorStyleIdx);
                 }
             }
 

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ss/POISheetWriter.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ss/POISheetWriter.java
@@ -101,12 +101,19 @@ public final class POISheetWriter implements SheetWriter {
                 setReference(new CellAddress(row, firstCol));
                 writeString(group.getName());
                 final CellStyle gs = _styles.resolve(group.getHeaderStyle(), null);
+                final CellStyle anchorStyle;
                 if (gs != null) {
                     CellUtil.getCell(CellUtil.getRow(row, _sheet), firstCol).setCellStyle(gs);
+                    anchorStyle = gs;
+                } else {
+                    final Column column = _schema.findColumn(new CellAddress(row, firstCol));
+                    anchorStyle = column == null ? null
+                            : _styles.resolve(column.getValue().getHeaderStyle(),
+                                    column.getType().getRawClass());
                 }
                 if (firstCol < lastCol) {
                     _sheet.addMergedRegion(new CellRangeAddress(row, row, firstCol, lastCol));
-                    _fillMergedInnerCellsHorizontal(row, firstCol, lastCol, gs);
+                    _fillMergedInnerCellsHorizontal(row, firstCol, lastCol, anchorStyle);
                 }
             }
 

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/MergeRegionInnerCellsTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/MergeRegionInnerCellsTest.java
@@ -113,6 +113,34 @@ class MergeRegionInnerCellsTest {
                 poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
     }
 
+    // (2b) Group header merge with NO explicit groupHeaderStyle — the anchor
+    // cell inherits columnHeaderStyle via the writeString path, and the inner
+    // cells must inherit the same style. Without the fix the inner cells stay
+    // empty and the border breaks along the group region.
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    @DataGrid(columnStyle = "border", columnHeaderStyle = "border")
+    static class GroupHeaderInheritsRow {
+        int id;
+        String name;
+        @DataColumnGroup("Address") Address address;
+    }
+
+    @Test
+    void groupCellInheritsColumnHeaderStyle_ssmlEqualsPoi() throws Exception {
+        final List<GroupHeaderInheritsRow> data = Arrays.asList(
+                new GroupHeaderInheritsRow(1, "Alice", new Address("12345", "Seoul")),
+                new GroupHeaderInheritsRow(2, "Bob", new Address("67890", "Busan")));
+
+        final File ssmlFile = _debugFile("merge-inner-group-inherit-ssml.xlsx");
+        final File poiFile = _debugFile("merge-inner-group-inherit-poi.xlsx");
+        _ssmlMapper().writeValue(ssmlFile, data, GroupHeaderInheritsRow.class);
+        _poiMapper().writeValue(poiFile, data, GroupHeaderInheritsRow.class);
+
+        XlsxDomAssertions.assertPartEqualIgnoringDimension(
+                poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
+    }
+
     // (4) Nested list outer-field merge — outer column merged across inner
     // list rows via mergeScopedColumns; fires the back-write path so the
     // inner-cell fill happens after inner items emit.


### PR DESCRIPTION
## Summary
- `visitGroupCell`'s `gs == null` path was blocked by PR #143's
  `_fillMergedInnerCells` early-return guard, leaving inner cells
  unstyled and producing a discontinuous group-region border in
  LibreOffice / Numbers.
- Both writers now pass the anchor's effective style (`gs`,
  otherwise the column header style for `firstCol`) to
  `_fillMergedInnerCellsHorizontal`.

## Test plan
- [x] `MergeRegionInnerCellsTest.groupCellInheritsColumnHeaderStyle_ssmlEqualsPoi`
      — `@DataGrid(columnHeaderStyle = "border")` + `@DataColumnGroup`
      without an explicit group `headerStyle`; SSML vs POI byte-equal
      `sheet1.xml`.
- [x] Full suite under POI 5.5.1 + POI 4.1.1 compat-min.
- [x] LibreOffice visual check — pre-fix shows the anchor's top
      border only, post-fix shows the merge region as a closed
      rectangle.