### PR TITLE
Bump to 1.6.5-SNAPSHOT

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "io.github.scndry"
-version = "1.6.4"
+version = "1.6.5-SNAPSHOT"
 description = "Support for reading and writing Excel (XLSX/XLS) via Jackson abstractions."
 
 val title = "Jackson dataformat: Spreadsheet"


### PR DESCRIPTION
## Summary

Restore the `-SNAPSHOT` qualifier on the artifact after the v1.6.4 tag was published. User-facing version snippets in README / GUIDE / BENCHMARK stay at 1.6.4 — the released coordinates.