### PR TITLE
Raise coverage with meaningful tests; deprecate writeValuesAsArray

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -148,6 +148,7 @@ jmh {
 tasks.jacocoTestReport {
     reports {
         csv.required.set(true)
+        xml.required.set(true)
     }
 }
 

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SpreadsheetWriter.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SpreadsheetWriter.java
@@ -111,10 +111,24 @@ public final class SpreadsheetWriter extends ObjectWriter {
         return _newSequenceWriter(false, createGenerator(out), true);
     }
 
+    /**
+     * @deprecated since 1.6.5, scheduled for removal in a future major release.
+     * The outer array wrapping is a no-op on a spreadsheet target — a spreadsheet's
+     * natural data model is already an array of rows, so the result is identical to
+     * {@link #writeValues(Sheet)}. Use that instead.
+     */
+    @Deprecated
     public SequenceWriter writeValuesAsArray(final Sheet out) throws IOException {
         return _newSequenceWriter(true, createGenerator(out), true);
     }
 
+    /**
+     * @deprecated since 1.6.5, scheduled for removal in a future major release.
+     * The outer array wrapping is a no-op on a spreadsheet target — a spreadsheet's
+     * natural data model is already an array of rows, so the result is identical to
+     * {@link #writeValues(SheetOutput)}. Use that instead.
+     */
+    @Deprecated
     public SequenceWriter writeValuesAsArray(final SheetOutput<?> out) throws IOException {
         return _newSequenceWriter(true, createGenerator(out), true);
     }

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/BackWriteProjectionTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/BackWriteProjectionTest.java
@@ -1,5 +1,8 @@
 package io.github.scndry.jackson.dataformat.spreadsheet;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.OptBoolean;
@@ -8,6 +11,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
@@ -19,6 +23,7 @@ import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.BackWrite
 import static io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.BackWriteProjection.CELL_MEMORY_BYTES;
 import static io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.BackWriteProjection.ROW_MEMORY_BYTES;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Unit-level checks for the back-write projection — guards the
@@ -118,6 +123,41 @@ class BackWriteProjectionTest {
     void requiresBackWriteScope_outerFirstReturnsFalse() throws Exception {
         final SpreadsheetSchema schema = _schemaFor(OuterFirst.class);
         assertThat(BackWriteProjection.requiresBackWriteScope(schema)).isFalse();
+    }
+
+    // ----------------------------------------------------------------
+    // Integration — writeStartArray's fail-fast on projected overflow
+    // ----------------------------------------------------------------
+
+    @TempDir File tempDir;
+
+    @Test
+    void writeStartArray_projectionExceedsLimit_throwsWithMitigationGuidance() throws Exception {
+        // Outer has back-write scope (list followed by outer field). Compute
+        // the boundary list size that just trips the projection limit and
+        // verify the message contract — operator size, the projected and
+        // limit byte figures, and the three mitigation options.
+        final SpreadsheetMapper mapper = new SpreadsheetMapper();
+        final SpreadsheetSchema schema = mapper.sheetSchemaFor(Outer.class);
+        final ColumnPointer arrayPointer = _findInnerArrayPointer(schema);
+        final long perRow = BackWriteProjection.project(schema, arrayPointer, 1);
+        final long limit = BackWriteProjection.backWriteBufferLimit();
+        final int overflowSize = Math.toIntExact(limit / perRow + 1);
+
+        final List<Inner> items = new ArrayList<>(overflowSize);
+        for (int i = 0; i < overflowSize; i++) items.add(new Inner(i));
+        final Outer outer = new Outer(1, items, 100);
+
+        final File file = new File(tempDir, "overflow.xlsx");
+
+        assertThatThrownBy(() -> mapper.writeValue(
+                        file, Collections.singletonList(outer), Outer.class))
+                .rootCause()
+                .isInstanceOf(SheetStreamWriteException.class)
+                .hasMessageContaining("Nested list size " + overflowSize)
+                .hasMessageContaining("projected back-write")
+                .hasMessageContaining("exceeds limit")
+                .hasMessageContaining("USE_POI_USER_MODEL");
     }
 
     // ----------------------------------------------------------------

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/ConditionalFormattingTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/ConditionalFormattingTest.java
@@ -19,12 +19,22 @@ import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.openxml4j.opc.OPCPackage;
+import org.apache.poi.ss.usermodel.BorderFormatting;
+import org.apache.poi.ss.usermodel.BorderStyle;
+import org.apache.poi.ss.usermodel.Font;
+import org.apache.poi.ss.usermodel.FontFormatting;
+import org.apache.poi.ss.usermodel.Sheet;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -612,6 +622,62 @@ class ConditionalFormattingTest {
         try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
             return wb.getSheetAt(0).getSheetConditionalFormatting()
                     .getConditionalFormattingAt(0).getRule(0);
+        }
+    }
+
+    @Test
+    void hssfPathConditionalFormattingFontAndBorder() throws Exception {
+        // HSSF (.xls) workbook routes font color, underline, font height, and
+        // border color through the indexed-color path of GridConfigurer's
+        // dxf builder — distinct from the XSSF color object path.
+        File file = new File(tempDir, "cf-hssf.xls");
+        List<Score> data = Arrays.asList(new Score("Alice", 90), new Score("Bob", 50));
+
+        SpreadsheetMapper mapper = SpreadsheetMapper.builder()
+                .stylesBuilder(new StylesBuilder()
+                        .cellStyle("highlight")
+                            .font()
+                                .bold()
+                                .fontHeight((short) 14)
+                                .color(IndexedColors.WHITE)
+                                .underline().single()
+                                .end()
+                            .borderTop().thin()
+                            .topBorderColor(IndexedColors.RED)
+                            .end())
+                .gridConfigurer(new GridConfigurer()
+                        .conditionalFormatting("score",
+                                greaterThanOrEqual(80).style("highlight")))
+                .build();
+
+        try (HSSFWorkbook wb = new HSSFWorkbook();
+             OutputStream os = new FileOutputStream(file)) {
+            Sheet sheet = wb.createSheet("Data");
+            mapper.writeValue(sheet, data, Score.class);
+            wb.write(os);
+        }
+
+        try (InputStream is = new FileInputStream(file);
+             HSSFWorkbook wb = new HSSFWorkbook(is)) {
+            SheetConditionalFormatting scf = wb.getSheetAt(0).getSheetConditionalFormatting();
+            assertThat(scf.getNumConditionalFormattings()).isEqualTo(1);
+            ConditionalFormattingRule rule = scf.getConditionalFormattingAt(0).getRule(0);
+            assertThat(rule.getComparisonOperation()).isEqualTo(ComparisonOperator.GE);
+            assertThat(rule.getFormula1()).isEqualTo("80");
+
+            // Indexed-path font dxf: color index, underline byte, height in twentieths of a point.
+            FontFormatting ff = rule.getFontFormatting();
+            assertThat(ff).isNotNull();
+            assertThat(ff.isBold()).isTrue();
+            assertThat(ff.getFontColorIndex()).isEqualTo(IndexedColors.WHITE.getIndex());
+            assertThat(ff.getUnderlineType()).isEqualTo(Font.U_SINGLE);
+            assertThat(ff.getFontHeight()).isEqualTo(14 * 20);
+
+            // Indexed-path border dxf: top color resolved to indexed value.
+            BorderFormatting bf = rule.getBorderFormatting();
+            assertThat(bf).isNotNull();
+            assertThat(bf.getBorderTop()).isEqualTo(BorderStyle.THIN);
+            assertThat(bf.getTopBorderColor()).isEqualTo(IndexedColors.RED.getIndex());
         }
     }
 

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/SpreadsheetWriterStreamingTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/SpreadsheetWriterStreamingTest.java
@@ -1,0 +1,94 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import com.fasterxml.jackson.databind.SequenceWriter;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+import io.github.scndry.jackson.dataformat.spreadsheet.ser.SheetOutput;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Streaming write through {@link SpreadsheetWriter#writeValues(Sheet)} and
+ * {@link SpreadsheetWriter#writeValues(SheetOutput)} — the {@link SequenceWriter}
+ * pattern used when rows arrive lazily (paged repository, JDBC cursor) and the
+ * caller must release each row's memory before the next is produced.
+ *
+ * <p>The verification chain is write-many-incremental → read-back-all to assert
+ * row ordering and count survive the streaming path end-to-end.</p>
+ */
+class SpreadsheetWriterStreamingTest {
+
+    @TempDir File tempDir;
+    SpreadsheetMapper mapper;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @DataGrid
+    static class Item {
+        @DataColumn("ID") private long id;
+        @DataColumn("Name") private String name;
+    }
+
+    @BeforeEach
+    void setUp() {
+        mapper = new SpreadsheetMapper();
+    }
+
+    @Test
+    void writeValuesToSheet_streamsItemsIncrementally() throws Exception {
+        File file = new File(tempDir, "stream-sheet.xlsx");
+        SpreadsheetWriter writer = mapper.sheetWriterFor(Item.class);
+
+        try (SXSSFWorkbook wb = new SXSSFWorkbook();
+             OutputStream os = new FileOutputStream(file)) {
+            Sheet sheet = wb.createSheet("Stream");
+            try (SequenceWriter seq = writer.writeValues(sheet)) {
+                for (int i = 0; i < 50; i++) {
+                    seq.write(new Item(i, "row-" + i));
+                }
+            }
+            wb.write(os);
+            wb.dispose();
+        }
+
+        List<Item> read = mapper.readValues(file, Item.class);
+        assertThat(read).hasSize(50);
+        assertThat(read.get(0).getId()).isZero();
+        assertThat(read.get(49).getName()).isEqualTo("row-49");
+    }
+
+    @Test
+    void writeValuesToSheetOutput_streamsItemsIncrementally() throws Exception {
+        File file = new File(tempDir, "stream-sheetoutput.xlsx");
+        SpreadsheetWriter writer = mapper.sheetWriterFor(Item.class);
+
+        try (SequenceWriter seq = writer.writeValues(SheetOutput.target(file, "Stream"))) {
+            for (int i = 0; i < 50; i++) {
+                seq.write(new Item(i, "row-" + i));
+            }
+        }
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            assertThat(wb.getSheet("Stream")).isNotNull();
+        }
+        List<Item> read = mapper.readValues(file, Item.class);
+        assertThat(read).hasSize(50);
+        assertThat(read.get(25).getId()).isEqualTo(25);
+        assertThat(read.get(25).getName()).isEqualTo("row-25");
+    }
+}

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/WriterReaderApiTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/WriterReaderApiTest.java
@@ -13,7 +13,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.*;
+import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
@@ -228,5 +230,61 @@ class WriterReaderApiTest {
             Item item = mapper.readValue(is, Item.class);
             assertThat(item.name).isEqualTo("B");
         }
+    }
+
+    @Test
+    void writeWithStringOrigin() throws Exception {
+        File file = new File(tempDir, "origin-string.xlsx");
+        mapper.setOrigin("C5");
+        mapper.writeValue(file, Collections.singletonList(new Item("O", 1)), Item.class);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            // Origin "C5" → header at row 4 col 2 (0-indexed), data starts at row 5.
+            assertThat(sheet.getRow(4).getCell(2).getStringCellValue()).isEqualTo("name");
+            assertThat(sheet.getRow(5).getCell(2).getStringCellValue()).isEqualTo("O");
+        }
+    }
+
+    @Test
+    void readSingleValueFromSheetInput() throws Exception {
+        File file = new File(tempDir, "single-input.xlsx");
+        mapper.writeValue(SheetOutput.target(file, "Data"),
+                Arrays.asList(new Item("First", 1), new Item("Second", 2)), Item.class);
+
+        Item single = mapper.readValue(SheetInput.source(file, "Data"), Item.class);
+        assertThat(single.name).isEqualTo("First");
+    }
+
+    @Test
+    void readSingleValueFromPath() throws Exception {
+        File file = new File(tempDir, "single-path.xlsx");
+        mapper.writeValue(file, Arrays.asList(new Item("P1", 1), new Item("P2", 2)), Item.class);
+
+        Path path = file.toPath();
+        Item single = mapper.readValue(path, Item.class);
+        assertThat(single.name).isEqualTo("P1");
+    }
+
+    @Test
+    void writeSingleToSheetOutput() throws Exception {
+        File file = new File(tempDir, "infer-sheetoutput.xlsx");
+        // 1-arg overload — valueType inferred from single object's class.
+        mapper.writeValue(SheetOutput.target(file, "Inferred"), new Item("I", 1));
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            assertThat(wb.getSheet("Inferred")).isNotNull();
+            assertThat(wb.getSheet("Inferred").getRow(1).getCell(0).getStringCellValue()).isEqualTo("I");
+        }
+    }
+
+    @Test
+    void writeSingleToPath() throws Exception {
+        File file = new File(tempDir, "infer-path.xlsx");
+        // 1-arg overload — Path target, valueType inferred from single object's class.
+        mapper.writeValue(file.toPath(), new Item("PT", 9));
+
+        Item read = mapper.readValue(file, Item.class);
+        assertThat(read.qty).isEqualTo(9);
     }
 }


### PR DESCRIPTION
Adds focused tests for SequenceWriter streaming, SheetInput/Output/Origin API, HSSF conditional formatting dxf, and back-write overflow message. Deprecates `writeValuesAsArray` on Sheet/SheetOutput targets — empirical check shows the outer array wrap is a no-op on a spreadsheet.