### PR TITLE
Avoid CellAddress allocation in cell read hot path

### DIFF
--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetParser.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetParser.java
@@ -12,7 +12,6 @@ import java.util.List;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.ss.usermodel.CellType;
-import org.apache.poi.ss.util.CellAddress;
 
 import com.fasterxml.jackson.core.*;
 import com.fasterxml.jackson.core.base.ParserMinimalBase;
@@ -50,7 +49,8 @@ public final class SheetParser extends ParserMinimalBase {
     private ObjectCodec _objectCodec;
     private SpreadsheetSchema _schema;
     private SheetStreamContext _parsingContext;
-    private CellAddress _reference;
+    private int _referenceRow = -1;
+    private int _referenceColumn = -1;
     private CellValue _value;
     private boolean _headerProcessed;
 
@@ -66,7 +66,6 @@ public final class SheetParser extends ParserMinimalBase {
         _formatFeatures = formatFeatures;
         _reader = reader;
         _nextTokens = new LinkedList<>();
-        _reference = new CellAddress(-1, -1);
     }
 
     public boolean isEnabled(final Feature f) {
@@ -133,7 +132,7 @@ public final class SheetParser extends ParserMinimalBase {
                 _parsingContext = _parsingContext.clearAndGetParent();
                 break;
             case FIELD_NAME:
-                final Column column = _schema.getColumn(_reference);
+                final Column column = _schema.getColumn(_referenceColumn);
                 final ColumnPointer pointer = _parsingContext.relativePointer(column.getPointer());
                 _parsingContext.setCurrentName(pointer.head().name());
                 break;
@@ -174,13 +173,15 @@ public final class SheetParser extends ParserMinimalBase {
                 _nextTokens.add(JsonToken.START_ARRAY);
                 break;
             case ROW_START:
-                _reference = new CellAddress(_reader.getRow(), -1);
+                _referenceRow = _reader.getRow();
+                _referenceColumn = -1;
                 _nextTokens.add(JsonToken.START_OBJECT);
                 break;
             case CELL_VALUE:
-                _reference = _reader.getReference();
+                _referenceRow = _reader.getRow();
+                _referenceColumn = _reader.getColumn();
                 _value = _reader.getCellValue();
-                final Column column = _schema.findColumn(_reference);
+                final Column column = _schema.findColumn(_referenceColumn);
                 if (column == null) break; // unmatched column (reordering)
                 _emitScopeTokens(column);
                 _nextTokens.add(JsonToken.FIELD_NAME);
@@ -337,7 +338,7 @@ public final class SheetParser extends ParserMinimalBase {
 
     @Override
     public JsonLocation getCurrentLocation() {
-        return new SheetLocation(_contentReference(), _reference.getRow(), _reference.getColumn());
+        return new SheetLocation(_contentReference(), _referenceRow, _referenceColumn);
     }
 
     @Override

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLSheetReader.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLSheetReader.java
@@ -38,7 +38,6 @@ public final class SSMLSheetReader implements SheetReader {
     private final PackagePart _sheet;
     private SheetToken _next;
     private CTCell _cell;
-    private CellAddress _reference;
     private int _rowIndex = -1;
     private int _columnIndex = -1;
 
@@ -78,7 +77,7 @@ public final class SSMLSheetReader implements SheetReader {
 
     @Override
     public CellAddress getReference() {
-        return _reference;
+        return _columnIndex < 0 ? null : new CellAddress(_rowIndex, _columnIndex);
     }
 
     @Override
@@ -165,13 +164,12 @@ public final class SSMLSheetReader implements SheetReader {
                 break;
             case CELL_VALUE:
                 _cell = _reader.collectCell();
-                _reference = new CellAddress(_cell.getR());
-                _columnIndex = _reference.getColumn();
+                _columnIndex = _parseColumnFromRef(_cell.getR());
                 _next = _matched(START_CELL, END_ROW) ? SheetToken.CELL_VALUE : SheetToken.ROW_END;
                 break;
             case ROW_END:
                 _cell = null;
-                _reference = null;
+                _columnIndex = -1;
                 _next = _matched(
                         START_ROW,
                         END_SHEET_DATA) ? SheetToken.ROW_START : SheetToken.SHEET_DATA_END;
@@ -193,5 +191,16 @@ public final class SSMLSheetReader implements SheetReader {
     private boolean _matched(final Matcher start, final Matcher end) {
         final Matcher hit = _reader.nextUntil(start, end);
         return hit != null && !hit.isEndElement();
+    }
+
+    private static int _parseColumnFromRef(final String ref) {
+        int col = 0;
+        final int len = ref.length();
+        for (int i = 0; i < len; i++) {
+            final char c = ref.charAt(i);
+            if (c < 'A' || c > 'Z') break;
+            col = col * 26 + (c - 'A' + 1);
+        }
+        return col - 1;
     }
 }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ss/POISheetWriter.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ss/POISheetWriter.java
@@ -106,7 +106,7 @@ public final class POISheetWriter implements SheetWriter {
                     CellUtil.getCell(CellUtil.getRow(row, _sheet), firstCol).setCellStyle(gs);
                     anchorStyle = gs;
                 } else {
-                    final Column column = _schema.findColumn(new CellAddress(row, firstCol));
+                    final Column column = _schema.findColumn(firstCol);
                     anchorStyle = column == null ? null
                             : _styles.resolve(column.getValue().getHeaderStyle(),
                                     column.getType().getRawClass());
@@ -120,7 +120,7 @@ public final class POISheetWriter implements SheetWriter {
             @Override
             public void visitVerticalMerge(final int firstRow, final int lastRow, final int col) {
                 _sheet.addMergedRegion(new CellRangeAddress(firstRow, lastRow, col, col));
-                final Column column = _schema.findColumn(new CellAddress(firstRow, col));
+                final Column column = _schema.findColumn(col);
                 final CellStyle hs = column == null ? null
                         : _styles.resolve(column.getValue().getHeaderStyle(),
                                 column.getType().getRawClass());

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
@@ -76,10 +76,14 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
     }
 
     public Column findColumn(final CellAddress reference) {
+        return findColumn(reference.getColumn());
+    }
+
+    public Column findColumn(final int column) {
         if (_columns.isEmpty()) {
             return null;
         }
-        final int idx = reference.getColumn() - getOriginColumn();
+        final int idx = column - getOriginColumn();
         if (idx < 0 || idx >= _columns.size()) {
             return null;
         }
@@ -87,7 +91,11 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
     }
 
     public Column getColumn(final CellAddress reference) {
-        return _columns.get(reference.getColumn() - getOriginColumn());
+        return getColumn(reference.getColumn());
+    }
+
+    public Column getColumn(final int column) {
+        return _columns.get(column - getOriginColumn());
     }
 
     public int getDataRow() {


### PR DESCRIPTION
## Summary

`SSMLSheetReader` allocated `new CellAddress(_cell.getR())` per cell, parsing the A1 reference (e.g. `"B2"`) only to extract the column index. `SheetParser` held a separate `CellAddress` field whose only readers were `getRow()` / `getColumn()` / `findColumn()` calls — never the whole address. Allocating the wrapper plus the substring/parse work it carries dominated a measurable slice of the read hot loop.

This PR removes the per-cell allocation and exposes int-based lookups so the inner read loop touches only primitives. External `CellAddress` overloads remain as thin wrappers, so user-facing API is unchanged.

## Changes

- `SSMLSheetReader`: replace per-cell `new CellAddress(_cell.getR())` with a single-pass column letter parser; `getReference()` is now lazy and built only when callers (logging, location) ask for it.
- `SheetParser`: split `_reference` (`CellAddress`) into `_referenceRow` / `_referenceColumn` int fields. `getCurrentLocation()` builds `SheetLocation` from the ints directly.
- `SpreadsheetSchema`: add `findColumn(int)` / `getColumn(int)` overloads; the existing `CellAddress` overloads delegate to them.
- `POISheetWriter`: header layout (`visitGroupCell` / `visitVerticalMerge`) calls `findColumn(int)` directly instead of constructing a throwaway `CellAddress`.

## Measurement

`ReadProfileBenchmark.warmSchema` @ 50000 rows, fork=1, warmup 3×1s, iter 5×1s, JMH `gc` profiler:

| metric | main | perf | delta |
|---|---|---|---|
| score (ms/op) | 70.964 ± 1.718 | 58.982 ± 6.460 | -16.9% |
| gc.alloc.rate.norm (B/op) | 132,243,889 | 99,833,846 | -24.5% |
| gc.count (per trial) | 31 | 27 | -4 |

async-profiler `flame-cpu-forward`: `CellAddress.<init>` frame is gone on the perf branch; remaining hotspots (`collectCell`, `nextUntil`, `_matched`) are unchanged and reserved for a follow-up PR (CTCell reuse).

## Test plan

- [x] `./gradlew test` — all green on `perf/cell-address-int`.