### PR TITLE
Reuse CTCell across cells in the SSML read hot path

### DIFF
--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/CTCell.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/CTCell.java
@@ -14,14 +14,14 @@ package io.github.scndry.jackson.dataformat.spreadsheet.poi.ooxml;
  */
 final class CTCell {
 
-    private final String _r;
-    private final STCellType _t;
-    private final String _v;
-    private final STCellFormulaType _ft;
-    private final String _is;
+    private String _r;
+    private STCellType _t;
+    private String _v;
+    private STCellFormulaType _ft;
+    private String _is;
 
-    CTCell(final String r, final STCellType t, final String v,
-           final STCellFormulaType ft, final String is) {
+    void set(final String r, final STCellType t, final String v,
+             final STCellFormulaType ft, final String is) {
         _r = r;
         _t = t;
         _v = v;

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/XmlElementReader.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/XmlElementReader.java
@@ -21,6 +21,7 @@ final class XmlElementReader implements AutoCloseable {
     }
 
     private final XMLStreamReader _xml;
+    private final CTCell _ctCell = new CTCell();
     private boolean _closed;
 
     XmlElementReader(final InputStream src) {
@@ -141,7 +142,7 @@ final class XmlElementReader implements AutoCloseable {
     // Cell collection (CT_Cell — ECMA-376 §18.3.1.4)
     // ---------------------------------------------------------------
 
-    /** Collect cell attributes and children into a lightweight {@link CTCell}. */
+    /** Collect cell attributes and children into a reusable {@link CTCell}. */
     CTCell collectCell() {
         try {
             final String r = _xml.getAttributeValue(null, SpreadsheetML.ATTR_REF);
@@ -169,7 +170,8 @@ final class XmlElementReader implements AutoCloseable {
                         break;
                 }
             }
-            return new CTCell(r, t, v, ft, is);
+            _ctCell.set(r, t, v, ft, is);
+            return _ctCell;
         } catch (XMLStreamException e) {
             throw new IllegalStateException("Failed to read cell", e);
         }


### PR DESCRIPTION
## Summary

`XmlElementReader.collectCell()` allocated a fresh `CTCell` (5 ref fields) for every cell. The wrapper is package-private, lives entirely inside a single `next()` token, and its values are copied out into `CellValue` before the next call — so a single reusable instance held inside the reader is sound and removes the per-cell allocation outright.

## Changes

- `CTCell`: drop `final` on the five fields, remove the per-cell constructor, add an in-place `set(r, t, v, ft, is)` so the same instance can be refilled. Getters unchanged.
- `XmlElementReader`: hold a single `CTCell` instance, return it from `collectCell()` after calling `set(...)` with the freshly parsed attributes/children.

## Measurement

`ReadProfileBenchmark.warmSchema` @ 50000 rows, fork=1, warmup 3×1s, iter 5×1s, JMH `gc` profiler:

| metric | main (1단계 base) | perf (CTCell reuse) | delta |
|---|---|---|---|
| score (ms/op) | 64.192 ± 5.339 | 58.201 ± 2.716 | -9.3% |
| gc.alloc.rate.norm (B/op) | 106,639,487 | 95,833,080 | -10.1% |
| gc.count (per trial) | 26 | 21 | -5 |

Cumulative effect across the two perf PRs (CellAddress elimination in #150 + this PR): score 70.964 → 58.201 ms/op (-18.0%), allocation 132 MB → 91 MB per benchmark op (-31.1%).

Remaining hot frames (`collectCell` parse work itself, `nextUntil` / `_matched` matcher iteration) unchanged — left for follow-up.

## Test plan

- [x] `./gradlew test` — all green on `perf/ctcell-reuse`.