### PR TITLE
Fix BigDecimal/BigInteger mapping for non-numeric cell formats in POI mode

### DIFF
--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetParser.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetParser.java
@@ -393,7 +393,15 @@ public final class SheetParser extends ParserMinimalBase {
 
     @Override
     public BigInteger getBigIntegerValue() throws IOException {
-        return new BigDecimal(_value.getStringValue()).toBigIntegerExact();
+        final String s = _value.getStringValue();
+        if (s != null) {
+            try {
+                return new BigDecimal(s).toBigIntegerExact();
+            } catch (NumberFormatException ignored) {
+                // non-numeric cell format (e.g., currency, percentage) — fall through
+            }
+        }
+        return BigDecimal.valueOf(_value.getNumberValue()).toBigIntegerExact();
     }
 
     @Override
@@ -408,7 +416,15 @@ public final class SheetParser extends ParserMinimalBase {
 
     @Override
     public BigDecimal getDecimalValue() throws IOException {
-        return new BigDecimal(_value.getStringValue());
+        final String s = _value.getStringValue();
+        if (s != null) {
+            try {
+                return new BigDecimal(s);
+            } catch (NumberFormatException ignored) {
+                // non-numeric cell format (e.g., currency, percentage) — fall through
+            }
+        }
+        return BigDecimal.valueOf(_value.getNumberValue());
     }
 
     @Override


### PR DESCRIPTION
## Summary

- POI mode preserves DataFormatter output as a cell's stringValue. `getDecimalValue` / `getBigIntegerValue` fed that string directly to `new BigDecimal(String)`, which throws `NumberFormatException` for any cell format that emits non-numeric characters — currency (`$1,234.56`), percent (`50.0%`), date (`2026-05-20`), and similar styled cells. This means `BigDecimal` / `BigInteger` fields silently work for general/number formats and silently break for the rest.
- The fix tries string parsing first and falls back to `BigDecimal.valueOf(rawDouble)` when parsing fails. General and simple numeric formats keep going through string parsing, so BigDecimal scale (e.g., `"0.50"` -> scale=2) is preserved. Only non-numeric formats switch to raw-double conversion.
- SSML mode is unaffected: its stringValue is the raw XML `<v>` text, which already parses as a number.

## Test plan

- [x] `./gradlew test` — full suite passes (no existing test depended on the broken behavior)
- [ ] Manual verification with a workbook containing currency / percent / date cells mapped to `BigDecimal` / `BigInteger` fields