### PR TITLE
Bump to 1.6.5

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -57,13 +57,13 @@ POI types (`Sheet`, `Workbook`) are first-class I/O targets — see [POI Integra
 <dependency>
     <groupId>io.github.scndry</groupId>
     <artifactId>jackson-dataformat-spreadsheet</artifactId>
-    <version>1.6.4</version>
+    <version>1.6.5</version>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-implementation "io.github.scndry:jackson-dataformat-spreadsheet:1.6.4"
+implementation "io.github.scndry:jackson-dataformat-spreadsheet:1.6.5"
 ```
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ Available on Maven Central:
 <dependency>
     <groupId>io.github.scndry</groupId>
     <artifactId>jackson-dataformat-spreadsheet</artifactId>
-    <version>1.6.4</version>
+    <version>1.6.5</version>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-implementation "io.github.scndry:jackson-dataformat-spreadsheet:1.6.4"
+implementation "io.github.scndry:jackson-dataformat-spreadsheet:1.6.5"
 ```
 
 ### Requirements
@@ -277,7 +277,7 @@ Fastest read and write throughput at 100K rows, with the lowest write memory. 6x
 XLSX (OOXML) and XLS (legacy). XLSX uses StAX streaming; XLS uses POI object model.
 
 **Q: Is it production-ready?**
-Yes. Version 1.6.4 on Maven Central. Java 8+, Jackson 2.14+, POI 4.1.1+. Listed as a [community data format module](https://github.com/FasterXML/jackson#data-format-modules) in the FasterXML jackson repository.
+Yes. Version 1.6.5 on Maven Central. Java 8+, Jackson 2.14+, POI 4.1.1+. Listed as a [community data format module](https://github.com/FasterXML/jackson#data-format-modules) in the FasterXML jackson repository.
 
 **Q: Is the mapper thread-safe?**
 The mapper instance is reusable across threads once configured (same rule as Jackson's `ObjectMapper`). Concurrent calls with `File` / `InputStream` / `OutputStream` inputs are safe — the library opens an isolated `Workbook` per call. If you pass a `Sheet` directly, POI's `Workbook`/`Sheet` are not thread-safe, so each thread needs its own.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "io.github.scndry"
-version = "1.6.5-SNAPSHOT"
+version = "1.6.5"
 description = "Support for reading and writing Excel (XLSX/XLS) via Jackson abstractions."
 
 val title = "Jackson dataformat: Spreadsheet"


### PR DESCRIPTION
## Summary

Drop the `-SNAPSHOT` from the artifact and align the user-facing version snippets in README / GUIDE from 1.6.4 to 1.6.5 ahead of the v1.6.5 tag push. BENCHMARK.md keeps the 1.6.4 measurement marker — that table records the version under test, not the current release.

## 1.6.5 highlights (since 1.6.4)

- #148 Raise coverage with meaningful tests; deprecate `writeValuesAsArray`.
- #149 Fix BigInteger deserialization for numeric cells with scientific notation.
- #150 Avoid CellAddress allocation in cell read hot path.
- #151 Reuse CTCell across cells in the SSML read hot path.
- #152 Fix BigDecimal/BigInteger mapping for non-numeric cell formats in POI mode.

## Test plan

- [x] `./gradlew test` — green
- [ ] `./gradlew test -PpoiVersion=4.1.1 -PjacksonVersion=2.14.0` — green on CI (compat-min matrix)