### PR TITLE
Bump to 1.7.0-SNAPSHOT

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "io.github.scndry"
-version = "1.6.5"
+version = "1.7.0-SNAPSHOT"
 description = "Support for reading and writing Excel (XLSX/XLS) via Jackson abstractions."
 
 val title = "Jackson dataformat: Spreadsheet"


### PR DESCRIPTION
## Summary

Restore the `-SNAPSHOT` qualifier on the artifact after the v1.6.5 tag was published. User-facing version snippets in README / GUIDE / BENCHMARK stay at 1.6.5 — the released coordinates. Bumping to 1.7.0 (not 1.6.6) to make room for the next iteration's user-visible changes (#153).