### PR TITLE
Remove deprecated writeValuesAsArray methods

### DIFF
--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SpreadsheetWriter.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SpreadsheetWriter.java
@@ -111,28 +111,6 @@ public final class SpreadsheetWriter extends ObjectWriter {
         return _newSequenceWriter(false, createGenerator(out), true);
     }
 
-    /**
-     * @deprecated since 1.6.5, scheduled for removal in a future major release.
-     * The outer array wrapping is a no-op on a spreadsheet target — a spreadsheet's
-     * natural data model is already an array of rows, so the result is identical to
-     * {@link #writeValues(Sheet)}. Use that instead.
-     */
-    @Deprecated
-    public SequenceWriter writeValuesAsArray(final Sheet out) throws IOException {
-        return _newSequenceWriter(true, createGenerator(out), true);
-    }
-
-    /**
-     * @deprecated since 1.6.5, scheduled for removal in a future major release.
-     * The outer array wrapping is a no-op on a spreadsheet target — a spreadsheet's
-     * natural data model is already an array of rows, so the result is identical to
-     * {@link #writeValues(SheetOutput)}. Use that instead.
-     */
-    @Deprecated
-    public SequenceWriter writeValuesAsArray(final SheetOutput<?> out) throws IOException {
-        return _newSequenceWriter(true, createGenerator(out), true);
-    }
-
     /*
     /**********************************************************
     /* Serialization methods, others


### PR DESCRIPTION
## Summary

- Drop the two `writeValuesAsArray` overloads (`Sheet` / `SheetOutput<?>`). Both were deprecated in 1.6.5 (#148) — the outer-array wrapping is a no-op on a spreadsheet target since a spreadsheet's natural data model is already an array of rows.
- Migration: replace `writer.writeValuesAsArray(out)` with `writer.writeValues(out)`. No behavior delta.

## Breaking change note

The 1.6.5 deprecation javadoc read "scheduled for removal in a future major release." Removing in 1.7.0 (minor bump) is one cycle ahead of that contract. The 1.7.0 release notes will call this out under a dedicated **Removed** section so the deviation is explicit, not silent. 1.7.0 already carries one user-facing change track (#153, NUMERIC + String field cell-format alignment), so bundling the removal in the same minor is intentional.

## Test plan

- [x] `./gradlew test` — green
- [ ] `./gradlew test -PpoiVersion=4.1.1 -PjacksonVersion=2.14.0` — green on CI (compat-min matrix)