### PR TITLE
Defer DataFormatter call for NUMERIC cells in POI mode

### DIFF
--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/CellValue.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/CellValue.java
@@ -11,7 +11,7 @@ import org.apache.poi.ss.usermodel.CellType;
  * @see SheetReader
  * @see SheetParser
  */
-public final class CellValue {
+public class CellValue {
 
     public static final CellValue BLANK = new CellValue(CellType.BLANK, 0.0, false, null, 0);
     public static final CellValue TRUE = new CellValue(CellType.BOOLEAN, 0.0, true, null, 0);

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ss/POICellValue.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ss/POICellValue.java
@@ -1,0 +1,45 @@
+package io.github.scndry.jackson.dataformat.spreadsheet.poi.ss;
+
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.DataFormatter;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.deser.CellValue;
+
+/**
+ * {@link CellValue} for POI-mode NUMERIC cells that defers
+ * {@link DataFormatter#formatRawCellContents} until {@link #getStringValue()}.
+ *
+ * @see POISheetReader
+ */
+public final class POICellValue extends CellValue {
+
+    private final Cell _cell;
+    private final DataFormatter _formatter;
+    private String _lazyText;
+    private boolean _computed;
+
+    public POICellValue(final double numberValue, final Cell cell, final DataFormatter formatter) {
+        super(numberValue);
+        _cell = cell;
+        _formatter = formatter;
+    }
+
+    @Override
+    public String getStringValue() {
+        if (!_computed) {
+            _lazyText = _formattedString();
+            _computed = true;
+        }
+        return _lazyText;
+    }
+
+    private String _formattedString() {
+        final CellStyle style = _cell.getCellStyle();
+        if (style == null || style.getDataFormatString() == null) return null;
+        return _formatter.formatRawCellContents(
+                getNumberValue(),
+                style.getDataFormat(),
+                style.getDataFormatString());
+    }
+}

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ss/POISheetReader.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ss/POISheetReader.java
@@ -62,8 +62,7 @@ public final class POISheetReader implements SheetReader {
         final CellType type = CellFormat.ultimateType(_cell);
         switch (type) {
             case NUMERIC:
-                final double value = _cell.getNumericCellValue();
-                return new CellValue(value, _formattedString(value, _cell.getCellStyle()));
+                return new POICellValue(_cell.getNumericCellValue(), _cell, _formatter);
             case STRING:
                 return new CellValue(_cell.getStringCellValue());
             case BOOLEAN:
@@ -154,13 +153,4 @@ public final class POISheetReader implements SheetReader {
         return false;
     }
 
-    private String _formattedString(final double value, final CellStyle style) {
-        if (style != null && style.getDataFormatString() != null) {
-            return _formatter.formatRawCellContents(
-                    value,
-                    style.getDataFormat(),
-                    style.getDataFormatString());
-        }
-        return null;
-    }
 }

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ss/POICellValueTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ss/POICellValueTest.java
@@ -1,0 +1,77 @@
+package io.github.scndry.jackson.dataformat.spreadsheet.poi.ss;
+
+import java.io.IOException;
+
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.DataFormatter;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class POICellValueTest {
+
+    private Workbook _workbook;
+    private Cell _cell;
+    private CountingDataFormatter _formatter;
+
+    @BeforeEach
+    void setUp() {
+        _workbook = new XSSFWorkbook();
+        final Sheet sheet = _workbook.createSheet();
+        final Row row = sheet.createRow(0);
+        _cell = row.createCell(0);
+        _cell.setCellValue(1234.56);
+        final CellStyle style = _workbook.createCellStyle();
+        style.setDataFormat(_workbook.createDataFormat().getFormat("\"$\"#,##0.00"));
+        _cell.setCellStyle(style);
+        _formatter = new CountingDataFormatter();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        _workbook.close();
+    }
+
+    @Test
+    void deferredUntilFirstGetStringValue() {
+        final POICellValue value = new POICellValue(1234.56, _cell, _formatter);
+        assertThat(_formatter.callCount).isZero();
+
+        final String s = value.getStringValue();
+        assertThat(_formatter.callCount).isEqualTo(1);
+        assertThat(s).isEqualTo("$1,234.56");
+    }
+
+    @Test
+    void memoizedAfterFirstCompute() {
+        final POICellValue value = new POICellValue(1234.56, _cell, _formatter);
+        value.getStringValue();
+        value.getStringValue();
+        value.getStringValue();
+        assertThat(_formatter.callCount).isEqualTo(1);
+    }
+
+    @Test
+    void numericPathSkipsCompute() {
+        final POICellValue value = new POICellValue(1234.56, _cell, _formatter);
+        assertThat(value.getNumberValue()).isEqualTo(1234.56);
+        assertThat(_formatter.callCount).isZero();
+    }
+
+    private static final class CountingDataFormatter extends DataFormatter {
+        int callCount;
+
+        @Override
+        public String formatRawCellContents(final double value, final int formatIndex, final String formatString) {
+            callCount++;
+            return super.formatRawCellContents(value, formatIndex, formatString);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Defer DataFormatter.formatRawCellContents in POI-mode NUMERIC cells to the first getStringValue() call. Numeric / BigDecimal / Date field mappings never read the formatted string.

POICellValue owns the lazy state; CellValue stays an immutable carrier.

Part of #153 (PR 1 of 2 — POI mode lazy stringValue).

## Measurement

ReadBenchmark.jacksonSpreadsheetPOI @ rowCount=100000, fork=3, warmup=3, iterations=5 (sequential same-session):

| Metric | Before | After | Δ |
|---|---|---|---|
| time | 1315.7 ms/op ±114 | 1231.1 ms/op ±85 | **−6.4%** |
| alloc.rate.norm | 2925.8 MB/op | 2403.6 MB/op | **−17.9%** |

async-profiler alloc, same benchmark:

| Path | Before samples | After samples | Δ |
|---|---|---|---|
| Total alloc | 16,590 | 13,708 | −17.4% |
| `_formattedString` chain | 2,817 | 0 | **−100%** |
| `BigInteger` (DataFormatter chain) | 624 | 4 | −99% |
| `BigDecimal` (DataFormatter chain) | 218 | 0 | −100% |

JMH alloc delta (−17.9%) matches async-profiler total samples delta (−17.4%) — the DataFormatter chain (regex Matcher, BigInteger, BigDecimal) is eliminated from the numeric-field mapping path.

## Test plan

- [x] ./gradlew test — all existing tests pass
- [x] POICellValueTest — lazy / memoize / numeric path 3 cases
- [x] JMH ReadBenchmark.jacksonSpreadsheetPOI fork=3 measured
- [x] async-profiler alloc hot path verified