### PR TITLE
Cell format-aware string value for SSML-mode NUMERIC cells

### DIFF
--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/BlankStylesLookup.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/BlankStylesLookup.java
@@ -1,0 +1,19 @@
+package io.github.scndry.jackson.dataformat.spreadsheet.poi.ooxml;
+
+/**
+ * Sentinel {@link StylesLookup} for workbooks without a styles part.
+ * Returns {@code numFmtId 0} and a {@code null} format string for any index.
+ */
+enum BlankStylesLookup implements StylesLookup {
+    INSTANCE;
+
+    @Override
+    public int getNumFmtId(final int xfIdx) {
+        return 0;
+    }
+
+    @Override
+    public String getFormatString(final int numFmtId) {
+        return null;
+    }
+}

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/CTCell.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/CTCell.java
@@ -6,6 +6,7 @@ package io.github.scndry.jackson.dataformat.spreadsheet.poi.ooxml;
  * Field names match the XSD attribute/element names:
  * <ul>
  *   <li>{@code r} — cell reference (e.g. "A1")</li>
+ *   <li>{@code s} — cell style (XF) index</li>
  *   <li>{@code t} — cell type ({@link STCellType})</li>
  *   <li>{@code v} — cell value text</li>
  *   <li>{@code ft} — formula type from {@code <f t="...">} ({@link STCellFormulaType})</li>
@@ -16,14 +17,16 @@ final class CTCell {
 
     private String _r;
     private STCellType _t;
+    private int _s;
     private String _v;
     private STCellFormulaType _ft;
     private String _is;
 
-    void set(final String r, final STCellType t, final String v,
+    void set(final String r, final STCellType t, final int s, final String v,
              final STCellFormulaType ft, final String is) {
         _r = r;
         _t = t;
+        _s = s;
         _v = v;
         _ft = ft;
         _is = is;
@@ -31,6 +34,7 @@ final class CTCell {
 
     String getR() { return _r; }
     STCellType getT() { return _t; }
+    int getS() { return _s; }
     String getV() { return _v; }
     STCellFormulaType getFt() { return _ft; }
     String getIs() { return _is; }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/LazyStylesLookup.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/LazyStylesLookup.java
@@ -1,0 +1,98 @@
+package io.github.scndry.jackson.dataformat.spreadsheet.poi.ooxml;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.poi.openxml4j.opc.PackagePart;
+import org.apache.poi.ss.usermodel.BuiltinFormats;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.poi.ooxml.XmlElementReader.Matcher;
+
+/**
+ * {@link StylesLookup} that scans {@code <cellXfs>} and user-defined {@code <numFmts>}
+ * via {@link XmlElementReader}; built-in number formats fall through to
+ * {@link BuiltinFormats}. Parses on first lookup.
+ */
+final class LazyStylesLookup implements StylesLookup {
+
+    private static final Matcher START_NUM_FMTS = Matcher.startElement(SpreadsheetML.NUM_FMTS);
+    private static final Matcher START_NUM_FMT = Matcher.startElement(SpreadsheetML.NUM_FMT);
+    private static final Matcher END_NUM_FMTS = Matcher.endElement(SpreadsheetML.NUM_FMTS);
+    private static final Matcher START_CELL_XFS = Matcher.startElement(SpreadsheetML.CELL_XFS);
+    private static final Matcher START_XF = Matcher.startElement(SpreadsheetML.XF);
+    private static final Matcher END_CELL_XFS = Matcher.endElement(SpreadsheetML.CELL_XFS);
+    private static final Matcher END_STYLE_SHEET = Matcher.endElement(SpreadsheetML.STYLE_SHEET);
+
+    private final PackagePart _stylesPart;
+    private int[] _xfNumFmtId;
+    private Map<Integer, String> _userFormats;
+    private boolean _initialized;
+
+    LazyStylesLookup(final PackagePart stylesPart) {
+        _stylesPart = stylesPart;
+    }
+
+    @Override
+    public int getNumFmtId(final int xfIdx) {
+        _init();
+        if (xfIdx < 0 || xfIdx >= _xfNumFmtId.length) return 0;
+        return _xfNumFmtId[xfIdx];
+    }
+
+    @Override
+    public String getFormatString(final int numFmtId) {
+        _init();
+        final String custom = _userFormats.get(numFmtId);
+        return custom != null ? custom : BuiltinFormats.getBuiltinFormat(numFmtId);
+    }
+
+    private void _init() {
+        if (_initialized) return;
+        final List<Integer> xfNumFmtIds = new ArrayList<>();
+        final Map<Integer, String> userFormats = new HashMap<>();
+        try (XmlElementReader reader = new XmlElementReader(_stylesPart.getInputStream())) {
+            reader.navigateTo(SpreadsheetML.STYLE_SHEET);
+            while (true) {
+                final Matcher hit = reader.nextUntil(START_NUM_FMTS, START_CELL_XFS, END_STYLE_SHEET);
+                if (hit == null || hit == END_STYLE_SHEET) break;
+                if (hit == START_NUM_FMTS) {
+                    _collectNumFmts(reader, userFormats);
+                } else {
+                    _collectCellXfs(reader, xfNumFmtIds);
+                }
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        _xfNumFmtId = new int[xfNumFmtIds.size()];
+        for (int i = 0; i < _xfNumFmtId.length; i++) {
+            _xfNumFmtId[i] = xfNumFmtIds.get(i);
+        }
+        _userFormats = userFormats;
+        _initialized = true;
+    }
+
+    private static void _collectNumFmts(final XmlElementReader reader, final Map<Integer, String> out) {
+        while (true) {
+            final Matcher hit = reader.nextUntil(START_NUM_FMT, END_NUM_FMTS);
+            if (hit == null || hit.isEndElement()) break;
+            final int id = reader.intAttribute(SpreadsheetML.ATTR_NUM_FMT_ID);
+            final String fmt = reader.attribute(SpreadsheetML.ATTR_FORMAT_CODE);
+            if (fmt != null) out.put(id, fmt);
+        }
+    }
+
+    private static void _collectCellXfs(final XmlElementReader reader, final List<Integer> out) {
+        while (true) {
+            final Matcher hit = reader.nextUntil(START_XF, END_CELL_XFS);
+            if (hit == null || hit.isEndElement()) break;
+            final String idAttr = reader.attribute(SpreadsheetML.ATTR_NUM_FMT_ID);
+            out.add(idAttr == null ? 0 : Integer.parseInt(idAttr));
+            reader.skipElement();
+        }
+    }
+}

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLCellValue.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLCellValue.java
@@ -1,0 +1,48 @@
+package io.github.scndry.jackson.dataformat.spreadsheet.poi.ooxml;
+
+import org.apache.poi.ss.usermodel.DataFormatter;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.deser.CellValue;
+
+/**
+ * {@link CellValue} for SSML-mode NUMERIC cells that defers
+ * {@link DataFormatter#formatRawCellContents} until {@link #getStringValue()}.
+ *
+ * @see SSMLSheetReader
+ */
+final class SSMLCellValue extends CellValue {
+
+    private final int _styleIndex;
+    private final StylesLookup _styles;
+    private final DataFormatter _formatter;
+    private String _lazyText;
+    private boolean _computed;
+
+    SSMLCellValue(final double numberValue, final String rawText,
+                  final int styleIndex, final StylesLookup styles,
+                  final DataFormatter formatter) {
+        super(numberValue, rawText);
+        _styleIndex = styleIndex;
+        _styles = styles;
+        _formatter = formatter;
+    }
+
+    @Override
+    public String getStringValue() {
+        if (!_computed) {
+            _lazyText = _formattedString();
+            _computed = true;
+        }
+        return _lazyText;
+    }
+
+    private String _formattedString() {
+        final int numFmtId = _styles.getNumFmtId(_styleIndex);
+        final String fmt = _styles.getFormatString(numFmtId);
+        if (fmt == null) return super.getStringValue();
+        return _formatter.formatRawCellContents(
+                getNumberValue(),
+                numFmtId,
+                fmt);
+    }
+}

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLSheetReader.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLSheetReader.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.openxml4j.exceptions.InvalidOperationException;
 import org.apache.poi.openxml4j.opc.PackagePart;
 import org.apache.poi.ss.SpreadsheetVersion;
+import org.apache.poi.ss.usermodel.DataFormatter;
 import org.apache.poi.ss.usermodel.FormulaError;
 import org.apache.poi.ss.util.CellAddress;
 
@@ -33,6 +34,8 @@ public final class SSMLSheetReader implements SheetReader {
     private static final Matcher END_SHEET_DATA = Matcher.endElement(SpreadsheetML.SHEET_DATA);
 
     private final SharedStringsLookup _strings;
+    private final StylesLookup _styles;
+    private final DataFormatter _formatter = new DataFormatter();
     private final XmlElementReader _reader;
     private final SSMLWorkbook _workbook;
     private final PackagePart _sheet;
@@ -57,6 +60,10 @@ public final class SSMLSheetReader implements SheetReader {
             } else {
                 _strings = new InMemorySharedStringsLookup(sharedStrings);
             }
+            final PackagePart stylesPart = _workbook.getStylesPart();
+            _styles = stylesPart == null
+                    ? BlankStylesLookup.INSTANCE
+                    : new LazyStylesLookup(stylesPart);
             _reader = new XmlElementReader(_sheet.getInputStream());
             _reader.nextUntil(START_SHEET_DATA);
         } catch (IOException e) {
@@ -89,13 +96,10 @@ public final class SSMLSheetReader implements SheetReader {
             case BOOLEAN:
                 return CellValue.valueOf("1".equals(value));
             case NUMBER:
-                if (_cell.getFt() == null) {
-                    return value == null ? CellValue.BLANK : new CellValue(
-                            Double.parseDouble(value),
-                            value);
-                }
-                if (_cell.getFt() == STCellFormulaType.SHARED) {
-                    return new CellValue(Double.parseDouble(value));
+                if (value == null) return CellValue.BLANK;
+                if (_cell.getFt() == null || _cell.getFt() == STCellFormulaType.SHARED) {
+                    return new SSMLCellValue(
+                            Double.parseDouble(value), value, _cell.getS(), _styles, _formatter);
                 }
                 throw new UnsupportedOperationException("Unexpected formula type: " +
                         _cell.getFt());

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SpreadsheetML.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SpreadsheetML.java
@@ -42,6 +42,16 @@ final class SpreadsheetML {
     static final String SHEET = "sheet";
     /** {@code <sheets>} — sheet list container (§18.2.20) */
     static final String SHEETS = "sheets";
+    /** {@code <styleSheet>} — styles root (§18.8.39) */
+    static final String STYLE_SHEET = "styleSheet";
+    /** {@code <numFmts>} — number format list (§18.8.31) */
+    static final String NUM_FMTS = "numFmts";
+    /** {@code <numFmt>} — number format entry (§18.8.30) */
+    static final String NUM_FMT = "numFmt";
+    /** {@code <cellXfs>} — cell formatting record list (§18.8.10) */
+    static final String CELL_XFS = "cellXfs";
+    /** {@code <xf>} — formatting record (§18.8.45) */
+    static final String XF = "xf";
 
     // ---------------------------------------------------------------
     // Attribute local names
@@ -51,6 +61,8 @@ final class SpreadsheetML {
     static final String ATTR_REF = "r";
     /** {@code t} — cell type on {@code <c>}, formula type on {@code <f>} */
     static final String ATTR_TYPE = "t";
+    /** {@code s} — cell style (XF) index on {@code <c>} */
+    static final String ATTR_STYLE = "s";
     /** {@code uniqueCount} — unique string count on {@code <sst>} */
     static final String ATTR_UNIQUE_COUNT = "uniqueCount";
     /** {@code date1904} — date windowing on {@code <workbookPr>} */
@@ -59,6 +71,10 @@ final class SpreadsheetML {
     static final String ATTR_NAME = "name";
     /** {@code sheetId} — sheet ID on {@code <sheet>} */
     static final String ATTR_SHEET_ID = "sheetId";
+    /** {@code numFmtId} — number format index on {@code <numFmt>} / {@code <xf>} */
+    static final String ATTR_NUM_FMT_ID = "numFmtId";
+    /** {@code formatCode} — format pattern on {@code <numFmt>} */
+    static final String ATTR_FORMAT_CODE = "formatCode";
 
     // ---------------------------------------------------------------
     // Relationship namespace URIs

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/StylesLookup.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/StylesLookup.java
@@ -1,0 +1,13 @@
+package io.github.scndry.jackson.dataformat.spreadsheet.poi.ooxml;
+
+/**
+ * Lightweight style lookup abstraction for resolving a cell's style index
+ * to a number-format pattern, isolating SSML read code from {@code styles.xml}
+ * representation choices.
+ */
+interface StylesLookup {
+
+    int getNumFmtId(int xfIdx);
+
+    String getFormatString(int numFmtId);
+}

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/XmlElementReader.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/XmlElementReader.java
@@ -148,6 +148,8 @@ final class XmlElementReader implements AutoCloseable {
             final String r = _xml.getAttributeValue(null, SpreadsheetML.ATTR_REF);
             final STCellType t = STCellType
                     .of(_xml.getAttributeValue(null, SpreadsheetML.ATTR_TYPE));
+            final String sAttr = _xml.getAttributeValue(null, SpreadsheetML.ATTR_STYLE);
+            final int s = (sAttr == null) ? 0 : Integer.parseInt(sAttr);
             String v = null;
             STCellFormulaType ft = null;
             String is = null;
@@ -170,7 +172,7 @@ final class XmlElementReader implements AutoCloseable {
                         break;
                 }
             }
-            _ctCell.set(r, t, v, ft, is);
+            _ctCell.set(r, t, s, v, ft, is);
             return _ctCell;
         } catch (XMLStreamException e) {
             throw new IllegalStateException("Failed to read cell", e);

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/ReadModeEquivalenceTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/ReadModeEquivalenceTest.java
@@ -1,0 +1,101 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that POI-mode and SSML-mode reads return the same String value
+ * for NUMERIC cells mapped to a String field, across cell formats (currency,
+ * percentage, date). Closes the cross-mode inconsistency targeted by #153.
+ */
+class ReadModeEquivalenceTest {
+
+    private File _file;
+
+    @Data
+    @NoArgsConstructor
+    @DataGrid
+    static class FormattedRow {
+        String price;
+        String pct;
+        String when;
+    }
+
+    @BeforeEach
+    void setUp() throws IOException {
+        _file = File.createTempFile("read-mode-equiv-", ".xlsx");
+        _file.deleteOnExit();
+        try (XSSFWorkbook wb = new XSSFWorkbook()) {
+            final Sheet sheet = wb.createSheet();
+
+            final CellStyle currency = wb.createCellStyle();
+            currency.setDataFormat(wb.createDataFormat().getFormat("\"$\"#,##0.00"));
+            final CellStyle percentage = wb.createCellStyle();
+            percentage.setDataFormat(wb.createDataFormat().getFormat("0.00%"));
+            final CellStyle date = wb.createCellStyle();
+            date.setDataFormat(wb.createDataFormat().getFormat("yyyy-mm-dd"));
+
+            final Row header = sheet.createRow(0);
+            header.createCell(0).setCellValue("price");
+            header.createCell(1).setCellValue("pct");
+            header.createCell(2).setCellValue("when");
+
+            final Row data = sheet.createRow(1);
+            final Cell priceCell = data.createCell(0);
+            priceCell.setCellValue(1234.56);
+            priceCell.setCellStyle(currency);
+            final Cell pctCell = data.createCell(1);
+            pctCell.setCellValue(0.5);
+            pctCell.setCellStyle(percentage);
+            final Cell dateCell = data.createCell(2);
+            dateCell.setCellValue(45797.0); // Excel serial — used only for cross-mode equivalence
+            dateCell.setCellStyle(date);
+
+            try (FileOutputStream fos = new FileOutputStream(_file)) {
+                wb.write(fos);
+            }
+        }
+    }
+
+    @AfterEach
+    void tearDown() {
+        _file.delete();
+    }
+
+    @Test
+    void poiAndSsmlReturnSameStringFieldForFormattedNumericCells() throws IOException {
+        final SpreadsheetMapper ssmlMapper = new SpreadsheetMapper();
+        final SpreadsheetMapper poiMapper = new SpreadsheetMapper(
+                new SpreadsheetFactory(XSSFWorkbook::new,
+                        SpreadsheetFactory.DEFAULT_SHEET_PARSER_FEATURE_FLAGS)
+                        .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL));
+
+        final FormattedRow ssmlRow = ssmlMapper.readValue(_file, FormattedRow.class);
+        final FormattedRow poiRow = poiMapper.readValue(_file, FormattedRow.class);
+
+        assertThat(ssmlRow.price).isEqualTo(poiRow.price);
+        assertThat(ssmlRow.pct).isEqualTo(poiRow.pct);
+        assertThat(ssmlRow.when).isEqualTo(poiRow.when);
+
+        // Absolute checks for the deterministic formats; date formatting is
+        // locale-sensitive so only the equivalence above is asserted for it.
+        assertThat(poiRow.price).isEqualTo("$1,234.56");
+        assertThat(poiRow.pct).isEqualTo("50.00%");
+    }
+}

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLCellValueTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLCellValueTest.java
@@ -1,0 +1,102 @@
+package io.github.scndry.jackson.dataformat.spreadsheet.poi.ooxml;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.DataFormatter;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SSMLCellValueTest {
+
+    private File _file;
+    private SSMLWorkbook _workbook;
+    private StylesLookup _styles;
+    private int _styleIndex;
+    private CountingDataFormatter _formatter;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        _file = File.createTempFile("ssml-cell-value-test-", ".xlsx");
+        _file.deleteOnExit();
+        try (XSSFWorkbook wb = new XSSFWorkbook()) {
+            final CellStyle style = wb.createCellStyle();
+            style.setDataFormat(wb.createDataFormat().getFormat("\"$\"#,##0.00"));
+            _styleIndex = style.getIndex();
+            final Sheet sheet = wb.createSheet();
+            final Row row = sheet.createRow(0);
+            final Cell cell = row.createCell(0);
+            cell.setCellValue(1234.56);
+            cell.setCellStyle(style);
+            try (FileOutputStream fos = new FileOutputStream(_file)) {
+                wb.write(fos);
+            }
+        }
+        _workbook = SSMLWorkbook.create(_file);
+        _styles = new LazyStylesLookup(_workbook.getStylesPart());
+        _formatter = new CountingDataFormatter();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        _workbook.close();
+        _file.delete();
+    }
+
+    @Test
+    void deferredUntilFirstGetStringValue() {
+        final SSMLCellValue value = new SSMLCellValue(
+                1234.56, "1234.56", _styleIndex, _styles, _formatter);
+        assertThat(_formatter.callCount).isZero();
+
+        final String s = value.getStringValue();
+        assertThat(_formatter.callCount).isEqualTo(1);
+        assertThat(s).isEqualTo("$1,234.56");
+    }
+
+    @Test
+    void memoizedAfterFirstCompute() {
+        final SSMLCellValue value = new SSMLCellValue(
+                1234.56, "1234.56", _styleIndex, _styles, _formatter);
+        value.getStringValue();
+        value.getStringValue();
+        value.getStringValue();
+        assertThat(_formatter.callCount).isEqualTo(1);
+    }
+
+    @Test
+    void numericPathSkipsCompute() {
+        final SSMLCellValue value = new SSMLCellValue(
+                1234.56, "1234.56", _styleIndex, _styles, _formatter);
+        assertThat(value.getNumberValue()).isEqualTo(1234.56);
+        assertThat(_formatter.callCount).isZero();
+    }
+
+    @Test
+    void outOfBoundsStyleIndexFallsBackToGeneralFormat() {
+        final SSMLCellValue value = new SSMLCellValue(
+                1234.56, "1234.56", Integer.MAX_VALUE, _styles, _formatter);
+        // out-of-bounds → numFmtId 0 (General) → raw-equivalent output via DataFormatter
+        assertThat(value.getStringValue()).isEqualTo("1234.56");
+        assertThat(_formatter.callCount).isEqualTo(1);
+    }
+
+    private static final class CountingDataFormatter extends DataFormatter {
+        int callCount;
+
+        @Override
+        public String formatRawCellContents(final double value, final int formatIndex, final String formatString) {
+            callCount++;
+            return super.formatRawCellContents(value, formatIndex, formatString);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add cell format-aware stringValue for SSML-mode NUMERIC cells, closing the cross-mode inconsistency targeted by #153.

POI mode emitted DataFormatter-formatted strings via the cell's data format, while SSML mode emitted the raw <v> XML text. The same workbook produced different String field values depending on which read path the user opted into.

SSMLSheetReader now emits SSMLCellValue (new, package-private) for NUMBER cells (formula and shared-formula included). It carries a StylesLookup and defers DataFormatter.formatRawCellContents until the first getStringValue() call.

StylesLookup is a minimal styles.xml lookup via XmlElementReader. The interface + Blank sentinel + Lazy impl follows the SharedStringsLookup pattern. Transitional and strict OOXML share the same path.

Closes #153.

## Changes

- `poi/ooxml/StylesLookup.java` (new interface) — abstraction over styles.xml lookup
- `poi/ooxml/BlankStylesLookup.java` (new enum sentinel) — for workbooks without a styles part
- `poi/ooxml/LazyStylesLookup.java` (new) — XmlElementReader-based parser, defers parse to first lookup
- `poi/ooxml/SSMLCellValue.java` (new, package-private) — lazy formatted stringValue carrier
- `poi/ooxml/SSMLSheetReader.java` — emit SSMLCellValue for NUMBER cells
- `poi/ooxml/CTCell.java` + `XmlElementReader.collectCell()` — read `s` (style index) attribute on `<c>`
- `poi/ooxml/SpreadsheetML.java` — styles-related element/attribute constants
- Tests: SSMLCellValueTest, ReadModeEquivalenceTest (POI vs SSML for currency / percentage / date)

## Measurement

ReadBenchmark.jacksonSpreadsheet @ rowCount=100000, fork=3, warmup=3, iterations=5 (sequential same-session):

| Metric | Before | After | Δ |
|---|---|---|---|
| time | 185.8 ms/op ±4.2 | 194.4 ms/op ±5.3 | +4.6% |
| alloc.rate.norm | 293.6 MB/op ±7.5 | 301.6 MB/op ±0.004 | +2.7% |

The cost is SSMLCellValue alloc itself (200K instances for ReadBenchmark's mixed-type fixture). The benchmark's NUMERIC fields map to int/double — the lazy formatter is never invoked and styles.xml is not parsed.

## Test plan

- [x] ./gradlew test — all tests pass
- [x] SSMLCellValueTest — lazy / memoize / numeric path / out-of-bounds (4 cases)
- [x] ReadModeEquivalenceTest — POI vs SSML String field cross-mode for currency / percentage / date
- [x] JMH ReadBenchmark.jacksonSpreadsheet fork=3 measured