### PR TITLE
Cut SSML read allocation: raw decimal path + ArrayDeque token queue

### DIFF
--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/CellValue.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/CellValue.java
@@ -68,6 +68,14 @@ public class CellValue {
         return _textValue;
     }
 
+    public String getRawText() {
+        return getStringValue();
+    }
+
+    protected final String _textValue() {
+        return _textValue;
+    }
+
     public CellType getCellType() {
         return _cellType;
     }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetParser.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetParser.java
@@ -4,10 +4,10 @@ import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 
 import lombok.extern.slf4j.Slf4j;
@@ -46,6 +46,7 @@ public final class SheetParser extends ParserMinimalBase {
     private final Deque<JsonToken> _nextTokens;
     private final int _formatFeatures;
     private boolean _closed;
+    private boolean _ended;
     private ObjectCodec _objectCodec;
     private SpreadsheetSchema _schema;
     private SheetStreamContext _parsingContext;
@@ -65,7 +66,7 @@ public final class SheetParser extends ParserMinimalBase {
         _objectCodec = codec;
         _formatFeatures = formatFeatures;
         _reader = reader;
-        _nextTokens = new LinkedList<>();
+        _nextTokens = new ArrayDeque<>();
     }
 
     public boolean isEnabled(final Feature f) {
@@ -112,13 +113,14 @@ public final class SheetParser extends ParserMinimalBase {
     public JsonToken nextToken() throws IOException {
         _checkSchemaSet();
         _prepareDeterministicNext();
+        if (_nextTokens.isEmpty()) {
+            _currToken = null;
+            if (log.isTraceEnabled()) log.trace("null");
+            return null;
+        }
         final JsonToken token = _nextTokens.removeFirst();
         if (log.isTraceEnabled()) {
             log.trace("{}", token);
-        }
-        if (token == null) {
-            _currToken = null;
-            return null;
         }
         switch (token) {
             case START_ARRAY:
@@ -152,7 +154,7 @@ public final class SheetParser extends ParserMinimalBase {
     }
 
     private void _prepareDeterministicNext() throws StreamReadException {
-        while (_nextTokens.isEmpty() || _isStartObject()) {
+        while (!_ended && (_nextTokens.isEmpty() || _isStartObject())) {
             _prepareNext();
             _handleEmptyObject();
         }
@@ -165,7 +167,7 @@ public final class SheetParser extends ParserMinimalBase {
     private void _prepareNext() throws StreamReadException {
         final SheetToken token = _readNext();
         if (token == null) {
-            _nextTokens.add(null);
+            _ended = true;
             return;
         }
         switch (token) {
@@ -285,7 +287,7 @@ public final class SheetParser extends ParserMinimalBase {
         }
         _nextTokens.clear();
         if (isEnabled(Feature.BREAK_ON_BLANK_ROW)) {
-            _nextTokens.add(null);
+            _ended = true;
         } else if (isEnabled(Feature.BLANK_ROW_AS_NULL)) {
             _nextTokens.add(JsonToken.VALUE_NULL);
         }
@@ -393,7 +395,7 @@ public final class SheetParser extends ParserMinimalBase {
 
     @Override
     public BigInteger getBigIntegerValue() throws IOException {
-        final String s = _value.getStringValue();
+        final String s = _value.getRawText();
         if (s != null) {
             try {
                 return new BigDecimal(s).toBigIntegerExact();
@@ -416,7 +418,7 @@ public final class SheetParser extends ParserMinimalBase {
 
     @Override
     public BigDecimal getDecimalValue() throws IOException {
-        final String s = _value.getStringValue();
+        final String s = _value.getRawText();
         if (s != null) {
             try {
                 return new BigDecimal(s);

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLCellValue.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLCellValue.java
@@ -36,10 +36,15 @@ final class SSMLCellValue extends CellValue {
         return _lazyText;
     }
 
+    @Override
+    public String getRawText() {
+        return _textValue();
+    }
+
     private String _formattedString() {
         final int numFmtId = _styles.getNumFmtId(_styleIndex);
         final String fmt = _styles.getFormatString(numFmtId);
-        if (fmt == null) return super.getStringValue();
+        if (fmt == null) return _textValue();
         return _formatter.formatRawCellContents(
                 getNumberValue(),
                 numFmtId,


### PR DESCRIPTION
## Summary

Two independent allocation reductions on the SSML read hot path, identified by async-profiler and verified by JMH.

1. **Raw text on BigDecimal/BigInteger mapping path** — avoids the lazy `DataFormatter` call triggered by #158 when a `BigDecimal`/`BigInteger` field is mapped to a NUMERIC cell.
2. **ArrayDeque token queue** — removes per-token `LinkedList.Node` allocation in `SheetParser`.

## Changes

### 1. Raw text on `getDecimalValue` / `getBigIntegerValue`

PR #158 emits SSMLCellValue for NUMERIC cells and computes the formatted string lazily on `getStringValue()`. PR #152's `SheetParser.getDecimalValue` calls `_value.getStringValue()` to recover scale precision via `new BigDecimal(s)`, which triggered the lazy `DataFormatter.formatRawCellContents` on every BigDecimal-typed field.

This PR introduces `CellValue.getRawText()` — defaults to `getStringValue()` so POI-mode behavior is unchanged; `SSMLCellValue` overrides it to expose the raw `<v>` text without compute. `SheetParser` uses `getRawText()` on the decimal path.

### 2. `SheetParser._nextTokens` → `ArrayDeque`

`SheetParser._nextTokens` was a `LinkedList<JsonToken>`. Tokens are pushed at the back and popped from the front (`addLast` / `removeFirst`), with ~3 add operations per cell. async-profiler showed `LinkedList$Node` alloc at ~8% of jackson-spreadsheet SSML read alloc.

`ArrayDeque` amortizes adds without per-node allocation. The previous `_nextTokens.add(null)` sentinel for stream-end is replaced with a dedicated `_ended` boolean (ArrayDeque rejects null).

## Measurement

ReadBenchmark.jacksonSpreadsheet @ rowCount=100000, fork=1, warmup=3, iterations=5 (sequential same-session):

| Metric | Before | After | Δ |
|---|---|---|---|
| time | 320.60 ms/op ±13.3 | 285.87 ms/op ±18.0 | **−10.8%** |
| alloc.rate.norm | 914.57 MB/op | 579.01 MB/op | **−36.7%** |

Across all scales (1K / 10K / 50K / 100K / 500K):

| Metric | Δ range |
|---|---|
| time | −10% ~ −17% |
| alloc | −30% ~ −37% |

Other libraries (`fastExcelReader`, `fesod`, `poiUserModel`, `jacksonSpreadsheetPOI`) variance stays within ±2% (noise level) — change is real signal for SSML mode only.

## Test plan

- [x] `./gradlew test` — all existing tests pass (no behavior change for non-decimal field mappings)
- [x] `ReadModeEquivalenceTest` — POI vs SSML String field still equivalent (cross-mode consistency preserved by #158)
- [x] `POICellValueTest` / `SSMLCellValueTest` — lazy compute paths still hold
- [x] JMH `ReadBenchmark.jacksonSpreadsheet` fork=1 sequential same-session measured

## Behavior preserved

- POI mode (`POICellValue`) — `getRawText()` defaults to `getStringValue()` (the lazy formatted string). PR #152 path unchanged for POI.
- SSML mode String field mapping (cross-mode equivalence) — uses `getStringValue()` (lazy formatted). Unchanged.
- Only `BigDecimal` / `BigInteger` field mapping on SSML side now uses raw text — same numeric result, fewer allocations.