### PR TITLE
Unify POI User Model decision into a single boolean

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -268,14 +268,14 @@ mapper.writeValue(file, employee)
 
 ### Dual Writer Strategy
 
-| | SSMLSheetWriter (default) | POISheetWriter (`USE_POI_USER_MODEL`) |
+| | SSMLSheetWriter | POISheetWriter |
 |---|---|---|
 | Packaging | POI scaffold + ZipOutputStream | POI `Workbook.write()` |
 | Cell writing | SoA buffer → StringBuilder → ZipOutputStream | POI `Cell.setCellValue()` |
 | Shared strings | `SharedStringsStore` (in-memory or file-backed) | POI managed |
 | Styles | POI `CellStyle.getIndex()` from scaffold | POI `CellStyle` API |
-| Performance | ~150 ms / 100K rows | ~335 ms / 100K rows |
 | Format | XLSX only (requires XSSFWorkbook) | XLSX, XLS |
+| When used | OOXML output + XSSFSheet workbook | Direct `Sheet` output, non-XSSF custom workbook, or `USE_POI_USER_MODEL` |
 
 ### Scaffold-Based Streaming
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -44,7 +44,7 @@ Jackson processes data in three layers. This library plugs into all three:
 |-------|---------|-------------|------|
 | **Data Binding** | ObjectMapper, ObjectReader, ObjectWriter | SpreadsheetMapper, SpreadsheetReader, SpreadsheetWriter | POJO serialization — **inherited, not reimplemented** |
 | **Streaming** | JsonParser, JsonGenerator, JsonFactory | SheetParser, SheetGenerator, SpreadsheetFactory | Flat cell ↔ nested token translation — **the core abstraction** |
-| **Format I/O** | UTF8StreamJsonParser reads bytes | SheetReader / SheetWriter (interface) | Raw format read/write — **swappable** (POI or SSML) |
+| **Format I/O** | UTF8StreamJsonParser reads bytes | SheetReader / SheetWriter (interface) | Raw format read/write — **swappable** (Streaming or POI User Model) |
 
 Layer 3 is fully inherited — all Jackson annotations, overloads, and features work as-is. Layer 2 is where the library's core logic lives. Layer 1 is pluggable behind an interface.
 

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Throughput close to FastExcel at 100K rows (writer slightly faster), with ~20% l
 XLSX (OOXML) and XLS (legacy). XLSX uses StAX streaming; XLS uses POI object model.
 
 **Q: Is it production-ready?**
-Yes. Version 1.6.5 on Maven Central. Java 8+, Jackson 2.14+, POI 4.1.1+. Listed as a [community data format module](https://github.com/FasterXML/jackson#data-format-modules) in the FasterXML jackson repository.
+Yes. Available on Maven Central. Java 8+, Jackson 2.14+, POI 4.1.1+. Listed as a [community data format module](https://github.com/FasterXML/jackson#data-format-modules) in the FasterXML jackson repository.
 
 **Q: Is the mapper thread-safe?**
 The mapper instance is reusable across threads once configured (same rule as Jackson's `ObjectMapper`). Concurrent calls with `File` / `InputStream` / `OutputStream` inputs are safe — the library opens an isolated `Workbook` per call. If you pass a `Sheet` directly, POI's `Workbook`/`Sheet` are not thread-safe, so each thread needs its own.

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SpreadsheetFactory.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SpreadsheetFactory.java
@@ -240,13 +240,10 @@ public final class SpreadsheetFactory extends JsonFactory {
     }
 
     private SheetReader _createFileSheetReader(final SheetInput<File> src) throws IOException {
-        if (Feature.USE_POI_USER_MODEL.enabledIn(_featureFlags)) {
+        if (_shouldUsePOIUserModel(src.getRaw())) {
             return _createPOISheetReader(WorkbookFactory.create(src.getRaw()), src);
         }
-        if (PackageUtil.isOOXML(src.getRaw())) {
-            return _createSSMLSheetReader(SSMLWorkbook.create(src.getRaw()), src);
-        }
-        return _createPOISheetReader(WorkbookFactory.create(src.getRaw()), src);
+        return _createSSMLSheetReader(SSMLWorkbook.create(src.getRaw()), src);
     }
 
     private SheetReader _createInputStreamSheetReader(
@@ -283,6 +280,11 @@ public final class SpreadsheetFactory extends JsonFactory {
             throw new IllegalArgumentException("No sheet for " + src);
         }
         return new POISheetReader(sheet);
+    }
+
+    private boolean _shouldUsePOIUserModel(final File src) {
+        return Feature.USE_POI_USER_MODEL.enabledIn(_featureFlags)
+            || !PackageUtil.isOOXML(src);
     }
 
     // Copy InputStream to temp File — POI's File path uses much less heap than InputStream (POIFS HOWTO ~20% vs ~120% for HSSF; OPCPackage Javadoc reports the same trend for OOXML).
@@ -343,17 +345,16 @@ public final class SpreadsheetFactory extends JsonFactory {
         final Workbook workbook = _workbookProvider.create();
         final Sheet sheet = out.isNamed()
                 ? workbook.createSheet(out.getName()) : workbook.createSheet();
-        if (Feature.USE_POI_USER_MODEL.enabledIn(_featureFlags)) {
-            return _createPOISheetWriter(sheet, out.getRaw());
-        }
-        if (sheet instanceof XSSFSheet) {
-            return _createSSMLSheetWriter(out.getRaw(), sheet);
-        }
-        if (log.isDebugEnabled()) {
+        final boolean useUserModel = _shouldUsePOIUserModel(sheet);
+        final boolean autoFallback = useUserModel && !Feature.USE_POI_USER_MODEL.enabledIn(_featureFlags);
+        if (autoFallback && log.isDebugEnabled()) {
             log.debug("Sheet is not XSSFSheet ({}); falling back to POISheetWriter",
                     sheet.getClass().getSimpleName());
         }
-        return _createPOISheetWriter(sheet, out.getRaw());
+        if (useUserModel) {
+            return _createPOISheetWriter(sheet, out.getRaw());
+        }
+        return _createSSMLSheetWriter(out.getRaw(), sheet);
     }
 
     private SSMLSheetWriter _createSSMLSheetWriter(
@@ -371,6 +372,11 @@ public final class SpreadsheetFactory extends JsonFactory {
         return new POISheetWriter(sheet, out);
     }
 
+    private boolean _shouldUsePOIUserModel(final Sheet sheet) {
+        return Feature.USE_POI_USER_MODEL.enabledIn(_featureFlags)
+            || !(sheet instanceof XSSFSheet);
+    }
+
     @SuppressWarnings("unchecked")
     private SheetOutput<OutputStream> _rawAsOutputStream(
             final SheetOutput<?> out) throws IOException {
@@ -384,8 +390,14 @@ public final class SpreadsheetFactory extends JsonFactory {
      */
     public enum Feature implements FormatFeature {
         /**
-         * Use POI's User Model ({@code Sheet}/{@code Row}/{@code Cell}) for all read/write operations,
-         * bypassing SSML streaming. Default: disabled (SSML is used for OOXML).
+         * Force POI User Model ({@code Sheet}/{@code Row}/{@code Cell}) for OOXML read/write,
+         * bypassing SSML streaming.
+         *
+         * <p>POI User Model is also selected automatically when SSML is not applicable:
+         * direct {@code Sheet} input/output, XLS files, non-OOXML {@code InputStream},
+         * or non-XSSF custom workbooks. This flag is one of several triggers.
+         *
+         * <p>Default: disabled.
          */
         USE_POI_USER_MODEL(false),
         /**


### PR DESCRIPTION
## Summary

POISheetReader/POISheetWriter activation conditions were spread across multiple if-branches, making it non-obvious which inputs drive the POI path. Collapse the dispatch into a single boolean decision (`_shouldUsePOIUserModel`). The `USE_POI_USER_MODEL` flag becomes one trigger among several — automatic triggers (direct `Sheet` input/output, XLS files, non-XSSF custom workbooks) live in the same decision function.

## Changes

- `SpreadsheetFactory._shouldUsePOIUserModel(File)` / `(Sheet)` — single boolean decision function
- `_createFileSheetReader` / `_createSheetWriter` — branches collapsed to a single if
- `USE_POI_USER_MODEL` javadoc — clarifies the flag as one of several triggers
- ARCHITECTURE.md — Write path Dual Writer Strategy table now mirrors the Read path layout; stale per-op timing row removed
- ARCHITECTURE.md — Layer table uses user-facing mode names (Streaming / POI User Model) instead of the internal SSML abbreviation
- README.md FAQ Q6 — hard-coded version number dropped (the Maven Central badge already shows the current version)

## Behavior preservation

This is an internal restructuring. External API and runtime behavior are unchanged.

| Path | Before | After |
|------|--------|-------|
| File + flag enabled | POI, isOOXML skipped | POI, short-circuit |
| File + flag disabled + OOXML | SSML | SSML |
| File + flag disabled + XLS | POI | POI |
| Write flag enabled | POI, no log | POI, no log |
| Write flag disabled + XSSF | SSML | SSML |
| Write flag disabled + non-XSSF | POI + debug log | POI + debug log |

## Test plan

- [x] `./gradlew test` — 413 tests pass, 0 failures, 3 skipped (pre-existing)
- [x] `./gradlew check` — pass
- [x] Read/Write path behavior equivalence verified across all 4 cases each