### PR TITLE
Extend POI User Model decision to the InputStream path

### DIFF
--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SpreadsheetFactory.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SpreadsheetFactory.java
@@ -287,14 +287,18 @@ public final class SpreadsheetFactory extends JsonFactory {
             || !PackageUtil.isOOXML(src);
     }
 
+    private boolean _shouldUsePOIUserModel(final InputStream src) {
+        return Feature.USE_POI_USER_MODEL.enabledIn(_featureFlags)
+            || !PackageUtil.isOOXML(src);
+    }
+
     // Copy InputStream to temp File — POI's File path uses much less heap than InputStream (POIFS HOWTO ~20% vs ~120% for HSSF; OPCPackage Javadoc reports the same trend for OOXML).
     @SuppressWarnings("unchecked")
     private SheetInput<?> _preferRawAsFile(final SheetInput<?> src) throws IOException {
         if (src.isFile()) return src;
-        if (Feature.USE_POI_USER_MODEL.enabledIn(_featureFlags)) return src;
         final InputStream raw = FileMagic.prepareToCheckMagic(
                 ((SheetInput<InputStream>) src).getRaw());
-        if (!PackageUtil.isOOXML(raw)) {
+        if (_shouldUsePOIUserModel(raw)) {
             return src.isNamed()
                     ? SheetInput.source(raw, src.getName())
                     : SheetInput.source(raw, src.getIndex());


### PR DESCRIPTION
## Summary

#161 unified the POI User Model trigger checks for File and Sheet inputs into `_shouldUsePOIUserModel(File)` / `(Sheet)`. The InputStream path in `_preferRawAsFile` still inlined the same `flag || !isOOXML` logic. Add a matching `_shouldUsePOIUserModel(InputStream)` overload and route the spool decision through it, so every POI User Model trigger now resolves in a single function family.

## Changes

- `_shouldUsePOIUserModel(InputStream)` overload added
- `_preferRawAsFile` collapses the two inline checks into a single call

## Behavior preservation

`prepareToCheckMagic` now runs before the flag check rather than only on the SSML spool branch. This is observably a no-op:

- POI's `WorkbookFactory.create(InputStream)` calls `prepareToCheckMagic` internally anyway
- `prepareToCheckMagic` returns the original stream when `markSupported` is true, otherwise wraps in `BufferedInputStream`
- The InputStream path never engages `isResourceManaged && isFile` (the temp-file cleanup), and `AUTO_CLOSE_SOURCE` (default true) already drove `_reader.close()` in both before and after

| Path | Before | After |
|------|--------|-------|
| InputStream + flag enabled | src returned, prepareToCheckMagic skipped | prepareToCheckMagic + wrapped src |
| InputStream + flag disabled + XLS | wrap | wrap |
| InputStream + flag disabled + OOXML | spool to temp file | spool to temp file |

The flag-enabled row flips `resourceManaged` from false to true. `SheetParser.close` only reacts to `resourceManaged && isFile`, which stays false for any InputStream input — so no observable change.

## Test plan

- [x] \`./gradlew test\` — 413 tests pass, 0 failures, 3 skipped (pre-existing)
- [x] Behavior equivalence verified across all three InputStream paths