### PR TITLE
Reflect unified POI User Model decision in Read/Write Path diagrams

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -180,10 +180,9 @@ mapper.readValue(file, Employee.class)
   │    └─ Jackson FormatVisitor → annotation introspection → SpreadsheetSchema
   │
   ├─ SpreadsheetFactory.createParser(file)
-  │    ├─ USE_POI_USER_MODEL? → POISheetReader (POI object model)
-  │    ├─ PackageUtil.isOOXML(file)?
-  │    │   ├─ yes → SSMLSheetReader (StAX streaming)
-  │    │   └─ no  → POISheetReader  (POI object model)
+  │    ├─ USE_POI_USER_MODEL OR non-OOXML(file)?
+  │    │   ├─ yes → POISheetReader (POI object model)
+  │    │   └─ no  → SSMLSheetReader (StAX streaming)
   │    └─ new SheetParser(reader, formatFeatures)
   │
   └─ SheetParser.nextToken() loop
@@ -246,10 +245,9 @@ Result: lowest memory allocation among all tested libraries at 100K rows. See [B
 mapper.writeValue(file, employee)
   │
   ├─ SpreadsheetFactory.createGenerator(file)
-  │    ├─ USE_POI_USER_MODEL?
+  │    ├─ USE_POI_USER_MODEL OR non-XSSF(sheet)?
   │    │   ├─ yes → POISheetWriter → SheetGenerator
-  │    │   └─ no  → XSSFSheet? → SSMLSheetWriter → SheetGenerator
-  │    └─ non-XSSF fallback → POISheetWriter → SheetGenerator
+  │    │   └─ no  → SSMLSheetWriter → SheetGenerator
   │
   └─ Jackson BeanSerializer
        ├─ writeStartObject()


### PR DESCRIPTION
## Summary

Both Read Path and Write Path diagrams in ARCHITECTURE.md showed the dispatch as multiple cascading checks (flag, format, fallback) — the shape the factory used before #161/#162. The factory now resolves them through a single `_shouldUsePOIUserModel` predicate. Update each diagram to one condition listing so the documented flow matches the code.

## Changes

- Read Path diagram (`createParser(file)` branch): replaced the two-step `USE_POI_USER_MODEL? → POISheetReader` + `PackageUtil.isOOXML(file)?` with `USE_POI_USER_MODEL OR non-OOXML(file)?`
- Write Path diagram (`createGenerator(file)` branch): replaced the three-step flag/XSSFSheet/fallback sequence with `USE_POI_USER_MODEL OR non-XSSF(sheet)?`

## Test plan

- [x] Diagram condition matches `_shouldUsePOIUserModel(File)` = `flag || !isOOXML(src)` (Read) and `_shouldUsePOIUserModel(Sheet)` = `flag || !(sheet instanceof XSSFSheet)` (Write)
- [x] No code change; existing tests remain valid