### PR TITLE
Fix mergeScopedColumns overflow for sibling nested lists

### DIFF
--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SheetStreamContext.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SheetStreamContext.java
@@ -68,6 +68,10 @@ public abstract class SheetStreamContext extends JsonStreamContext {
         return _size;
     }
 
+    public int getMaxChildArrayRowSpan() {
+        return 0;
+    }
+
     public abstract int getRow();
 
     public abstract int getColumn();
@@ -160,6 +164,12 @@ public abstract class SheetStreamContext extends JsonStreamContext {
         @Override
         public SheetStreamContext clearAndGetParent() {
             _parent._size += _size - 1;
+            if (this instanceof ArrayContext && _parent instanceof ObjectContext) {
+                final ObjectContext parent = (ObjectContext) _parent;
+                if (_size > parent._maxChildArrayRowSpan) {
+                    parent._maxChildArrayRowSpan = _size;
+                }
+            }
             return super.clearAndGetParent();
         }
     }
@@ -219,9 +229,15 @@ public abstract class SheetStreamContext extends JsonStreamContext {
     static final class ObjectContext extends ChildContext {
 
         private String _name;
+        int _maxChildArrayRowSpan;
 
         ObjectContext(final SheetStreamContext parent) {
             super(TYPE_OBJECT, parent);
+        }
+
+        @Override
+        public int getMaxChildArrayRowSpan() {
+            return _maxChildArrayRowSpan;
         }
 
         @Override

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/BackWriteProjection.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/BackWriteProjection.java
@@ -1,8 +1,10 @@
 package io.github.scndry.jackson.dataformat.spreadsheet.schema.internal;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.WeakHashMap;
 
 import lombok.extern.slf4j.Slf4j;
@@ -113,13 +115,36 @@ public final class BackWriteProjection {
         return false;
     }
 
-    /** Cached form of {@link #hasOuterFieldAfterList(SpreadsheetSchema)}.
-     *  Writers call this once per nested array to gate flush suspension —
-     *  the cache avoids recomputing the result across every record. */
+    /** Returns true when the schema has more than one top-level array
+     *  field — sibling lists share the parent row, so the second list
+     *  must back-write into rows already produced by the first list. */
+    public static boolean hasMultipleSiblingLists(final SpreadsheetSchema schema) {
+        final Set<ColumnPointer> topLevelArrays = new HashSet<>();
+        for (final Column c : schema) {
+            if (c == null) continue;
+            final ColumnPointer head = _topLevelArrayHead(c.getPointer());
+            if (head != null) topLevelArrays.add(head);
+        }
+        return topLevelArrays.size() > 1;
+    }
+
+    private static ColumnPointer _topLevelArrayHead(final ColumnPointer pointer) {
+        ColumnPointer head = ColumnPointer.empty();
+        for (final ColumnPointer seg : pointer) {
+            head = head.resolve(seg);
+            if (seg.equals(ColumnPointer.array())) return head;
+        }
+        return null;
+    }
+
+    /** Cached form of {@link #hasOuterFieldAfterList(SpreadsheetSchema)} or
+     *  {@link #hasMultipleSiblingLists(SpreadsheetSchema)}. Writers call this
+     *  once per nested array to gate flush suspension — the cache avoids
+     *  recomputing the result across every record. */
     public static boolean requiresBackWriteScope(final SpreadsheetSchema schema) {
         final Boolean cached = SCOPE_CACHE.get(schema);
         if (cached != null) return cached;
-        final boolean v = hasOuterFieldAfterList(schema);
+        final boolean v = hasOuterFieldAfterList(schema) || hasMultipleSiblingLists(schema);
         SCOPE_CACHE.put(schema, v);
         return v;
     }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/ser/SheetGenerator.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/ser/SheetGenerator.java
@@ -134,6 +134,18 @@ public final class SheetGenerator extends GeneratorBase {
     public void writeEndArray() throws IOException {
         final boolean nested = !_outputContext.getParent().inRoot();
         final boolean backWriteRisk = nested && BackWriteProjection.requiresBackWriteScope(_schema);
+        if (nested) {
+            // Sibling list length check — unequal sizes would produce
+            // overlapping merged regions across siblings.
+            final int actualSize = _outputContext.size();
+            final int previousSpan = _outputContext.getParent().getMaxChildArrayRowSpan();
+            if (previousSpan > 0 && previousSpan != actualSize) {
+                throw new SheetStreamWriteException(
+                        "Sibling nested List<T> fields in @DataGrid must have equal sizes."
+                        + " Previous list size: " + previousSpan
+                        + ", current list size: " + actualSize, this);
+            }
+        }
         _outputContext = _closeStruct(END_ARRAY);
         _writer.restoreRowWindow();
         if (backWriteRisk) {
@@ -154,10 +166,10 @@ public final class SheetGenerator extends GeneratorBase {
 
     @Override
     public void writeEndObject() throws IOException {
-        final int size = _outputContext.size();
+        final int rowSpan = _outputContext.getMaxChildArrayRowSpan();
         _outputContext = _closeStruct(END_OBJECT);
         final ColumnPointer pointer = _outputContext.currentPointer();
-        _writer.mergeScopedColumns(pointer, _outputContext.getRow(), size);
+        _writer.mergeScopedColumns(pointer, _outputContext.getRow(), rowSpan);
     }
 
     @Override

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/MergeTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/MergeTest.java
@@ -488,4 +488,302 @@ class MergeTest {
     private File tempFile(String name) {
         return tempDir.resolve(name).toFile();
     }
+
+    // -- Sibling nested lists reproduction (mergeRange off-by-one bug) --
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class Item {
+        @DataColumn("ItemB") int b;
+        @DataColumn("ItemC") int c;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class Note {
+        @DataColumn("NoteB") int b;
+        @DataColumn("NoteC") int c;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class TwoListsOuter {
+        @DataColumn(value = "ID", merge = OptBoolean.TRUE) int id;
+        List<Item> items;
+        List<Note> notes;
+        @DataColumn(value = "Total", merge = OptBoolean.TRUE) int total;
+    }
+
+    @Test
+    void siblingNestedLists_mergeRangeMustNotOverflow() throws Exception {
+        File file = new File("/tmp/jackson-spreadsheet-multi-list-bug.xlsx");
+        if (file.exists() && !file.delete()) {
+            throw new IllegalStateException("Failed to delete " + file);
+        }
+
+        // Two outers, each with items[2] + notes[2] (same length M=N=2)
+        TwoListsOuter outer1 = new TwoListsOuter(
+                1,
+                Arrays.asList(new Item(11, 12), new Item(13, 14)),
+                Arrays.asList(new Note(15, 16), new Note(17, 18)),
+                99);
+        TwoListsOuter outer2 = new TwoListsOuter(
+                2,
+                Arrays.asList(new Item(21, 22), new Item(23, 24)),
+                Arrays.asList(new Note(25, 26), new Note(27, 28)),
+                199);
+
+        mapper.writeValue(file, Arrays.asList(outer1, outer2), TwoListsOuter.class);
+
+        System.out.println("[Reproduction] Written to: " + file.getAbsolutePath());
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            List<CellRangeAddress> merged = sheet.getMergedRegions();
+
+            System.out.println("[Reproduction] Merged regions:");
+            for (CellRangeAddress r : merged) {
+                System.out.println("  " + r);
+            }
+
+            // Expected: each outer's id (col 0) mergeRange spans max(M,N) = 2 rows.
+            // Bug: spans M+N-1 = 3 rows → overlaps the next outer's first row.
+            assertThat(merged)
+                    .filteredOn(r -> r.getFirstColumn() == 0)
+                    .allSatisfy(r -> {
+                        int rowSpan = r.getLastRow() - r.getFirstRow() + 1;
+                        assertThat(rowSpan)
+                                .as("id mergeRange row span (expected max(M,N)=2, "
+                                        + "bug spans M+N-1=3)")
+                                .isEqualTo(2);
+                    });
+        }
+    }
+
+    @Test
+    void siblingNestedLists_mergeRangeMustNotOverflow_ssmlMode() throws Exception {
+        // SSML emits XML directly, so the bug surfaces as overlapping
+        // mergedRegions instead of an immediate throw (POI mode).
+        File file = new File("/tmp/jackson-spreadsheet-multi-list-bug-ssml.xlsx");
+        if (file.exists() && !file.delete()) {
+            throw new IllegalStateException("Failed to delete " + file);
+        }
+
+        SpreadsheetMapper ssmlMapper = new SpreadsheetMapper();
+
+        TwoListsOuter outer1 = new TwoListsOuter(
+                1,
+                Arrays.asList(new Item(11, 12), new Item(13, 14)),
+                Arrays.asList(new Note(15, 16), new Note(17, 18)),
+                99);
+        TwoListsOuter outer2 = new TwoListsOuter(
+                2,
+                Arrays.asList(new Item(21, 22), new Item(23, 24)),
+                Arrays.asList(new Note(25, 26), new Note(27, 28)),
+                199);
+
+        ssmlMapper.writeValue(file, Arrays.asList(outer1, outer2), TwoListsOuter.class);
+
+        System.out.println("[SSML Reproduction] Written to: " + file.getAbsolutePath());
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            List<CellRangeAddress> merged = sheet.getMergedRegions();
+
+            System.out.println("[SSML Reproduction] Merged regions:");
+            for (CellRangeAddress r : merged) {
+                System.out.println("  " + r);
+            }
+
+            assertThat(merged)
+                    .filteredOn(r -> r.getFirstColumn() == 0)
+                    .allSatisfy(r -> {
+                        int rowSpan = r.getLastRow() - r.getFirstRow() + 1;
+                        assertThat(rowSpan)
+                                .as("id mergeRange row span (expected max(M,N)=2, "
+                                        + "bug spans M+N-1=3)")
+                                .isEqualTo(2);
+                    });
+        }
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class TwoListsWithMiddleField {
+        @DataColumn(value = "ID", merge = OptBoolean.TRUE) int id;
+        List<Item> items;
+        @DataColumn(value = "Mid", merge = OptBoolean.TRUE) int middle;   // between lists
+        List<Note> notes;
+        @DataColumn(value = "Total", merge = OptBoolean.TRUE) int total;
+    }
+
+    @Test
+    void siblingNestedLists_middleField_poiMode() throws Exception {
+        File file = tempFile("middle-field-poi.xlsx");
+
+        TwoListsWithMiddleField outer1 = new TwoListsWithMiddleField(
+                1,
+                Arrays.asList(new Item(11, 12), new Item(13, 14)),
+                50,
+                Arrays.asList(new Note(15, 16), new Note(17, 18)),
+                99);
+        TwoListsWithMiddleField outer2 = new TwoListsWithMiddleField(
+                2,
+                Arrays.asList(new Item(21, 22), new Item(23, 24)),
+                150,
+                Arrays.asList(new Note(25, 26), new Note(27, 28)),
+                199);
+
+        mapper.writeValue(file, Arrays.asList(outer1, outer2),
+                TwoListsWithMiddleField.class);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            List<CellRangeAddress> merged = sheet.getMergedRegions();
+            assertThat(merged)
+                    .filteredOn(r -> r.getFirstColumn() == 0)
+                    .allSatisfy(r -> {
+                        int rowSpan = r.getLastRow() - r.getFirstRow() + 1;
+                        assertThat(rowSpan).isEqualTo(2);
+                    });
+        }
+    }
+
+    @Test
+    void siblingNestedLists_middleField_ssmlMode() throws Exception {
+        File file = new File("/tmp/jackson-spreadsheet-multi-list-middle-bug-ssml.xlsx");
+        if (file.exists() && !file.delete()) {
+            throw new IllegalStateException("Failed to delete " + file);
+        }
+
+        SpreadsheetMapper ssmlMapper = new SpreadsheetMapper();
+
+        TwoListsWithMiddleField outer1 = new TwoListsWithMiddleField(
+                1,
+                Arrays.asList(new Item(11, 12), new Item(13, 14)),
+                50,
+                Arrays.asList(new Note(15, 16), new Note(17, 18)),
+                99);
+        TwoListsWithMiddleField outer2 = new TwoListsWithMiddleField(
+                2,
+                Arrays.asList(new Item(21, 22), new Item(23, 24)),
+                150,
+                Arrays.asList(new Note(25, 26), new Note(27, 28)),
+                199);
+
+        ssmlMapper.writeValue(file, Arrays.asList(outer1, outer2),
+                TwoListsWithMiddleField.class);
+
+        System.out.println("[SSML Middle] Written to: " + file.getAbsolutePath());
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            List<CellRangeAddress> merged = sheet.getMergedRegions();
+
+            System.out.println("[SSML Middle] Merged regions:");
+            for (CellRangeAddress r : merged) {
+                System.out.println("  " + r);
+            }
+
+            assertThat(merged)
+                    .filteredOn(r -> r.getFirstColumn() == 0)
+                    .allSatisfy(r -> {
+                        int rowSpan = r.getLastRow() - r.getFirstRow() + 1;
+                        assertThat(rowSpan)
+                                .as("id mergeRange row span (expected max(M,N)=2)")
+                                .isEqualTo(2);
+                    });
+        }
+    }
+
+    @Test
+    void siblingNestedLists_lengthMismatch_throws() {
+        File file = tempFile("length-mismatch.xlsx");
+
+        TwoListsOuter outer = new TwoListsOuter(
+                1,
+                Arrays.asList(new Item(11, 12), new Item(13, 14)),
+                Arrays.asList(new Note(15, 16), new Note(17, 18), new Note(19, 20)),
+                99);
+
+        assertThatThrownBy(() -> mapper.writeValue(file, outer))
+                .rootCause()
+                .hasMessageContaining("Sibling nested List<T> fields")
+                .hasMessageContaining("Previous list size: 2")
+                .hasMessageContaining("current list size: 3");
+    }
+
+    @Test
+    void siblingNestedLists_lengthMismatch_throws_ssmlMode() {
+        File file = tempFile("length-mismatch-ssml.xlsx");
+        SpreadsheetMapper ssmlMapper = new SpreadsheetMapper();
+
+        TwoListsOuter outer = new TwoListsOuter(
+                1,
+                Arrays.asList(new Item(11, 12), new Item(13, 14)),
+                Arrays.asList(new Note(15, 16), new Note(17, 18), new Note(19, 20)),
+                99);
+
+        assertThatThrownBy(() -> ssmlMapper.writeValue(file, outer))
+                .rootCause()
+                .hasMessageContaining("Sibling nested List<T> fields")
+                .hasMessageContaining("Previous list size: 2")
+                .hasMessageContaining("current list size: 3");
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class Detail {
+        @DataColumn("DetailX") int x;
+        @DataColumn("DetailY") int y;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class WithNested {
+        @DataColumn("Yi") int yi;
+        List<Detail> zs;
+        @DataColumn("Yj") int yj;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class SiblingWithNestedOuter {
+        @DataColumn(value = "ID", merge = OptBoolean.TRUE) int id;
+        List<Item> xs;            // flat element
+        List<WithNested> ys;      // nested element (contains List<Detail>)
+    }
+
+    @Test
+    void siblingNestedLists_innerNested_throws() {
+        // xs row span = 2 (flat).
+        // ys = 1 WithNested with 3 details → row span = 3.
+        // Length mismatch caught by sibling length check at ys close.
+        File file = tempFile("sibling-with-nested.xlsx");
+
+        SiblingWithNestedOuter outer = new SiblingWithNestedOuter(
+                1,
+                Arrays.asList(new Item(11, 12), new Item(13, 14)),
+                Arrays.asList(new WithNested(20,
+                        Arrays.asList(new Detail(21, 22), new Detail(23, 24), new Detail(25, 26)),
+                        29)));
+
+        assertThatThrownBy(() -> mapper.writeValue(file, outer))
+                .rootCause()
+                .hasMessageContaining("Sibling nested List<T> fields")
+                .hasMessageContaining("Previous list size: 2")
+                .hasMessageContaining("current list size: 3");
+    }
+
+    @Test
+    void siblingNestedLists_innerNested_throws_ssmlMode() {
+        File file = tempFile("sibling-with-nested-ssml.xlsx");
+        SpreadsheetMapper ssmlMapper = new SpreadsheetMapper();
+
+        SiblingWithNestedOuter outer = new SiblingWithNestedOuter(
+                1,
+                Arrays.asList(new Item(11, 12), new Item(13, 14)),
+                Arrays.asList(new WithNested(20,
+                        Arrays.asList(new Detail(21, 22), new Detail(23, 24), new Detail(25, 26)),
+                        29)));
+
+        assertThatThrownBy(() -> ssmlMapper.writeValue(file, outer))
+                .rootCause()
+                .hasMessageContaining("Sibling nested List<T> fields")
+                .hasMessageContaining("Previous list size: 2")
+                .hasMessageContaining("current list size: 3");
+    }
 }


### PR DESCRIPTION
## Summary

ObjectContext tracks the max child-array row span separately from Jackson's cumulative size, fixing the `mergeScopedColumns` overflow that previously caused sibling `List<T>` fields to produce merged regions overlapping into the next outer record's first row.

`writeEndArray` rejects sibling lists with mismatched sizes at write time. `BackWriteProjection.requiresBackWriteScope` now also returns true for schemas with multiple top-level arrays, so the SSML writer keeps buffered cells alive across siblings and back-writes into rows produced by the earlier sibling succeed.

## Test plan

- [x] `MergeTest` reproductions for POI and SSML modes, covering same-length sibling lists, middle outer field, length mismatch, and sibling with an internally nested element type
- [x] `SSMLSheetWriterDomEquivalenceTest.sheetXmlDomEquivalent_twoNestedListsPerRecord` (byte-level POI/SSML equivalence) still passes
- [x] Full `./gradlew test` green