### PR TITLE
Detect back-write trigger at every record scope

### DIFF
--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/BackWriteProjection.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/BackWriteProjection.java
@@ -2,6 +2,7 @@ package io.github.scndry.jackson.dataformat.spreadsheet.schema.internal;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -98,21 +99,50 @@ public final class BackWriteProjection {
         return String.format("%.2f GB", bytes / (1024.0 * 1024 * 1024));
     }
 
-    /** Returns true when the schema's column order has any outer
-     *  (non-array-scope) column appearing after at least one inner
-     *  (array-scope) column — the trigger for SSML back-write. */
+    /** Returns true when any record scope (root or nested) has an
+     *  outer field of that scope appearing after a child array of the
+     *  same scope — the trigger for SSML back-write at that scope. */
     public static boolean hasOuterFieldAfterList(final SpreadsheetSchema schema) {
-        boolean seenInner = false;
+        final Set<ColumnPointer> scopes = new LinkedHashSet<>();
+        scopes.add(ColumnPointer.empty());
         for (final Column c : schema) {
             if (c == null) continue;
-            final boolean inner = c.getPointer().contains(ColumnPointer.array());
-            if (inner) {
-                seenInner = true;
-            } else if (seenInner) {
-                return true;
+            ColumnPointer head = ColumnPointer.empty();
+            for (final ColumnPointer seg : c.getPointer()) {
+                head = head.resolve(seg);
+                if (seg.equals(ColumnPointer.array())) scopes.add(head);
+            }
+        }
+        for (final ColumnPointer scope : scopes) {
+            if (_outerAfterListAt(schema, scope)) return true;
+        }
+        return false;
+    }
+
+    private static boolean _outerAfterListAt(
+            final SpreadsheetSchema schema, final ColumnPointer scope) {
+        boolean seenChildArray = false;
+        for (final Column c : schema) {
+            if (c == null) continue;
+            final ColumnPointer myScope = _immediateScope(c.getPointer());
+            if (!myScope.equals(scope) && !myScope.startsWith(scope)) continue;
+            if (myScope.equals(scope)) {
+                if (seenChildArray) return true;
+            } else {
+                seenChildArray = true;
             }
         }
         return false;
+    }
+
+    private static ColumnPointer _immediateScope(final ColumnPointer pointer) {
+        ColumnPointer head = ColumnPointer.empty();
+        ColumnPointer last = ColumnPointer.empty();
+        for (final ColumnPointer seg : pointer) {
+            head = head.resolve(seg);
+            if (seg.equals(ColumnPointer.array())) last = head;
+        }
+        return last;
     }
 
     /** Returns true when the schema has more than one top-level array

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/BackWriteProjectionTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/BackWriteProjectionTest.java
@@ -125,6 +125,49 @@ class BackWriteProjectionTest {
         assertThat(BackWriteProjection.requiresBackWriteScope(schema)).isFalse();
     }
 
+    // Mid level holds the outer-after-list pattern; root is clean
+    // (id + items[] only). Triggers SSML back-write at the items/[] scope
+    // — root-only detection misses this.
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class MidWithTrailing {
+        @DataColumn(value = "midId", merge = OptBoolean.TRUE) String midId;
+        List<Inner> details;
+        @DataColumn(value = "midName", merge = OptBoolean.TRUE) String midName;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class NestedOuterAfterList {
+        @DataColumn(value = "id", merge = OptBoolean.TRUE) int id;
+        List<MidWithTrailing> items;
+    }
+
+    @Test
+    void requiresBackWriteScope_nestedScopeOuterAfterListReturnsTrue() throws Exception {
+        final SpreadsheetSchema schema = _schemaFor(NestedOuterAfterList.class);
+        assertThat(BackWriteProjection.requiresBackWriteScope(schema)).isTrue();
+    }
+
+    // Mid level keeps outer-before-list ordering at every scope; back-write
+    // not required anywhere.
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class MidOuterFirst {
+        @DataColumn(value = "midId", merge = OptBoolean.TRUE) String midId;
+        @DataColumn(value = "midName", merge = OptBoolean.TRUE) String midName;
+        List<Inner> details;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class NestedOuterFirst {
+        @DataColumn(value = "id", merge = OptBoolean.TRUE) int id;
+        List<MidOuterFirst> items;
+    }
+
+    @Test
+    void requiresBackWriteScope_nestedScopeOuterFirstReturnsFalse() throws Exception {
+        final SpreadsheetSchema schema = _schemaFor(NestedOuterFirst.class);
+        assertThat(BackWriteProjection.requiresBackWriteScope(schema)).isFalse();
+    }
+
     // ----------------------------------------------------------------
     // Integration — writeStartArray's fail-fast on projected overflow
     // ----------------------------------------------------------------


### PR DESCRIPTION
## Summary
- hasOuterFieldAfterList missed outer-after-list patterns inside nested record scopes — pointer.contains([]) marked everything beneath any array as inner. SSML then skipped flush suspension and write failed on nested back-write.
- Reworked the detection to walk each record scope (root + every array scope) independently, using immediateScope to decide whether a column belongs to the scope or its child arrays.

## Test plan
- BackWriteProjectionTest gains positive (NestedOuterAfterList) and negative (NestedOuterFirst) coverage for the nested-scope walk.
- Existing Outer / OuterFirst cases still pass because the per-scope walk also evaluates the empty scope.
- `./gradlew clean test` passes (5 executed).