### PR TITLE
Detect multi-sibling lists at every record scope

### DIFF
--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/BackWriteProjection.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/BackWriteProjection.java
@@ -1,6 +1,7 @@
 package io.github.scndry.jackson.dataformat.spreadsheet.schema.internal;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -145,26 +146,28 @@ public final class BackWriteProjection {
         return last;
     }
 
-    /** Returns true when the schema has more than one top-level array
-     *  field — sibling lists share the parent row, so the second list
-     *  must back-write into rows already produced by the first list. */
+    /** Returns true when any record scope (root or nested) has more than
+     *  one immediate child array — sibling lists share the parent row,
+     *  so the second list must back-write into rows already produced by
+     *  the first list. */
     public static boolean hasMultipleSiblingLists(final SpreadsheetSchema schema) {
-        final Set<ColumnPointer> topLevelArrays = new HashSet<>();
+        final Map<ColumnPointer, Set<ColumnPointer>> childArraysByParent = new HashMap<>();
         for (final Column c : schema) {
             if (c == null) continue;
-            final ColumnPointer head = _topLevelArrayHead(c.getPointer());
-            if (head != null) topLevelArrays.add(head);
+            ColumnPointer head = ColumnPointer.empty();
+            ColumnPointer parent = ColumnPointer.empty();
+            for (final ColumnPointer seg : c.getPointer()) {
+                head = head.resolve(seg);
+                if (seg.equals(ColumnPointer.array())) {
+                    childArraysByParent.computeIfAbsent(parent, k -> new HashSet<>()).add(head);
+                    parent = head;
+                }
+            }
         }
-        return topLevelArrays.size() > 1;
-    }
-
-    private static ColumnPointer _topLevelArrayHead(final ColumnPointer pointer) {
-        ColumnPointer head = ColumnPointer.empty();
-        for (final ColumnPointer seg : pointer) {
-            head = head.resolve(seg);
-            if (seg.equals(ColumnPointer.array())) return head;
+        for (final Set<ColumnPointer> childArrays : childArraysByParent.values()) {
+            if (childArrays.size() > 1) return true;
         }
-        return null;
+        return false;
     }
 
     /** Cached form of {@link #hasOuterFieldAfterList(SpreadsheetSchema)} or

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/BackWriteProjectionTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/BackWriteProjectionTest.java
@@ -168,6 +168,48 @@ class BackWriteProjectionTest {
         assertThat(BackWriteProjection.requiresBackWriteScope(schema)).isFalse();
     }
 
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class Extra {
+        @DataColumn("e") int e;
+    }
+
+    // Root scope holds two sibling lists — top-level detection already
+    // catches this. Baseline test the existing schema lacked.
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class RootSiblingLists {
+        @DataColumn("id") int id;
+        List<Inner> items;
+        List<Extra> extras;
+    }
+
+    @Test
+    void requiresBackWriteScope_rootMultiSiblingReturnsTrue() throws Exception {
+        final SpreadsheetSchema schema = _schemaFor(RootSiblingLists.class);
+        assertThat(BackWriteProjection.requiresBackWriteScope(schema)).isTrue();
+    }
+
+    // Sibling lists live inside a nested record (mids[]/{as[], bs[]}) —
+    // top-level head count is 1 (mids/[]), so top-level-only detection
+    // misses this.
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class NestedMultiSiblingMid {
+        @DataColumn("mid") String mid;
+        List<Inner> as;
+        List<Extra> bs;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class NestedMultiSiblingTop {
+        @DataColumn("id") int id;
+        List<NestedMultiSiblingMid> mids;
+    }
+
+    @Test
+    void requiresBackWriteScope_nestedScopeMultiSiblingReturnsTrue() throws Exception {
+        final SpreadsheetSchema schema = _schemaFor(NestedMultiSiblingTop.class);
+        assertThat(BackWriteProjection.requiresBackWriteScope(schema)).isTrue();
+    }
+
     // ----------------------------------------------------------------
     // Integration — writeStartArray's fail-fast on projected overflow
     // ----------------------------------------------------------------


### PR DESCRIPTION
## Summary
- hasMultipleSiblingLists counted only top-level array heads, so sibling lists inside a nested record (e.g. mids[]/{as[], bs[]}) reduced to a single mids/[] head and returned false. SSML then skipped flush suspension and write failed on the second sibling's back-write target.
- Reworked the detection to group each immediate child array head under its parent scope (root or any deeper array scope) and return true when any parent holds more than one child array.

## Test plan
- BackWriteProjectionTest adds positive cases for root sibling lists (RootSiblingLists — baseline the suite previously lacked) and nested sibling lists (NestedMultiSiblingTop — the actual gap).
- Existing single-list cases (Outer / OuterFirst / NestedOuterAfterList / NestedOuterFirst) still hold.
- `./gradlew clean test` passes (5 executed).