### PR TITLE
Use addMergedRegionUnsafe in POI writer's per-record merge loop

### DIFF
--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ss/POISheetWriter.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ss/POISheetWriter.java
@@ -223,7 +223,12 @@ public final class POISheetWriter implements SheetWriter {
             if (log.isTraceEnabled()) {
                 log.trace(region.formatAsString());
             }
-            _sheet.addMergedRegion(region);
+            // addMergedRegionUnsafe skips POI's overlap validation. Validation
+            // is O(K) over already-registered regions, so the per-record loop
+            // here would degrade to O(N²) at N outer records × merged outer
+            // columns. The library only merges outer columns over their
+            // record's row range, so distinct calls never overlap.
+            _sheet.addMergedRegionUnsafe(region);
             final CellStyle ds = _styles.resolve(column.getValue().getStyle(),
                     column.getType().getRawClass());
             _fillMergedInnerCellsVertical(row, row + size - 1, col, ds);


### PR DESCRIPTION
## Summary
- POISheetWriter.mergeScopedColumns's addMergedRegion call ran POI's overlap validation on every record (O(K) per call), accumulating to O(N²) at N outer records. NestedWriteBenchmark caught it: nestedPoi 10k/50k/100k scaled 1×/24.8×/102.6× (vs flatPoi's near-linear 1×/5.2×/10.4×).
- Switched to addMergedRegionUnsafe — the library only ever merges outer columns over each record's disjoint row range, so the validation was wasted work.

## Test plan
- `./gradlew clean test` passes (5 executed). Existing MergeTest / MergeRegionInnerCellsTest still pass, confirming the merge-region output remains correct.
- NestedWriteBenchmark re-run: nestedPoi 10k 2,983 → 50 ms, 50k 73,937 → 276 ms, 100k 305,846 → 534 ms (573× speedup at 100k). Scaling now linear (10k → 50k = 5.5×, 50k → 100k = 1.9×). nestedPoi is also ~30% faster than flatPoi at 100k thanks to nested's halved cell count.