### PR TITLE
Add nested-list read with anchor-based record-tree buffer

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -189,9 +189,12 @@ mapper.readValue(file, Employee.class)
        ├─ SheetReader.next() → SheetToken
        ├─ row/column bounds check against schema
        ├─ ColumnPointer scope tracking
-       ├─ JsonToken emission (with nesting)
+       ├─ Flat path → JsonToken emission (with nesting)
+       ├─ Anchor path → RecordTreeBuffer assembles record tree, emits per outer
        └─ Jackson BeanDeserializer consumes tokens → Employee
 ```
+
+The anchor path engages when the schema declares any `@DataColumn(anchor = true)`. `RecordTreeBuffer` buffers cells row-by-row into a record tree keyed by array scope and emits each outer record (with its nested lists attached) once an anchor change, blank row, or end of sheet closes the boundary. Flat schemas bypass the buffer — the read path stays a single-pass StAX consume.
 
 ### Dual Reader Strategy
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -95,6 +95,8 @@ POJO:         Employee { name="Alice", address=Address { city="Seoul", zip="1234
 
 Why automate this? Because nested objects are the norm in Java, but spreadsheets are flat. Every other Excel library forces you to manually bridge this gap — either flattening on write or reconstructing on read. This library does both directions automatically via Jackson's token model.
 
+Nested `List<T>` fields extend the same idea across rows: write expands the list into a multi-row block; read collapses the block back into the outer record when one column per record level is marked as the anchor. The anchor is the only explicit declaration the read side needs — the buffering, record-tree assembly, and back-write boundaries fall out of the same token model.
+
 ### Format I/O → Format detection
 
 You don't choose between XLSX and XLS parsers. You pass a file.

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -415,7 +415,7 @@ By default, nested field headers use the path from the parent (e.g., `address/zi
 
 ### Nested Lists
 
-Nested lists are serialized into multi-row output. *Deserialization is not currently supported.*
+Nested lists are serialized into multi-row output. The reverse — reading multi-row blocks back into nested lists — is supported when the outer record carries an anchor column (see [Reading Nested Lists](#reading-nested-lists)).
 
 ```java
 @DataGrid(mergeColumn = OptBoolean.TRUE)
@@ -457,6 +457,38 @@ SpreadsheetMapper mapper = new SpreadsheetMapper(
     new SpreadsheetFactory(() -> new SXSSFWorkbook(500),
         SpreadsheetFactory.DEFAULT_SHEET_PARSER_FEATURE_FLAGS));
 ```
+
+#### Reading Nested Lists
+
+Mark one column per nested-list-bearing record level with `@DataColumn(anchor = true)`. The reader watches that column for value changes to detect record boundaries — a sequence of rows sharing the same anchor value collapses into one outer record with the inner rows as its list.
+
+```java
+@DataGrid(mergeColumn = OptBoolean.TRUE)
+class Order {
+    @DataColumn(value = "Order ID", anchor = true) int orderId;
+    List<Item> items;
+    @DataColumn("Total") int total;
+}
+```
+
+```java
+List<Order> orders = mapper.readValues(file, Order.class);
+// One Order per distinct Order ID, items[] holds the inner rows.
+```
+
+Anchor invariants are checked at `setSchema` time and surface as `IllegalStateException`:
+
+- Each nested-list-bearing record level needs exactly one anchor column at its immediate scope.
+- Anchor columns on records without a nested list are rejected.
+- Multiple anchors at the same scope are rejected.
+
+The read path buffers cells into a record tree keyed by array scope and emits each outer record once its boundary closes (anchor change, blank row, or end of sheet). Buffer growth is capped by the same heap-aware bound used on the write side — split large outer records or switch to `USE_POI_USER_MODEL` if a single record cannot fit.
+
+`BLANK_ROW_AS_NULL` and `BREAK_ON_BLANK_ROW` carry the same semantics as in the flat path: a fully blank row closes the currently open outer record, then either inserts a `null` entry into the result list or terminates iteration.
+
+`FEATURE_COLUMN_REORDERING` is incompatible with nested-list schemas (every nested-list schema uses `@DataColumnGroup`, which forces multi-row headers); enabling both raises `IllegalStateException` at `setSchema`.
+
+ERROR cells (`#N/A`, `#DIV/0!`, etc.) in nested reads raise `SheetStreamReadException` at cell-arrival time — matching the flat path. The reader does not silently substitute `null` for an ERROR cell.
 
 ## Annotations
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ mapper.writeValue(output, products, Product.class);
 
 ### Complex Objects
 
-Nested objects flatten into columns. Lists of nested objects expand into multiple rows.
+Nested objects flatten into columns. Lists of nested objects expand into multiple rows — and round-trip back into the same shape when the outer record carries an anchor column (see the [GUIDE](GUIDE.md#reading-nested-lists)).
 
 ```java
 @DataGrid(mergeColumn = OptBoolean.TRUE)
@@ -267,7 +267,7 @@ POI gives you cells. This gives you POJOs. You define a class with `@DataGrid`, 
 Apache Fesod has its own API. This extends Jackson's `ObjectMapper`, so you get the full Jackson ecosystem — custom deserializers, mix-ins, modules, polymorphic types.
 
 **Q: Does it support nested objects?**
-Yes. Nested POJOs automatically flatten to columns on write and reconstruct on read. No configuration needed.
+Yes. Nested POJOs automatically flatten to columns on write and reconstruct on read. No configuration needed. Nested `List<T>` fields round-trip too — write expands to multi-row blocks, read collapses them back into the same outer record when one column per record level is marked with `@DataColumn(anchor = true)`.
 
 **Q: How does performance compare?**
 Throughput close to FastExcel at 100K rows (writer slightly faster), with ~20% less allocation in both read and write. ~7x faster than Apache POI on read. See [BENCHMARK.md](BENCHMARK.md).

--- a/src/jmh/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedBenchWorkbookBuilder.java
+++ b/src/jmh/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedBenchWorkbookBuilder.java
@@ -1,0 +1,38 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+
+/**
+ * Builds a nested-list bench fixture — outer record count is
+ * {@code innerRowCount / ITEMS_PER_OUTER}; each outer carries
+ * {@link #ITEMS_PER_OUTER} {@link NestedLineItem}s, yielding
+ * {@code innerRowCount} total data rows (file-size parity with the
+ * flat {@code BenchWorkbookBuilder}).
+ */
+public final class NestedBenchWorkbookBuilder {
+
+    public static final int ITEMS_PER_OUTER = 10;
+
+    private NestedBenchWorkbookBuilder() {}
+
+    public static File createSampleFile(final String prefix, final int innerRowCount) throws IOException {
+        if (innerRowCount % ITEMS_PER_OUTER != 0) {
+            throw new IllegalArgumentException(
+                    "innerRowCount must be a multiple of " + ITEMS_PER_OUTER
+                            + " (got " + innerRowCount + ")");
+        }
+        final int outerCount = innerRowCount / ITEMS_PER_OUTER;
+        File file = File.createTempFile(prefix, ".xlsx");
+        file.deleteOnExit();
+        SpreadsheetMapper mapper = new SpreadsheetMapper(
+                new SpreadsheetFactory(SXSSFWorkbook::new,
+                        SpreadsheetFactory.DEFAULT_SHEET_PARSER_FEATURE_FLAGS));
+        List<NestedRow> data = NestedRow.sample(outerCount, ITEMS_PER_OUTER);
+        mapper.writeValue(file, data, NestedRow.class);
+        return file;
+    }
+}

--- a/src/jmh/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedCellParityBenchmark.java
+++ b/src/jmh/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedCellParityBenchmark.java
@@ -1,0 +1,131 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Cell-count-parity benchmark — sizes flat row count and nested inner
+ * row count so both fixtures hold roughly the same number of written
+ * cells. Removes the "file-size parity" framing (same row count, half
+ * the cells) and surfaces the V2 record-tree algorithm's per-cell cost
+ * relative to the flat path.
+ *
+ * <p>Flat fixture: targetCells / 10 rows (10 cols per row).
+ * Nested fixture: round_to_10(targetCells / 4.6) inner rows
+ * (itemsPerOuter = 10 → 4 inner + 6 outer × (1/10) cells per inner row).
+ * Cell counts match within 0.005 %.
+ *
+ * <p>Other libraries are omitted (no nested-list support).
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+public class NestedCellParityBenchmark {
+
+    @Param({"100000", "500000", "1000000"})
+    int targetCells;
+
+    File nestedFile;
+    File flatFile;
+    List<NestedRow> nestedData;
+    List<BenchRow> flatData;
+    SpreadsheetMapper mapper;
+    SpreadsheetMapper mapperPoiRead;
+    SpreadsheetMapper mapperPoiWrite;
+
+    @Setup(Level.Trial)
+    public void setUp() throws IOException {
+        final int flatRows = targetCells / 10;
+        final int nestedInner = Math.round(targetCells / 4.6f / 10) * 10;
+
+        mapper = new SpreadsheetMapper();
+        mapperPoiRead = new SpreadsheetMapper(
+                new SpreadsheetFactory(XSSFWorkbook::new,
+                        SpreadsheetFactory.DEFAULT_SHEET_PARSER_FEATURE_FLAGS)
+                        .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL));
+        mapperPoiWrite = new SpreadsheetMapper(
+                new SpreadsheetFactory(SXSSFWorkbook::new,
+                        SpreadsheetFactory.DEFAULT_SHEET_PARSER_FEATURE_FLAGS)
+                        .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL));
+
+        flatFile = BenchWorkbookBuilder.createSampleFile("bench-parity-flat-", flatRows);
+        nestedFile = NestedBenchWorkbookBuilder.createSampleFile("bench-parity-nested-", nestedInner);
+
+        final int outerCount = nestedInner / NestedBenchWorkbookBuilder.ITEMS_PER_OUTER;
+        nestedData = NestedRow.sample(outerCount, NestedBenchWorkbookBuilder.ITEMS_PER_OUTER);
+        flatData = new ArrayList<>(flatRows);
+        for (int i = 0; i < flatRows; i++) {
+            flatData.add(BenchRow.create(i));
+        }
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        nestedFile.delete();
+        flatFile.delete();
+    }
+
+    @Benchmark
+    public void flatRead(Blackhole bh) throws IOException {
+        List<BenchRow> values = mapper.readValues(flatFile, BenchRow.class);
+        bh.consume(values);
+    }
+
+    @Benchmark
+    public void flatReadPoi(Blackhole bh) throws IOException {
+        List<BenchRow> values = mapperPoiRead.readValues(flatFile, BenchRow.class);
+        bh.consume(values);
+    }
+
+    @Benchmark
+    public void flatWrite(Blackhole bh) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        mapper.writeValue(out, flatData, BenchRow.class);
+        bh.consume(out);
+    }
+
+    @Benchmark
+    public void flatWritePoi(Blackhole bh) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        mapperPoiWrite.writeValue(out, flatData, BenchRow.class);
+        bh.consume(out);
+    }
+
+    @Benchmark
+    public void nestedRead(Blackhole bh) throws IOException {
+        List<NestedRow> values = mapper.readValues(nestedFile, NestedRow.class);
+        bh.consume(values);
+    }
+
+    @Benchmark
+    public void nestedReadPoi(Blackhole bh) throws IOException {
+        List<NestedRow> values = mapperPoiRead.readValues(nestedFile, NestedRow.class);
+        bh.consume(values);
+    }
+
+    @Benchmark
+    public void nestedWrite(Blackhole bh) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        mapper.writeValue(out, nestedData, NestedRow.class);
+        bh.consume(out);
+    }
+
+    @Benchmark
+    public void nestedWritePoi(Blackhole bh) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        mapperPoiWrite.writeValue(out, nestedData, NestedRow.class);
+        bh.consume(out);
+    }
+}

--- a/src/jmh/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedLineItem.java
+++ b/src/jmh/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedLineItem.java
@@ -1,0 +1,26 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import java.time.LocalDate;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
+
+@Data @NoArgsConstructor
+public class NestedLineItem {
+
+    @DataColumn private int quantity;
+    @DataColumn private double price;
+    @DataColumn private LocalDate dueDate;
+    @DataColumn private String description;
+
+    public static NestedLineItem create(final int i) {
+        NestedLineItem item = new NestedLineItem();
+        item.setQuantity(i % 1000);
+        item.setPrice(9.99 + (i % 1000) * 0.5);
+        item.setDueDate(LocalDate.of(2024, 1, 1).plusDays(i % 365));
+        item.setDescription("line-" + i);
+        return item;
+    }
+}

--- a/src/jmh/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedReadBenchmark.java
+++ b/src/jmh/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedReadBenchmark.java
@@ -1,0 +1,76 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Nested-list read benchmark — exercises the V2 record-tree algorithm
+ * against a 10-column outer-after-list shape (6 outer + 4 inner,
+ * itemsPerOuter=10). BenchRow flat baseline is included for direct
+ * cross-shape comparison within the same JVM/trial (same total inner
+ * row count = same file size). Other readers are omitted because they
+ * do not deserialize nested lists.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+public class NestedReadBenchmark {
+
+    @Param({"10000", "50000", "100000"})
+    int rowCount;
+
+    File nestedFile;
+    File flatFile;
+    SpreadsheetMapper mapper;
+    SpreadsheetMapper mapperPoi;
+
+    @Setup(Level.Trial)
+    public void setUp() throws IOException {
+        mapper = new SpreadsheetMapper();
+        mapperPoi = new SpreadsheetMapper(
+                new SpreadsheetFactory(XSSFWorkbook::new,
+                        SpreadsheetFactory.DEFAULT_SHEET_PARSER_FEATURE_FLAGS)
+                        .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL));
+        nestedFile = NestedBenchWorkbookBuilder.createSampleFile("bench-nested-read-", rowCount);
+        flatFile = BenchWorkbookBuilder.createSampleFile("bench-flat-read-", rowCount);
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        nestedFile.delete();
+        flatFile.delete();
+    }
+
+    @Benchmark
+    public void nested(Blackhole bh) throws IOException {
+        List<NestedRow> values = mapper.readValues(nestedFile, NestedRow.class);
+        bh.consume(values);
+    }
+
+    @Benchmark
+    public void nestedPoi(Blackhole bh) throws IOException {
+        List<NestedRow> values = mapperPoi.readValues(nestedFile, NestedRow.class);
+        bh.consume(values);
+    }
+
+    @Benchmark
+    public void flat(Blackhole bh) throws IOException {
+        List<BenchRow> values = mapper.readValues(flatFile, BenchRow.class);
+        bh.consume(values);
+    }
+
+    @Benchmark
+    public void flatPoi(Blackhole bh) throws IOException {
+        List<BenchRow> values = mapperPoi.readValues(flatFile, BenchRow.class);
+        bh.consume(values);
+    }
+}

--- a/src/jmh/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedRow.java
+++ b/src/jmh/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedRow.java
@@ -24,7 +24,7 @@ import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
 @Data @NoArgsConstructor @DataGrid
 public class NestedRow {
 
-    @DataColumn(merge = OptBoolean.TRUE, anchor = OptBoolean.TRUE)
+    @DataColumn(merge = OptBoolean.TRUE, anchor = true)
     private Long id;
     @DataColumn(merge = OptBoolean.TRUE)
     private String name;

--- a/src/jmh/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedRow.java
+++ b/src/jmh/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedRow.java
@@ -1,0 +1,77 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.OptBoolean;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+
+/**
+ * Nested-list bench model — 10 columns total, same type distribution as
+ * {@link BenchRow}, split into 6 outer + 4 inner. {@code id} is the row
+ * anchor; {@code totalAmount} and {@code createdAt} sit after the items
+ * list to exercise the outer-after-list back-write path on write and
+ * the record-tree close on read.
+ */
+@Data @NoArgsConstructor @DataGrid
+public class NestedRow {
+
+    @DataColumn(merge = OptBoolean.TRUE, anchor = OptBoolean.TRUE)
+    private Long id;
+    @DataColumn(merge = OptBoolean.TRUE)
+    private String name;
+    @DataColumn(merge = OptBoolean.TRUE)
+    private String category;
+    @DataColumn(merge = OptBoolean.TRUE)
+    private String status;
+
+    @DataColumnGroup("Items")
+    private List<NestedLineItem> items;
+
+    @DataColumn(merge = OptBoolean.TRUE)
+    private BigDecimal totalAmount;
+    @DataColumn(merge = OptBoolean.TRUE)
+    private LocalDateTime createdAt;
+
+    private static final String[] CATEGORIES = {
+            "Electronics", "Clothing", "Food", "Books", "Sports",
+            "Home", "Garden", "Toys", "Health", "Automotive"
+    };
+
+    private static final String[] STATUSES = {
+            "Active", "Inactive", "Pending", "Archived"
+    };
+
+    public static NestedRow create(final int outerIdx, final int itemsPerOuter) {
+        NestedRow r = new NestedRow();
+        r.setId((long) outerIdx);
+        r.setName("Product-" + outerIdx);
+        r.setCategory(CATEGORIES[outerIdx % CATEGORIES.length]);
+        r.setStatus(STATUSES[outerIdx % STATUSES.length]);
+        r.setTotalAmount(BigDecimal.valueOf(100.50 + outerIdx * 0.01));
+        r.setCreatedAt(LocalDateTime.of(2024, 1, 1, 0, 0).plusMinutes(outerIdx));
+        List<NestedLineItem> items = new ArrayList<>(itemsPerOuter);
+        final int base = outerIdx * itemsPerOuter;
+        for (int j = 0; j < itemsPerOuter; j++) {
+            items.add(NestedLineItem.create(base + j));
+        }
+        r.setItems(items);
+        return r;
+    }
+
+    public static List<NestedRow> sample(final int outerCount, final int itemsPerOuter) {
+        List<NestedRow> list = new ArrayList<>(outerCount);
+        for (int i = 0; i < outerCount; i++) {
+            list.add(create(i, itemsPerOuter));
+        }
+        return list;
+    }
+}

--- a/src/jmh/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedSustainedThroughputBenchmark.java
+++ b/src/jmh/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedSustainedThroughputBenchmark.java
@@ -1,0 +1,121 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Sustained-throughput benchmark for the nested-list read/write path.
+ * Mirrors {@link SustainedThroughputBenchmark}'s 60-second measurement
+ * window to surface steady-state cost (allocation rate, GC pause
+ * accumulation) that single-shot per-op figures hide. Includes the
+ * flat BenchRow baselines for direct cross-shape comparison within
+ * the same trial. Other libraries are omitted because they do not
+ * read/write nested lists.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 1, time = 10)
+@Measurement(iterations = 1, time = 60)
+@Fork(1)
+public class NestedSustainedThroughputBenchmark {
+
+    static final int ROW_COUNT = 10_000;
+
+    File nestedFile;
+    File flatFile;
+    List<NestedRow> nestedData;
+    List<BenchRow> flatData;
+    SpreadsheetMapper mapper;
+    SpreadsheetMapper mapperPoiRead;
+    SpreadsheetMapper mapperPoiWrite;
+
+    @Setup(Level.Trial)
+    public void setUp() throws IOException {
+        mapper = new SpreadsheetMapper();
+        mapperPoiRead = new SpreadsheetMapper(
+                new SpreadsheetFactory(XSSFWorkbook::new,
+                        SpreadsheetFactory.DEFAULT_SHEET_PARSER_FEATURE_FLAGS)
+                        .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL));
+        mapperPoiWrite = new SpreadsheetMapper(
+                new SpreadsheetFactory(SXSSFWorkbook::new,
+                        SpreadsheetFactory.DEFAULT_SHEET_PARSER_FEATURE_FLAGS)
+                        .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL));
+        nestedFile = NestedBenchWorkbookBuilder.createSampleFile("bench-sustained-nested-", ROW_COUNT);
+        flatFile = BenchWorkbookBuilder.createSampleFile("bench-sustained-flat-", ROW_COUNT);
+
+        final int outerCount = ROW_COUNT / NestedBenchWorkbookBuilder.ITEMS_PER_OUTER;
+        nestedData = NestedRow.sample(outerCount, NestedBenchWorkbookBuilder.ITEMS_PER_OUTER);
+        flatData = new ArrayList<>(ROW_COUNT);
+        for (int i = 0; i < ROW_COUNT; i++) {
+            flatData.add(BenchRow.create(i));
+        }
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        nestedFile.delete();
+        flatFile.delete();
+    }
+
+    @Benchmark
+    public void nestedRead(Blackhole bh) throws IOException {
+        List<NestedRow> values = mapper.readValues(nestedFile, NestedRow.class);
+        bh.consume(values);
+    }
+
+    @Benchmark
+    public void nestedReadPoi(Blackhole bh) throws IOException {
+        List<NestedRow> values = mapperPoiRead.readValues(nestedFile, NestedRow.class);
+        bh.consume(values);
+    }
+
+    @Benchmark
+    public void nestedWrite(Blackhole bh) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        mapper.writeValue(out, nestedData, NestedRow.class);
+        bh.consume(out);
+    }
+
+    @Benchmark
+    public void nestedWritePoi(Blackhole bh) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        mapperPoiWrite.writeValue(out, nestedData, NestedRow.class);
+        bh.consume(out);
+    }
+
+    @Benchmark
+    public void flatRead(Blackhole bh) throws IOException {
+        List<BenchRow> values = mapper.readValues(flatFile, BenchRow.class);
+        bh.consume(values);
+    }
+
+    @Benchmark
+    public void flatReadPoi(Blackhole bh) throws IOException {
+        List<BenchRow> values = mapperPoiRead.readValues(flatFile, BenchRow.class);
+        bh.consume(values);
+    }
+
+    @Benchmark
+    public void flatWrite(Blackhole bh) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        mapper.writeValue(out, flatData, BenchRow.class);
+        bh.consume(out);
+    }
+
+    @Benchmark
+    public void flatWritePoi(Blackhole bh) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        mapperPoiWrite.writeValue(out, flatData, BenchRow.class);
+        bh.consume(out);
+    }
+}

--- a/src/jmh/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedWriteBenchmark.java
+++ b/src/jmh/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedWriteBenchmark.java
@@ -1,0 +1,87 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Nested-list write benchmark — outer-after-list shape exercises the
+ * SSML back-write path (totalAmount/createdAt sit after items[]).
+ * BenchRow flat baseline is included for direct cross-shape comparison
+ * within the same JVM/trial (same total inner row count = same file
+ * size). Other writers are omitted because they do not emit nested-list
+ * layouts.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+public class NestedWriteBenchmark {
+
+    @Param({"10000", "50000", "100000"})
+    int rowCount;
+
+    List<NestedRow> nestedData;
+    List<BenchRow> flatData;
+    File file;
+    SpreadsheetMapper mapper;
+    SpreadsheetMapper mapperPoi;
+
+    @Setup(Level.Trial)
+    public void setUp() {
+        mapper = new SpreadsheetMapper();
+        mapperPoi = new SpreadsheetMapper(
+                new SpreadsheetFactory(SXSSFWorkbook::new,
+                        SpreadsheetFactory.DEFAULT_SHEET_PARSER_FEATURE_FLAGS)
+                        .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL));
+        final int outerCount = rowCount / NestedBenchWorkbookBuilder.ITEMS_PER_OUTER;
+        nestedData = NestedRow.sample(outerCount, NestedBenchWorkbookBuilder.ITEMS_PER_OUTER);
+        flatData = new ArrayList<>(rowCount);
+        for (int i = 0; i < rowCount; i++) {
+            flatData.add(BenchRow.create(i));
+        }
+    }
+
+    @Setup(Level.Invocation)
+    public void setUpFile() throws IOException {
+        file = File.createTempFile("bench-nested-write-", ".xlsx");
+        file.deleteOnExit();
+    }
+
+    @TearDown(Level.Invocation)
+    public void tearDown() {
+        file.delete();
+    }
+
+    @Benchmark
+    public void nested(Blackhole bh) throws IOException {
+        mapper.writeValue(file, nestedData, NestedRow.class);
+        bh.consume(file);
+    }
+
+    @Benchmark
+    public void nestedPoi(Blackhole bh) throws IOException {
+        mapperPoi.writeValue(file, nestedData, NestedRow.class);
+        bh.consume(file);
+    }
+
+    @Benchmark
+    public void flat(Blackhole bh) throws IOException {
+        mapper.writeValue(file, flatData, BenchRow.class);
+        bh.consume(file);
+    }
+
+    @Benchmark
+    public void flatPoi(Blackhole bh) throws IOException {
+        mapperPoi.writeValue(file, flatData, BenchRow.class);
+        bh.consume(file);
+    }
+}

--- a/src/jmh/java/io/github/scndry/jackson/dataformat/spreadsheet/internal/CellTypeOverheadBenchmark.java
+++ b/src/jmh/java/io/github/scndry/jackson/dataformat/spreadsheet/internal/CellTypeOverheadBenchmark.java
@@ -1,0 +1,366 @@
+package io.github.scndry.jackson.dataformat.spreadsheet.internal;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.DataFormat;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.SpreadsheetMapper;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+
+/**
+ * Cell-type overhead probe — eight 10-column schemas, one per common
+ * Java type, against identical row count. Surfaces per-cell read/write
+ * cost differences (FloatingDecimal vs SST lookup vs Excel-serial date
+ * conversion vs BigDecimal parse) without nested-list overhead.
+ *
+ * <p>Fixtures are written via POI directly for the read side
+ * (`setCellValue` per type) and via the library mapper for the write
+ * side. Date/datetime cells carry a data format style so the library's
+ * {@code ExcelDateModule} recognises them.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+public class CellTypeOverheadBenchmark {
+
+    @Param({"10000"})
+    int rowCount;
+
+    SpreadsheetMapper mapper;
+
+    File intFile, longFile, doubleFile, booleanFile, stringFile,
+            bigDecimalFile, localDateFile, localDateTimeFile;
+
+    List<IntRow> intData;
+    List<LongRow> longData;
+    List<DoubleRow> doubleData;
+    List<BooleanRow> booleanData;
+    List<StringRow> stringData;
+    List<BigDecimalRow> bigDecimalData;
+    List<LocalDateRow> localDateData;
+    List<LocalDateTimeRow> localDateTimeData;
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    public static class IntRow {
+        @DataColumn private int c0; @DataColumn private int c1;
+        @DataColumn private int c2; @DataColumn private int c3;
+        @DataColumn private int c4; @DataColumn private int c5;
+        @DataColumn private int c6; @DataColumn private int c7;
+        @DataColumn private int c8; @DataColumn private int c9;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    public static class LongRow {
+        @DataColumn private long c0; @DataColumn private long c1;
+        @DataColumn private long c2; @DataColumn private long c3;
+        @DataColumn private long c4; @DataColumn private long c5;
+        @DataColumn private long c6; @DataColumn private long c7;
+        @DataColumn private long c8; @DataColumn private long c9;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    public static class DoubleRow {
+        @DataColumn private double c0; @DataColumn private double c1;
+        @DataColumn private double c2; @DataColumn private double c3;
+        @DataColumn private double c4; @DataColumn private double c5;
+        @DataColumn private double c6; @DataColumn private double c7;
+        @DataColumn private double c8; @DataColumn private double c9;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    public static class BooleanRow {
+        @DataColumn private boolean c0; @DataColumn private boolean c1;
+        @DataColumn private boolean c2; @DataColumn private boolean c3;
+        @DataColumn private boolean c4; @DataColumn private boolean c5;
+        @DataColumn private boolean c6; @DataColumn private boolean c7;
+        @DataColumn private boolean c8; @DataColumn private boolean c9;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    public static class StringRow {
+        @DataColumn private String c0; @DataColumn private String c1;
+        @DataColumn private String c2; @DataColumn private String c3;
+        @DataColumn private String c4; @DataColumn private String c5;
+        @DataColumn private String c6; @DataColumn private String c7;
+        @DataColumn private String c8; @DataColumn private String c9;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    public static class BigDecimalRow {
+        @DataColumn private BigDecimal c0; @DataColumn private BigDecimal c1;
+        @DataColumn private BigDecimal c2; @DataColumn private BigDecimal c3;
+        @DataColumn private BigDecimal c4; @DataColumn private BigDecimal c5;
+        @DataColumn private BigDecimal c6; @DataColumn private BigDecimal c7;
+        @DataColumn private BigDecimal c8; @DataColumn private BigDecimal c9;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    public static class LocalDateRow {
+        @DataColumn private LocalDate c0; @DataColumn private LocalDate c1;
+        @DataColumn private LocalDate c2; @DataColumn private LocalDate c3;
+        @DataColumn private LocalDate c4; @DataColumn private LocalDate c5;
+        @DataColumn private LocalDate c6; @DataColumn private LocalDate c7;
+        @DataColumn private LocalDate c8; @DataColumn private LocalDate c9;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    public static class LocalDateTimeRow {
+        @DataColumn private LocalDateTime c0; @DataColumn private LocalDateTime c1;
+        @DataColumn private LocalDateTime c2; @DataColumn private LocalDateTime c3;
+        @DataColumn private LocalDateTime c4; @DataColumn private LocalDateTime c5;
+        @DataColumn private LocalDateTime c6; @DataColumn private LocalDateTime c7;
+        @DataColumn private LocalDateTime c8; @DataColumn private LocalDateTime c9;
+    }
+
+    @Setup(Level.Trial)
+    public void setUp() throws IOException {
+        mapper = new SpreadsheetMapper();
+
+        intData = new ArrayList<>(rowCount);
+        longData = new ArrayList<>(rowCount);
+        doubleData = new ArrayList<>(rowCount);
+        booleanData = new ArrayList<>(rowCount);
+        stringData = new ArrayList<>(rowCount);
+        bigDecimalData = new ArrayList<>(rowCount);
+        localDateData = new ArrayList<>(rowCount);
+        localDateTimeData = new ArrayList<>(rowCount);
+
+        final LocalDate dateBase = LocalDate.of(2020, 1, 1);
+        final LocalDateTime dateTimeBase = LocalDateTime.of(2020, 1, 1, 0, 0);
+
+        for (int i = 0; i < rowCount; i++) {
+            intData.add(new IntRow(i, i+1, i+2, i+3, i+4, i+5, i+6, i+7, i+8, i+9));
+            longData.add(new LongRow(i, i+1, i+2, i+3, i+4, i+5, i+6, i+7, i+8, i+9));
+            doubleData.add(new DoubleRow(i+.1, i+.2, i+.3, i+.4, i+.5, i+.6, i+.7, i+.8, i+.9, i+1.0));
+            booleanData.add(new BooleanRow(
+                    i%2==0, i%2==1, i%3==0, i%3==1, i%5==0, i%5==1, i%7==0, i%7==1, i%11==0, i%11==1));
+            stringData.add(new StringRow(
+                    "c0-"+i, "c1-"+i, "c2-"+i, "c3-"+i, "c4-"+i,
+                    "c5-"+i, "c6-"+i, "c7-"+i, "c8-"+i, "c9-"+i));
+            bigDecimalData.add(new BigDecimalRow(
+                    BigDecimal.valueOf(i), BigDecimal.valueOf(i+1), BigDecimal.valueOf(i+2),
+                    BigDecimal.valueOf(i+3), BigDecimal.valueOf(i+4), BigDecimal.valueOf(i+5),
+                    BigDecimal.valueOf(i+6), BigDecimal.valueOf(i+7), BigDecimal.valueOf(i+8),
+                    BigDecimal.valueOf(i+9)));
+            localDateData.add(new LocalDateRow(
+                    dateBase.plusDays(i), dateBase.plusDays(i+1), dateBase.plusDays(i+2),
+                    dateBase.plusDays(i+3), dateBase.plusDays(i+4), dateBase.plusDays(i+5),
+                    dateBase.plusDays(i+6), dateBase.plusDays(i+7), dateBase.plusDays(i+8),
+                    dateBase.plusDays(i+9)));
+            localDateTimeData.add(new LocalDateTimeRow(
+                    dateTimeBase.plusMinutes(i), dateTimeBase.plusMinutes(i+1),
+                    dateTimeBase.plusMinutes(i+2), dateTimeBase.plusMinutes(i+3),
+                    dateTimeBase.plusMinutes(i+4), dateTimeBase.plusMinutes(i+5),
+                    dateTimeBase.plusMinutes(i+6), dateTimeBase.plusMinutes(i+7),
+                    dateTimeBase.plusMinutes(i+8), dateTimeBase.plusMinutes(i+9)));
+        }
+
+        intFile = _writeNumericFile("bench-celltype-int-", rowCount, (row, j, i) ->
+                row.createCell(j).setCellValue((double) (i + j)));
+        longFile = _writeNumericFile("bench-celltype-long-", rowCount, (row, j, i) ->
+                row.createCell(j).setCellValue((double) (i + j)));
+        doubleFile = _writeNumericFile("bench-celltype-double-", rowCount, (row, j, i) ->
+                row.createCell(j).setCellValue(i + (j + 1) / 10.0));
+        booleanFile = _writeBooleanFile("bench-celltype-boolean-", rowCount);
+        stringFile = _writeStringFile("bench-celltype-string-", rowCount);
+        bigDecimalFile = _writeNumericFile("bench-celltype-bigdecimal-", rowCount, (row, j, i) ->
+                row.createCell(j).setCellValue((double) (i + j)));
+        localDateFile = _writeDateFile("bench-celltype-localdate-", rowCount, "yyyy-mm-dd", dateBase, false);
+        localDateTimeFile = _writeDateFile(
+                "bench-celltype-localdatetime-", rowCount, "yyyy-mm-dd hh:mm:ss", dateTimeBase, true);
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        for (File f : new File[]{intFile, longFile, doubleFile, booleanFile, stringFile,
+                bigDecimalFile, localDateFile, localDateTimeFile}) {
+            if (f != null) f.delete();
+        }
+    }
+
+    @FunctionalInterface
+    private interface CellWriter {
+        void write(Row row, int col, int rowIdx);
+    }
+
+    private static File _writeNumericFile(
+            final String prefix, final int rows, final CellWriter writer) throws IOException {
+        File file = File.createTempFile(prefix, ".xlsx");
+        file.deleteOnExit();
+        try (SXSSFWorkbook wb = new SXSSFWorkbook(new XSSFWorkbook(), 100, false, true)) {
+            Sheet sheet = wb.createSheet("Sheet1");
+            Row h = sheet.createRow(0);
+            for (int c = 0; c < 10; c++) h.createCell(c).setCellValue("c" + c);
+            for (int i = 0; i < rows; i++) {
+                Row r = sheet.createRow(i + 1);
+                for (int c = 0; c < 10; c++) writer.write(r, c, i);
+            }
+            try (FileOutputStream fos = new FileOutputStream(file)) {
+                wb.write(fos);
+            }
+            wb.dispose();
+        }
+        return file;
+    }
+
+    private static File _writeBooleanFile(final String prefix, final int rows) throws IOException {
+        File file = File.createTempFile(prefix, ".xlsx");
+        file.deleteOnExit();
+        try (SXSSFWorkbook wb = new SXSSFWorkbook(new XSSFWorkbook(), 100, false, true)) {
+            Sheet sheet = wb.createSheet("Sheet1");
+            Row h = sheet.createRow(0);
+            for (int c = 0; c < 10; c++) h.createCell(c).setCellValue("c" + c);
+            for (int i = 0; i < rows; i++) {
+                Row r = sheet.createRow(i + 1);
+                for (int c = 0; c < 10; c++) r.createCell(c).setCellValue((i + c) % 2 == 0);
+            }
+            try (FileOutputStream fos = new FileOutputStream(file)) {
+                wb.write(fos);
+            }
+            wb.dispose();
+        }
+        return file;
+    }
+
+    private static File _writeStringFile(final String prefix, final int rows) throws IOException {
+        File file = File.createTempFile(prefix, ".xlsx");
+        file.deleteOnExit();
+        try (SXSSFWorkbook wb = new SXSSFWorkbook(new XSSFWorkbook(), 100, false, true)) {
+            Sheet sheet = wb.createSheet("Sheet1");
+            Row h = sheet.createRow(0);
+            for (int c = 0; c < 10; c++) h.createCell(c).setCellValue("c" + c);
+            for (int i = 0; i < rows; i++) {
+                Row r = sheet.createRow(i + 1);
+                for (int c = 0; c < 10; c++) r.createCell(c).setCellValue("c" + c + "-" + i);
+            }
+            try (FileOutputStream fos = new FileOutputStream(file)) {
+                wb.write(fos);
+            }
+            wb.dispose();
+        }
+        return file;
+    }
+
+    private static File _writeDateFile(
+            final String prefix, final int rows, final String format,
+            final Object base, final boolean dateTime) throws IOException {
+        File file = File.createTempFile(prefix, ".xlsx");
+        file.deleteOnExit();
+        try (SXSSFWorkbook wb = new SXSSFWorkbook(new XSSFWorkbook(), 100, false, true)) {
+            Sheet sheet = wb.createSheet("Sheet1");
+            DataFormat fmt = wb.createDataFormat();
+            CellStyle style = wb.createCellStyle();
+            style.setDataFormat(fmt.getFormat(format));
+            Row h = sheet.createRow(0);
+            for (int c = 0; c < 10; c++) h.createCell(c).setCellValue("c" + c);
+            for (int i = 0; i < rows; i++) {
+                Row r = sheet.createRow(i + 1);
+                for (int c = 0; c < 10; c++) {
+                    Cell cell = r.createCell(c);
+                    if (dateTime) cell.setCellValue(((LocalDateTime) base).plusMinutes(i + c));
+                    else cell.setCellValue(((LocalDate) base).plusDays(i + c));
+                    cell.setCellStyle(style);
+                }
+            }
+            try (FileOutputStream fos = new FileOutputStream(file)) {
+                wb.write(fos);
+            }
+            wb.dispose();
+        }
+        return file;
+    }
+
+    // Read benchmarks
+
+    @Benchmark public void intRead(Blackhole bh) throws IOException {
+        bh.consume(mapper.readValues(intFile, IntRow.class));
+    }
+    @Benchmark public void longRead(Blackhole bh) throws IOException {
+        bh.consume(mapper.readValues(longFile, LongRow.class));
+    }
+    @Benchmark public void doubleRead(Blackhole bh) throws IOException {
+        bh.consume(mapper.readValues(doubleFile, DoubleRow.class));
+    }
+    @Benchmark public void booleanRead(Blackhole bh) throws IOException {
+        bh.consume(mapper.readValues(booleanFile, BooleanRow.class));
+    }
+    @Benchmark public void stringRead(Blackhole bh) throws IOException {
+        bh.consume(mapper.readValues(stringFile, StringRow.class));
+    }
+    @Benchmark public void bigDecimalRead(Blackhole bh) throws IOException {
+        bh.consume(mapper.readValues(bigDecimalFile, BigDecimalRow.class));
+    }
+    @Benchmark public void localDateRead(Blackhole bh) throws IOException {
+        bh.consume(mapper.readValues(localDateFile, LocalDateRow.class));
+    }
+    @Benchmark public void localDateTimeRead(Blackhole bh) throws IOException {
+        bh.consume(mapper.readValues(localDateTimeFile, LocalDateTimeRow.class));
+    }
+
+    // Write benchmarks
+
+    @Benchmark public void intWrite(Blackhole bh) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        mapper.writeValue(out, intData, IntRow.class);
+        bh.consume(out);
+    }
+    @Benchmark public void longWrite(Blackhole bh) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        mapper.writeValue(out, longData, LongRow.class);
+        bh.consume(out);
+    }
+    @Benchmark public void doubleWrite(Blackhole bh) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        mapper.writeValue(out, doubleData, DoubleRow.class);
+        bh.consume(out);
+    }
+    @Benchmark public void booleanWrite(Blackhole bh) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        mapper.writeValue(out, booleanData, BooleanRow.class);
+        bh.consume(out);
+    }
+    @Benchmark public void stringWrite(Blackhole bh) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        mapper.writeValue(out, stringData, StringRow.class);
+        bh.consume(out);
+    }
+    @Benchmark public void bigDecimalWrite(Blackhole bh) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        mapper.writeValue(out, bigDecimalData, BigDecimalRow.class);
+        bh.consume(out);
+    }
+    @Benchmark public void localDateWrite(Blackhole bh) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        mapper.writeValue(out, localDateData, LocalDateRow.class);
+        bh.consume(out);
+    }
+    @Benchmark public void localDateTimeWrite(Blackhole bh) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        mapper.writeValue(out, localDateTimeData, LocalDateTimeRow.class);
+        bh.consume(out);
+    }
+}

--- a/src/jmh/java/io/github/scndry/jackson/dataformat/spreadsheet/internal/NestedIntParityBenchmark.java
+++ b/src/jmh/java/io/github/scndry/jackson/dataformat/spreadsheet/internal/NestedIntParityBenchmark.java
@@ -1,0 +1,225 @@
+package io.github.scndry.jackson.dataformat.spreadsheet.internal;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import com.fasterxml.jackson.annotation.OptBoolean;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.SpreadsheetFactory;
+import io.github.scndry.jackson.dataformat.spreadsheet.SpreadsheetMapper;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+
+/**
+ * Type-controlled cell-count-parity probe — flat 10 int columns vs
+ * nested 6 int outer + 4 int inner. All cells share the same primitive
+ * type so per-cell cost variance from BigDecimal/LocalDateTime/String
+ * formatting drops out. The remaining gap measures the pure record-tree
+ * algorithm overhead (RecordNode + LinkedHashMap + Cell wrapper alloc on
+ * read; back-write buffer + scope traversal on write).
+ *
+ * <p>Cell-count parity: flat = targetCells / 10 rows; nested inner =
+ * round_to_10(targetCells / 4.6). itemsPerOuter = 10.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+public class NestedIntParityBenchmark {
+
+    static final int ITEMS_PER_OUTER = 10;
+
+    @Param({"100000", "1000000"})
+    int targetCells;
+
+    File flatFile;
+    File nestedFile;
+    List<IntRow> flatData;
+    List<IntOuter> nestedData;
+    SpreadsheetMapper mapper;
+    SpreadsheetMapper mapperPoiRead;
+    SpreadsheetMapper mapperPoiWrite;
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    public static class IntRow {
+        @DataColumn private int c0;
+        @DataColumn private int c1;
+        @DataColumn private int c2;
+        @DataColumn private int c3;
+        @DataColumn private int c4;
+        @DataColumn private int c5;
+        @DataColumn private int c6;
+        @DataColumn private int c7;
+        @DataColumn private int c8;
+        @DataColumn private int c9;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    public static class IntItem {
+        @DataColumn private int i0;
+        @DataColumn private int i1;
+        @DataColumn private int i2;
+        @DataColumn private int i3;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    public static class IntOuter {
+        @DataColumn(anchor = OptBoolean.TRUE) private int id;
+        @DataColumn private int o1;
+        @DataColumn private int o2;
+        @DataColumn private int o3;
+        @DataColumn private int o4;
+        @DataColumn private int o5;
+        @DataColumnGroup("Items") private List<IntItem> items;
+    }
+
+    @Setup(Level.Trial)
+    public void setUp() throws IOException {
+        final int flatRows = targetCells / 10;
+        final int nestedInner = Math.round(targetCells / 4.6f / ITEMS_PER_OUTER) * ITEMS_PER_OUTER;
+        final int outerCount = nestedInner / ITEMS_PER_OUTER;
+
+        mapper = new SpreadsheetMapper();
+        mapperPoiRead = new SpreadsheetMapper(
+                new SpreadsheetFactory(XSSFWorkbook::new,
+                        SpreadsheetFactory.DEFAULT_SHEET_PARSER_FEATURE_FLAGS)
+                        .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL));
+        mapperPoiWrite = new SpreadsheetMapper(
+                new SpreadsheetFactory(SXSSFWorkbook::new,
+                        SpreadsheetFactory.DEFAULT_SHEET_PARSER_FEATURE_FLAGS)
+                        .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL));
+
+        flatData = new ArrayList<>(flatRows);
+        for (int i = 0; i < flatRows; i++) {
+            flatData.add(new IntRow(i, i + 1, i + 2, i + 3, i + 4, i + 5, i + 6, i + 7, i + 8, i + 9));
+        }
+        nestedData = new ArrayList<>(outerCount);
+        for (int i = 0; i < outerCount; i++) {
+            List<IntItem> items = new ArrayList<>(ITEMS_PER_OUTER);
+            final int base = i * ITEMS_PER_OUTER;
+            for (int j = 0; j < ITEMS_PER_OUTER; j++) {
+                items.add(new IntItem(base + j, base + j + 1, base + j + 2, base + j + 3));
+            }
+            nestedData.add(new IntOuter(i, i + 1, i + 2, i + 3, i + 4, i + 5, items));
+        }
+
+        flatFile = _writeFlatFile(flatData);
+        nestedFile = _writeNestedFile(nestedData);
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        flatFile.delete();
+        nestedFile.delete();
+    }
+
+    private File _writeFlatFile(final List<IntRow> data) throws IOException {
+        File file = File.createTempFile("bench-int-parity-flat-", ".xlsx");
+        file.deleteOnExit();
+        try (SXSSFWorkbook wb = new SXSSFWorkbook(new XSSFWorkbook(), 100, false, true)) {
+            Sheet sheet = wb.createSheet("Sheet1");
+            Row header = sheet.createRow(0);
+            for (int c = 0; c < 10; c++) header.createCell(c).setCellValue("c" + c);
+            for (int i = 0; i < data.size(); i++) {
+                IntRow r = data.get(i);
+                Row row = sheet.createRow(i + 1);
+                row.createCell(0).setCellValue(r.getC0());
+                row.createCell(1).setCellValue(r.getC1());
+                row.createCell(2).setCellValue(r.getC2());
+                row.createCell(3).setCellValue(r.getC3());
+                row.createCell(4).setCellValue(r.getC4());
+                row.createCell(5).setCellValue(r.getC5());
+                row.createCell(6).setCellValue(r.getC6());
+                row.createCell(7).setCellValue(r.getC7());
+                row.createCell(8).setCellValue(r.getC8());
+                row.createCell(9).setCellValue(r.getC9());
+            }
+            try (FileOutputStream fos = new FileOutputStream(file)) {
+                wb.write(fos);
+            }
+            wb.dispose();
+        }
+        return file;
+    }
+
+    private File _writeNestedFile(final List<IntOuter> data) throws IOException {
+        File file = File.createTempFile("bench-int-parity-nested-", ".xlsx");
+        file.deleteOnExit();
+        // Use the library writer for nested layout — column ordering is authoritative.
+        SpreadsheetMapper writer = new SpreadsheetMapper(
+                new SpreadsheetFactory(SXSSFWorkbook::new,
+                        SpreadsheetFactory.DEFAULT_SHEET_PARSER_FEATURE_FLAGS));
+        writer.writeValue(file, data, IntOuter.class);
+        return file;
+    }
+
+    @Benchmark
+    public void flatRead(Blackhole bh) throws IOException {
+        List<IntRow> values = mapper.readValues(flatFile, IntRow.class);
+        bh.consume(values);
+    }
+
+    @Benchmark
+    public void flatReadPoi(Blackhole bh) throws IOException {
+        List<IntRow> values = mapperPoiRead.readValues(flatFile, IntRow.class);
+        bh.consume(values);
+    }
+
+    @Benchmark
+    public void flatWrite(Blackhole bh) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        mapper.writeValue(out, flatData, IntRow.class);
+        bh.consume(out);
+    }
+
+    @Benchmark
+    public void flatWritePoi(Blackhole bh) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        mapperPoiWrite.writeValue(out, flatData, IntRow.class);
+        bh.consume(out);
+    }
+
+    @Benchmark
+    public void nestedRead(Blackhole bh) throws IOException {
+        List<IntOuter> values = mapper.readValues(nestedFile, IntOuter.class);
+        bh.consume(values);
+    }
+
+    @Benchmark
+    public void nestedReadPoi(Blackhole bh) throws IOException {
+        List<IntOuter> values = mapperPoiRead.readValues(nestedFile, IntOuter.class);
+        bh.consume(values);
+    }
+
+    @Benchmark
+    public void nestedWrite(Blackhole bh) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        mapper.writeValue(out, nestedData, IntOuter.class);
+        bh.consume(out);
+    }
+
+    @Benchmark
+    public void nestedWritePoi(Blackhole bh) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        mapperPoiWrite.writeValue(out, nestedData, IntOuter.class);
+        bh.consume(out);
+    }
+}

--- a/src/jmh/java/io/github/scndry/jackson/dataformat/spreadsheet/internal/NestedIntParityBenchmark.java
+++ b/src/jmh/java/io/github/scndry/jackson/dataformat/spreadsheet/internal/NestedIntParityBenchmark.java
@@ -8,8 +8,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import com.fasterxml.jackson.annotation.OptBoolean;
-
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -82,7 +80,7 @@ public class NestedIntParityBenchmark {
 
     @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
     public static class IntOuter {
-        @DataColumn(anchor = OptBoolean.TRUE) private int id;
+        @DataColumn(anchor = true) private int id;
         @DataColumn private int o1;
         @DataColumn private int o2;
         @DataColumn private int o3;

--- a/src/jmh/java/io/github/scndry/jackson/dataformat/spreadsheet/internal/NestedStringParityBenchmark.java
+++ b/src/jmh/java/io/github/scndry/jackson/dataformat/spreadsheet/internal/NestedStringParityBenchmark.java
@@ -1,0 +1,225 @@
+package io.github.scndry.jackson.dataformat.spreadsheet.internal;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.SpreadsheetFactory;
+import io.github.scndry.jackson.dataformat.spreadsheet.SpreadsheetMapper;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+
+/**
+ * Type-controlled cell-count-parity probe — flat 10 String columns vs
+ * nested 6 String outer + 4 String inner. Mirrors
+ * {@link NestedIntParityBenchmark}'s structure with {@code String}
+ * everywhere so the shared-strings lookup path (SST cache hits) is the
+ * dominant per-cell cost on the flat side. The remaining gap to the
+ * nested path measures the record-tree algorithm's fixed overhead
+ * against a cheaper-per-cell baseline than the int probe.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+public class NestedStringParityBenchmark {
+
+    static final int ITEMS_PER_OUTER = 10;
+
+    @Param({"100000", "1000000"})
+    int targetCells;
+
+    File flatFile;
+    File nestedFile;
+    List<StringRow> flatData;
+    List<StringOuter> nestedData;
+    SpreadsheetMapper mapper;
+    SpreadsheetMapper mapperPoiRead;
+    SpreadsheetMapper mapperPoiWrite;
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    public static class StringRow {
+        @DataColumn private String c0;
+        @DataColumn private String c1;
+        @DataColumn private String c2;
+        @DataColumn private String c3;
+        @DataColumn private String c4;
+        @DataColumn private String c5;
+        @DataColumn private String c6;
+        @DataColumn private String c7;
+        @DataColumn private String c8;
+        @DataColumn private String c9;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    public static class StringItem {
+        @DataColumn private String i0;
+        @DataColumn private String i1;
+        @DataColumn private String i2;
+        @DataColumn private String i3;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    public static class StringOuter {
+        @DataColumn(anchor = true) private String id;
+        @DataColumn private String o1;
+        @DataColumn private String o2;
+        @DataColumn private String o3;
+        @DataColumn private String o4;
+        @DataColumn private String o5;
+        @DataColumnGroup("Items") private List<StringItem> items;
+    }
+
+    @Setup(Level.Trial)
+    public void setUp() throws IOException {
+        final int flatRows = targetCells / 10;
+        final int nestedInner = Math.round(targetCells / 4.6f / ITEMS_PER_OUTER) * ITEMS_PER_OUTER;
+        final int outerCount = nestedInner / ITEMS_PER_OUTER;
+
+        mapper = new SpreadsheetMapper();
+        mapperPoiRead = new SpreadsheetMapper(
+                new SpreadsheetFactory(XSSFWorkbook::new,
+                        SpreadsheetFactory.DEFAULT_SHEET_PARSER_FEATURE_FLAGS)
+                        .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL));
+        mapperPoiWrite = new SpreadsheetMapper(
+                new SpreadsheetFactory(SXSSFWorkbook::new,
+                        SpreadsheetFactory.DEFAULT_SHEET_PARSER_FEATURE_FLAGS)
+                        .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL));
+
+        flatData = new ArrayList<>(flatRows);
+        for (int i = 0; i < flatRows; i++) {
+            flatData.add(new StringRow(
+                    "c0-" + i, "c1-" + i, "c2-" + i, "c3-" + i, "c4-" + i,
+                    "c5-" + i, "c6-" + i, "c7-" + i, "c8-" + i, "c9-" + i));
+        }
+        nestedData = new ArrayList<>(outerCount);
+        for (int i = 0; i < outerCount; i++) {
+            List<StringItem> items = new ArrayList<>(ITEMS_PER_OUTER);
+            final int base = i * ITEMS_PER_OUTER;
+            for (int j = 0; j < ITEMS_PER_OUTER; j++) {
+                items.add(new StringItem(
+                        "i0-" + (base + j), "i1-" + (base + j),
+                        "i2-" + (base + j), "i3-" + (base + j)));
+            }
+            nestedData.add(new StringOuter(
+                    "id-" + i, "o1-" + i, "o2-" + i, "o3-" + i, "o4-" + i, "o5-" + i, items));
+        }
+
+        flatFile = _writeFlatFile(flatData);
+        nestedFile = _writeNestedFile(nestedData);
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDown() {
+        flatFile.delete();
+        nestedFile.delete();
+    }
+
+    private File _writeFlatFile(final List<StringRow> data) throws IOException {
+        File file = File.createTempFile("bench-string-parity-flat-", ".xlsx");
+        file.deleteOnExit();
+        try (SXSSFWorkbook wb = new SXSSFWorkbook(new XSSFWorkbook(), 100, false, true)) {
+            Sheet sheet = wb.createSheet("Sheet1");
+            Row header = sheet.createRow(0);
+            for (int c = 0; c < 10; c++) header.createCell(c).setCellValue("c" + c);
+            for (int i = 0; i < data.size(); i++) {
+                StringRow r = data.get(i);
+                Row row = sheet.createRow(i + 1);
+                row.createCell(0).setCellValue(r.getC0());
+                row.createCell(1).setCellValue(r.getC1());
+                row.createCell(2).setCellValue(r.getC2());
+                row.createCell(3).setCellValue(r.getC3());
+                row.createCell(4).setCellValue(r.getC4());
+                row.createCell(5).setCellValue(r.getC5());
+                row.createCell(6).setCellValue(r.getC6());
+                row.createCell(7).setCellValue(r.getC7());
+                row.createCell(8).setCellValue(r.getC8());
+                row.createCell(9).setCellValue(r.getC9());
+            }
+            try (FileOutputStream fos = new FileOutputStream(file)) {
+                wb.write(fos);
+            }
+            wb.dispose();
+        }
+        return file;
+    }
+
+    private File _writeNestedFile(final List<StringOuter> data) throws IOException {
+        File file = File.createTempFile("bench-string-parity-nested-", ".xlsx");
+        file.deleteOnExit();
+        SpreadsheetMapper writer = new SpreadsheetMapper(
+                new SpreadsheetFactory(SXSSFWorkbook::new,
+                        SpreadsheetFactory.DEFAULT_SHEET_PARSER_FEATURE_FLAGS));
+        writer.writeValue(file, data, StringOuter.class);
+        return file;
+    }
+
+    @Benchmark
+    public void flatRead(Blackhole bh) throws IOException {
+        List<StringRow> values = mapper.readValues(flatFile, StringRow.class);
+        bh.consume(values);
+    }
+
+    @Benchmark
+    public void flatReadPoi(Blackhole bh) throws IOException {
+        List<StringRow> values = mapperPoiRead.readValues(flatFile, StringRow.class);
+        bh.consume(values);
+    }
+
+    @Benchmark
+    public void flatWrite(Blackhole bh) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        mapper.writeValue(out, flatData, StringRow.class);
+        bh.consume(out);
+    }
+
+    @Benchmark
+    public void flatWritePoi(Blackhole bh) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        mapperPoiWrite.writeValue(out, flatData, StringRow.class);
+        bh.consume(out);
+    }
+
+    @Benchmark
+    public void nestedRead(Blackhole bh) throws IOException {
+        List<StringOuter> values = mapper.readValues(nestedFile, StringOuter.class);
+        bh.consume(values);
+    }
+
+    @Benchmark
+    public void nestedReadPoi(Blackhole bh) throws IOException {
+        List<StringOuter> values = mapperPoiRead.readValues(nestedFile, StringOuter.class);
+        bh.consume(values);
+    }
+
+    @Benchmark
+    public void nestedWrite(Blackhole bh) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        mapper.writeValue(out, nestedData, StringOuter.class);
+        bh.consume(out);
+    }
+
+    @Benchmark
+    public void nestedWritePoi(Blackhole bh) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        mapperPoiWrite.writeValue(out, nestedData, StringOuter.class);
+        bh.consume(out);
+    }
+}

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SheetStreamContext.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SheetStreamContext.java
@@ -186,7 +186,7 @@ public abstract class SheetStreamContext extends JsonStreamContext {
         @Override
         public ColumnPointer currentPointer() {
             if (_parent.inRoot()) return _parent.currentPointer();
-            return _parent.currentPointer().resolveArray();
+            return _schema.resolveArray(_parent.currentPointer());
         }
 
         @Override
@@ -252,7 +252,7 @@ public abstract class SheetStreamContext extends JsonStreamContext {
 
         @Override
         public ColumnPointer currentPointer() {
-            return _parent.currentPointer().resolve(_name);
+            return _schema.resolve(_parent.currentPointer(), _name);
         }
 
         @Override

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/annotation/DataColumn.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/annotation/DataColumn.java
@@ -55,7 +55,11 @@ public @interface DataColumn {
 
     /**
      * Marks this column as the row anchor for nested-list records.
-     * Plain {@code boolean} (not {@link OptBoolean}) because anchor
+     * Read-side semantic only — the write path does not consult this
+     * attribute (only the read path's record-tree buffer uses it to
+     * detect record boundaries).
+     *
+     * <p>Plain {@code boolean} (not {@link OptBoolean}) because anchor
      * has no cascading source — a {@code DataGrid} cannot supply an
      * anchor default the way it does for {@link #merge} or
      * {@link #autoSize}, so a 3-state value would always collapse to

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/annotation/DataColumn.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/annotation/DataColumn.java
@@ -55,15 +55,7 @@ public @interface DataColumn {
 
     /**
      * Marks this column as the row anchor for nested-list records.
-     * Read-side semantic only — the write path does not consult this
-     * attribute (only the read path's record-tree buffer uses it to
-     * detect record boundaries).
-     *
-     * <p>Plain {@code boolean} (not {@link OptBoolean}) because anchor
-     * has no cascading source — a {@code DataGrid} cannot supply an
-     * anchor default the way it does for {@link #merge} or
-     * {@link #autoSize}, so a 3-state value would always collapse to
-     * 2-state.
+     * Read-side only — the write path ignores this attribute.
      */
     boolean anchor() default false;
 

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/annotation/DataColumn.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/annotation/DataColumn.java
@@ -53,8 +53,15 @@ public @interface DataColumn {
     /** Whether to merge cells vertically for repeated values. */
     OptBoolean merge() default OptBoolean.DEFAULT;
 
-    /** Marks this column as the row anchor for nested-list records. */
-    OptBoolean anchor() default OptBoolean.DEFAULT;
+    /**
+     * Marks this column as the row anchor for nested-list records.
+     * Plain {@code boolean} (not {@link OptBoolean}) because anchor
+     * has no cascading source — a {@code DataGrid} cannot supply an
+     * anchor default the way it does for {@link #merge} or
+     * {@link #autoSize}, so a 3-state value would always collapse to
+     * 2-state.
+     */
+    boolean anchor() default false;
 
     @EqualsAndHashCode
     final class Value implements JacksonAnnotationValue<DataColumn> {
@@ -70,13 +77,13 @@ public @interface DataColumn {
         private final int _minWidth;
         private final int _maxWidth;
         private final OptBoolean _merge;
-        private final OptBoolean _anchor;
+        private final boolean _anchor;
 
         public Value(final String name, final String comment,
                      final String style, final String headerStyle,
                      final int width, final OptBoolean autoSize,
                      final int minWidth, final int maxWidth, final OptBoolean merge,
-                     final OptBoolean anchor) {
+                     final boolean anchor) {
             _name = name;
             _comment = comment;
             _style = style;
@@ -92,7 +99,7 @@ public @interface DataColumn {
         private Value() {
             this("", "", "", "", DataGrid.DEFAULT_COLUMN_WIDTH, OptBoolean.DEFAULT,
                     DataGrid.DEFAULT_MIN_COLUMN_WIDTH, DataGrid.DEFAULT_MAX_COLUMN_WIDTH,
-                    OptBoolean.DEFAULT, OptBoolean.DEFAULT);
+                    OptBoolean.DEFAULT, false);
         }
 
         private Value(final DataColumn ann) {
@@ -116,7 +123,7 @@ public @interface DataColumn {
         public int getMinWidth() { return _minWidth; }
         public int getMaxWidth() { return _maxWidth; }
         public OptBoolean getMerge() { return _merge; }
-        public OptBoolean getAnchor() { return _anchor; }
+        public boolean getAnchor() { return _anchor; }
 
         public Value withName(final String name) {
             if (name == null || name.isEmpty()) return this;
@@ -149,7 +156,7 @@ public @interface DataColumn {
         }
 
         public boolean isAnchor() {
-            return _anchor == OptBoolean.TRUE;
+            return _anchor;
         }
 
         @Override

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/annotation/DataColumn.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/annotation/DataColumn.java
@@ -53,6 +53,9 @@ public @interface DataColumn {
     /** Whether to merge cells vertically for repeated values. */
     OptBoolean merge() default OptBoolean.DEFAULT;
 
+    /** Marks this column as the row anchor for nested-list records. */
+    OptBoolean anchor() default OptBoolean.DEFAULT;
+
     @EqualsAndHashCode
     final class Value implements JacksonAnnotationValue<DataColumn> {
 
@@ -67,11 +70,13 @@ public @interface DataColumn {
         private final int _minWidth;
         private final int _maxWidth;
         private final OptBoolean _merge;
+        private final OptBoolean _anchor;
 
         public Value(final String name, final String comment,
                      final String style, final String headerStyle,
                      final int width, final OptBoolean autoSize,
-                     final int minWidth, final int maxWidth, final OptBoolean merge) {
+                     final int minWidth, final int maxWidth, final OptBoolean merge,
+                     final OptBoolean anchor) {
             _name = name;
             _comment = comment;
             _style = style;
@@ -81,17 +86,18 @@ public @interface DataColumn {
             _minWidth = minWidth;
             _maxWidth = maxWidth;
             _merge = merge;
+            _anchor = anchor;
         }
 
         private Value() {
             this("", "", "", "", DataGrid.DEFAULT_COLUMN_WIDTH, OptBoolean.DEFAULT,
                     DataGrid.DEFAULT_MIN_COLUMN_WIDTH, DataGrid.DEFAULT_MAX_COLUMN_WIDTH,
-                    OptBoolean.DEFAULT);
+                    OptBoolean.DEFAULT, OptBoolean.DEFAULT);
         }
 
         private Value(final DataColumn ann) {
             this(ann.value(), ann.comment(), ann.style(), ann.headerStyle(), ann.width(),
-                    ann.autoSize(), ann.minWidth(), ann.maxWidth(), ann.merge()
+                    ann.autoSize(), ann.minWidth(), ann.maxWidth(), ann.merge(), ann.anchor()
             );
         }
 
@@ -110,11 +116,12 @@ public @interface DataColumn {
         public int getMinWidth() { return _minWidth; }
         public int getMaxWidth() { return _maxWidth; }
         public OptBoolean getMerge() { return _merge; }
+        public OptBoolean getAnchor() { return _anchor; }
 
         public Value withName(final String name) {
             if (name == null || name.isEmpty()) return this;
             return new Value(name, _comment, _style, _headerStyle, _width, _autoSize,
-                    _minWidth, _maxWidth, _merge);
+                    _minWidth, _maxWidth, _merge, _anchor);
         }
 
         public Value withDefaults(final DataGrid.Value defaults) {
@@ -128,7 +135,8 @@ public @interface DataColumn {
                             ? defaults.getMinColumnWidth() : _minWidth,
                     _maxWidth == DataGrid.DEFAULT_MAX_COLUMN_WIDTH
                             ? defaults.getMaxColumnWidth() : _maxWidth,
-                    _merge == OptBoolean.DEFAULT ? defaults.getMergeColumn() : _merge
+                    _merge == OptBoolean.DEFAULT ? defaults.getMergeColumn() : _merge,
+                    _anchor
             );
         }
 
@@ -138,6 +146,10 @@ public @interface DataColumn {
 
         public boolean isMerge() {
             return _merge == OptBoolean.TRUE;
+        }
+
+        public boolean isAnchor() {
+            return _anchor == OptBoolean.TRUE;
         }
 
         @Override
@@ -154,6 +166,7 @@ public @interface DataColumn {
                     + ", minWidth=" + _minWidth
                     + ", maxWidth=" + _maxWidth
                     + ", merge=" + _merge
+                    + ", anchor=" + _anchor
                     + ")";
         }
     }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/NestedReadAlg.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/NestedReadAlg.java
@@ -84,8 +84,24 @@ final class NestedReadAlg {
         _rowBuffer.clear();
     }
 
-    void onCellValue(final Column column, final CellValue value) {
+    void onCellValue(final Column column, final CellValue value) throws SheetStreamReadException {
+        if (!_isSupportedCellType(value.getCellType())) {
+            throw new SheetStreamReadException(null,
+                    "Unexpected value: " + value.getCellType());
+        }
         _rowBuffer.add(new Cell(column, value));
+    }
+
+    private static boolean _isSupportedCellType(final CellType type) {
+        switch (type) {
+            case NUMERIC:
+            case STRING:
+            case BLANK:
+            case BOOLEAN:
+                return true;
+            default:
+                return false;
+        }
     }
 
     /** Returns false when iteration should stop (BREAK_ON_BLANK_ROW). */
@@ -284,7 +300,8 @@ final class NestedReadAlg {
             case BLANK: return JsonToken.VALUE_NULL;
             case BOOLEAN: return v.getBooleanValue()
                     ? JsonToken.VALUE_TRUE : JsonToken.VALUE_FALSE;
-            default: return JsonToken.VALUE_NULL;
+            default: throw new IllegalStateException(
+                    "Unsupported cell type leaked past onCellValue: " + v.getCellType());
         }
     }
 

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/NestedReadAlg.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/NestedReadAlg.java
@@ -36,6 +36,7 @@ final class NestedReadAlg {
     private final List<ColumnPointer> _anchorScopesByDepth;
     private final Set<ColumnPointer> _leafArrayScopes;
     private final Map<ColumnPointer, ColumnPointer> _parentArrayScopeOf;
+    private final Map<Column, ColumnPointer> _immediateScopeByColumn;
     private final long _bufferLimitBytes;
     private final boolean _blankRowAsNull;
     private final boolean _breakOnBlankRow;
@@ -59,9 +60,20 @@ final class NestedReadAlg {
         _anchorScopesByDepth = _collectAnchorScopes(schema);
         _leafArrayScopes = _findLeafArrayScopes(schema);
         _parentArrayScopeOf = _computeParentScopeMap(schema);
+        _immediateScopeByColumn = _computeImmediateScopeByColumn(schema);
         _bufferLimitBytes = bufferLimitBytes;
         _blankRowAsNull = blankRowAsNull;
         _breakOnBlankRow = breakOnBlankRow;
+    }
+
+    private static Map<Column, ColumnPointer> _computeImmediateScopeByColumn(
+            final SpreadsheetSchema schema) {
+        final Map<Column, ColumnPointer> result = new HashMap<>();
+        for (final Column c : schema) {
+            if (c == null) continue;
+            result.put(c, SpreadsheetSchema.immediateScope(c.getPointer()));
+        }
+        return result;
     }
 
     void onSheetDataStart(final Emitter out) {
@@ -105,7 +117,7 @@ final class NestedReadAlg {
             final RecordNode openRecord = new RecordNode(scope);
             for (final Cell c : _rowBuffer) {
                 if (c.value == null || c.value.getCellType() == CellType.BLANK) continue;
-                if (SpreadsheetSchema.immediateScope(c.column.getPointer()).equals(scope)) {
+                if (_immediateScopeByColumn.get(c.column).equals(scope)) {
                     openRecord.outerCells.add(c);
                     _bufferedCells++;
                 }
@@ -118,7 +130,7 @@ final class NestedReadAlg {
             final List<Cell> leafCells = new ArrayList<>();
             for (final Cell c : _rowBuffer) {
                 if (c.value == null || c.value.getCellType() == CellType.BLANK) continue;
-                if (SpreadsheetSchema.immediateScope(c.column.getPointer()).equals(leafScope)) {
+                if (_immediateScopeByColumn.get(c.column).equals(leafScope)) {
                     leafCells.add(c);
                 }
             }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/NestedReadAlg.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/NestedReadAlg.java
@@ -1,0 +1,260 @@
+package io.github.scndry.jackson.dataformat.spreadsheet.deser;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.poi.ss.usermodel.CellType;
+
+import com.fasterxml.jackson.core.JsonToken;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.ColumnPointer;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
+
+/**
+ * Read algorithm — record-tree buffer keyed by array scope. Each
+ * anchored record (root or nested) carries its outer cells plus
+ * sibling-grouped child records; close walks the tree depth-first to
+ * emit JSON in {outer, child1[], child2[], ...} order. Sibling lists,
+ * outer-after-list, and N-depth all fall out of the recursion.
+ *
+ * <p>Buffer footprint per record: outer Cell refs + LinkedHashMap of
+ * child lists. Cells hold Column/CellValue refs only — no token
+ * serialization overhead.
+ */
+final class NestedReadAlg {
+
+    private final SpreadsheetSchema _schema;
+    private final List<ColumnPointer> _anchorScopesByDepth;
+    private final Set<ColumnPointer> _leafArrayScopes;
+    private final Map<ColumnPointer, ColumnPointer> _parentArrayScopeOf;
+
+    private final List<Cell> _rowBuffer = new ArrayList<>();
+    private final Map<ColumnPointer, RecordNode> _openRecords = new HashMap<>();
+    private final Map<ColumnPointer, Object> _lastAnchorByScope = new HashMap<>();
+
+    NestedReadAlg(final SpreadsheetSchema schema) {
+        _schema = schema;
+        _anchorScopesByDepth = _collectAnchorScopes(schema);
+        _leafArrayScopes = _findLeafArrayScopes(schema);
+        _parentArrayScopeOf = _computeParentScopeMap(schema);
+    }
+
+    void onSheetDataStart(final Emitter out) {
+        out.token(JsonToken.START_ARRAY);
+    }
+
+    void onRowStart() {
+        _rowBuffer.clear();
+    }
+
+    void onCellValue(final Column column, final CellValue value) {
+        _rowBuffer.add(new Cell(column, value));
+    }
+
+    void onRowEnd(final Emitter out) {
+        for (final ColumnPointer scope : _anchorScopesByDepth) {
+            final Column anchorCol = _schema.findAnchorColumn(scope);
+            if (anchorCol == null) continue;
+            final Cell cell = _findCell(anchorCol);
+            if (cell == null) continue;
+            final CellValue v = cell.value;
+            if (v == null || v.getCellType() == CellType.BLANK) continue;
+            final Object newKey = _anchorKey(v);
+            final Object lastKey = _lastAnchorByScope.get(scope);
+            if (newKey.equals(lastKey)) continue;
+
+            _closeRecordsAtOrDeeperThan(scope, out);
+
+            final RecordNode openRecord = new RecordNode(scope);
+            for (final Cell c : _rowBuffer) {
+                if (c.value == null || c.value.getCellType() == CellType.BLANK) continue;
+                if (SpreadsheetSchema.immediateScope(c.column.getPointer()).equals(scope)) {
+                    openRecord.outerCells.add(c);
+                }
+            }
+            _openRecords.put(scope, openRecord);
+            _lastAnchorByScope.put(scope, newKey);
+        }
+
+        for (final ColumnPointer leafScope : _leafArrayScopes) {
+            final List<Cell> leafCells = new ArrayList<>();
+            for (final Cell c : _rowBuffer) {
+                if (c.value == null || c.value.getCellType() == CellType.BLANK) continue;
+                if (SpreadsheetSchema.immediateScope(c.column.getPointer()).equals(leafScope)) {
+                    leafCells.add(c);
+                }
+            }
+            if (leafCells.isEmpty()) continue;
+
+            final RecordNode leafRecord = new RecordNode(leafScope);
+            leafRecord.outerCells.addAll(leafCells);
+
+            final ColumnPointer parentScope = _parentArrayScopeOf.get(leafScope);
+            final RecordNode parentRecord = _openRecords.get(parentScope);
+            parentRecord.childRecords
+                    .computeIfAbsent(leafScope, k -> new ArrayList<>())
+                    .add(leafRecord);
+        }
+    }
+
+    void onSheetDataEnd(final Emitter out) {
+        _closeRecordsAtOrDeeperThan(ColumnPointer.empty(), out);
+        out.token(JsonToken.END_ARRAY);
+    }
+
+    private void _closeRecordsAtOrDeeperThan(final ColumnPointer scope, final Emitter out) {
+        final List<ColumnPointer> toClose = new ArrayList<>();
+        for (final ColumnPointer s : _openRecords.keySet()) {
+            if (s.equals(scope) || s.startsWith(scope)) toClose.add(s);
+        }
+        toClose.sort(Comparator.comparingInt(NestedReadAlg::_scopeDepth).reversed());
+        for (final ColumnPointer s : toClose) {
+            final RecordNode record = _openRecords.remove(s);
+            _lastAnchorByScope.remove(s);
+            _emitOrAttach(record, out);
+        }
+    }
+
+    private void _emitOrAttach(final RecordNode record, final Emitter out) {
+        final ColumnPointer parentScope = _parentArrayScopeOf.get(record.scope);
+        final RecordNode parentRecord = parentScope == null ? null : _openRecords.get(parentScope);
+        if (parentRecord != null) {
+            parentRecord.childRecords
+                    .computeIfAbsent(record.scope, k -> new ArrayList<>())
+                    .add(record);
+        } else {
+            _emitRecord(record, out);
+        }
+    }
+
+    private void _emitRecord(final RecordNode record, final Emitter out) {
+        out.token(JsonToken.START_OBJECT);
+        for (final Cell c : record.outerCells) {
+            out.fieldName(c.column.getPointer().name());
+            out.scalar(c.value, _scalarToken(c.value));
+        }
+        for (final Map.Entry<ColumnPointer, List<RecordNode>> e : record.childRecords.entrySet()) {
+            out.fieldName(e.getKey().getParent().name());
+            out.token(JsonToken.START_ARRAY);
+            for (final RecordNode child : e.getValue()) {
+                _emitRecord(child, out);
+            }
+            out.token(JsonToken.END_ARRAY);
+        }
+        out.token(JsonToken.END_OBJECT);
+    }
+
+    private Cell _findCell(final Column column) {
+        for (final Cell c : _rowBuffer) {
+            if (c.column == column) return c;
+        }
+        return null;
+    }
+
+    private static List<ColumnPointer> _collectAnchorScopes(final SpreadsheetSchema schema) {
+        final List<ColumnPointer> scopes = new ArrayList<>();
+        if (schema.findAnchorColumn(ColumnPointer.empty()) != null) {
+            scopes.add(ColumnPointer.empty());
+        }
+        final List<ColumnPointer> arrayScopes = new ArrayList<>(schema.allArrayScopes());
+        arrayScopes.sort(Comparator.comparingInt(NestedReadAlg::_scopeDepth));
+        for (final ColumnPointer s : arrayScopes) {
+            if (schema.findAnchorColumn(s) != null) scopes.add(s);
+        }
+        return scopes;
+    }
+
+    private static Set<ColumnPointer> _findLeafArrayScopes(final SpreadsheetSchema schema) {
+        final Set<ColumnPointer> all = schema.allArrayScopes();
+        final Set<ColumnPointer> leafs = new LinkedHashSet<>();
+        for (final ColumnPointer scope : all) {
+            boolean hasChild = false;
+            for (final ColumnPointer other : all) {
+                if (_isImmediateChildArrayScope(scope, other)) { hasChild = true; break; }
+            }
+            if (!hasChild) leafs.add(scope);
+        }
+        return leafs;
+    }
+
+    private static Map<ColumnPointer, ColumnPointer> _computeParentScopeMap(
+            final SpreadsheetSchema schema) {
+        final Map<ColumnPointer, ColumnPointer> result = new HashMap<>();
+        for (final ColumnPointer scope : schema.allArrayScopes()) {
+            result.put(scope, _parentArrayScopeOf(scope));
+        }
+        return result;
+    }
+
+    private static ColumnPointer _parentArrayScopeOf(final ColumnPointer scope) {
+        ColumnPointer head = ColumnPointer.empty();
+        ColumnPointer parent = ColumnPointer.empty();
+        for (final ColumnPointer seg : scope) {
+            head = head.resolve(seg);
+            if (head.equals(scope)) break;
+            if (seg.equals(ColumnPointer.array())) parent = head;
+        }
+        return parent;
+    }
+
+    private static boolean _isImmediateChildArrayScope(
+            final ColumnPointer parent, final ColumnPointer child) {
+        if (!child.startsWith(parent) || child.equals(parent)) return false;
+        return _scopeDepth(child) == _scopeDepth(parent) + 1;
+    }
+
+    private static int _scopeDepth(final ColumnPointer scope) {
+        int d = 0;
+        for (final ColumnPointer seg : scope) {
+            if (seg.equals(ColumnPointer.array())) d++;
+        }
+        return d;
+    }
+
+    private static JsonToken _scalarToken(final CellValue v) {
+        switch (v.getCellType()) {
+            case NUMERIC: return v.getNumberValue() % 1 == 0
+                    ? JsonToken.VALUE_NUMBER_INT : JsonToken.VALUE_NUMBER_FLOAT;
+            case STRING: return JsonToken.VALUE_STRING;
+            case BLANK: return JsonToken.VALUE_NULL;
+            case BOOLEAN: return v.getBooleanValue()
+                    ? JsonToken.VALUE_TRUE : JsonToken.VALUE_FALSE;
+            default: return JsonToken.VALUE_NULL;
+        }
+    }
+
+    private static Object _anchorKey(final CellValue v) {
+        switch (v.getCellType()) {
+            case NUMERIC: return v.getNumberValue();
+            case STRING: return v.getStringValue();
+            case BOOLEAN: return v.getBooleanValue();
+            default: return null;
+        }
+    }
+
+    interface Emitter {
+        void token(JsonToken token);
+        void fieldName(String name);
+        void scalar(CellValue value, JsonToken scalarToken);
+    }
+
+    private static final class Cell {
+        final Column column;
+        final CellValue value;
+        Cell(final Column c, final CellValue v) { column = c; value = v; }
+    }
+
+    private static final class RecordNode {
+        final ColumnPointer scope;
+        final List<Cell> outerCells = new ArrayList<>();
+        final Map<ColumnPointer, List<RecordNode>> childRecords = new LinkedHashMap<>();
+        RecordNode(final ColumnPointer scope) { this.scope = scope; }
+    }
+}

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/NestedReadAlg.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/NestedReadAlg.java
@@ -13,9 +13,11 @@ import org.apache.poi.ss.usermodel.CellType;
 
 import com.fasterxml.jackson.core.JsonToken;
 
+import io.github.scndry.jackson.dataformat.spreadsheet.SheetStreamReadException;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.ColumnPointer;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.BackWriteProjection;
 
 /**
  * Read algorithm — record-tree buffer keyed by array scope. Each
@@ -34,16 +36,23 @@ final class NestedReadAlg {
     private final List<ColumnPointer> _anchorScopesByDepth;
     private final Set<ColumnPointer> _leafArrayScopes;
     private final Map<ColumnPointer, ColumnPointer> _parentArrayScopeOf;
+    private final long _bufferLimitBytes;
 
     private final List<Cell> _rowBuffer = new ArrayList<>();
     private final Map<ColumnPointer, RecordNode> _openRecords = new HashMap<>();
     private final Map<ColumnPointer, Object> _lastAnchorByScope = new HashMap<>();
+    private long _bufferedCells;
 
     NestedReadAlg(final SpreadsheetSchema schema) {
+        this(schema, BackWriteProjection.backWriteBufferLimit());
+    }
+
+    NestedReadAlg(final SpreadsheetSchema schema, final long bufferLimitBytes) {
         _schema = schema;
         _anchorScopesByDepth = _collectAnchorScopes(schema);
         _leafArrayScopes = _findLeafArrayScopes(schema);
         _parentArrayScopeOf = _computeParentScopeMap(schema);
+        _bufferLimitBytes = bufferLimitBytes;
     }
 
     void onSheetDataStart(final Emitter out) {
@@ -58,7 +67,7 @@ final class NestedReadAlg {
         _rowBuffer.add(new Cell(column, value));
     }
 
-    void onRowEnd(final Emitter out) {
+    void onRowEnd(final Emitter out) throws SheetStreamReadException {
         for (final ColumnPointer scope : _anchorScopesByDepth) {
             final Column anchorCol = _schema.findAnchorColumn(scope);
             if (anchorCol == null) continue;
@@ -77,6 +86,7 @@ final class NestedReadAlg {
                 if (c.value == null || c.value.getCellType() == CellType.BLANK) continue;
                 if (SpreadsheetSchema.immediateScope(c.column.getPointer()).equals(scope)) {
                     openRecord.outerCells.add(c);
+                    _bufferedCells++;
                 }
             }
             _openRecords.put(scope, openRecord);
@@ -95,6 +105,7 @@ final class NestedReadAlg {
 
             final RecordNode leafRecord = new RecordNode(leafScope);
             leafRecord.outerCells.addAll(leafCells);
+            _bufferedCells += leafCells.size();
 
             final ColumnPointer parentScope = _parentArrayScopeOf.get(leafScope);
             final RecordNode parentRecord = _openRecords.get(parentScope);
@@ -102,11 +113,23 @@ final class NestedReadAlg {
                     .computeIfAbsent(leafScope, k -> new ArrayList<>())
                     .add(leafRecord);
         }
+
+        _checkBufferLimit();
     }
 
     void onSheetDataEnd(final Emitter out) {
         _closeRecordsAtOrDeeperThan(ColumnPointer.empty(), out);
         out.token(JsonToken.END_ARRAY);
+    }
+
+    private void _checkBufferLimit() throws SheetStreamReadException {
+        final long bufferedBytes = _bufferedCells * (long) BackWriteProjection.CELL_MEMORY_BYTES;
+        if (bufferedBytes <= _bufferLimitBytes) return;
+        throw new SheetStreamReadException(null,
+                "Nested-list buffer (" + BackWriteProjection.formatBytes(bufferedBytes)
+                + ") exceeds limit (" + BackWriteProjection.formatBytes(_bufferLimitBytes)
+                + "). Use USE_POI_USER_MODEL to bypass back-write buffering,"
+                + " or split the outer record into smaller chunks.");
     }
 
     private void _closeRecordsAtOrDeeperThan(final ColumnPointer scope, final Emitter out) {
@@ -131,6 +154,7 @@ final class NestedReadAlg {
                     .add(record);
         } else {
             _emitRecord(record, out);
+            _bufferedCells = 0;
         }
     }
 

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/NestedReadAlg.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/NestedReadAlg.java
@@ -37,6 +37,8 @@ final class NestedReadAlg {
     private final Set<ColumnPointer> _leafArrayScopes;
     private final Map<ColumnPointer, ColumnPointer> _parentArrayScopeOf;
     private final long _bufferLimitBytes;
+    private final boolean _blankRowAsNull;
+    private final boolean _breakOnBlankRow;
 
     private final List<Cell> _rowBuffer = new ArrayList<>();
     private final Map<ColumnPointer, RecordNode> _openRecords = new HashMap<>();
@@ -44,15 +46,22 @@ final class NestedReadAlg {
     private long _bufferedCells;
 
     NestedReadAlg(final SpreadsheetSchema schema) {
-        this(schema, BackWriteProjection.backWriteBufferLimit());
+        this(schema, BackWriteProjection.backWriteBufferLimit(), true, false);
     }
 
     NestedReadAlg(final SpreadsheetSchema schema, final long bufferLimitBytes) {
+        this(schema, bufferLimitBytes, true, false);
+    }
+
+    NestedReadAlg(final SpreadsheetSchema schema, final long bufferLimitBytes,
+                  final boolean blankRowAsNull, final boolean breakOnBlankRow) {
         _schema = schema;
         _anchorScopesByDepth = _collectAnchorScopes(schema);
         _leafArrayScopes = _findLeafArrayScopes(schema);
         _parentArrayScopeOf = _computeParentScopeMap(schema);
         _bufferLimitBytes = bufferLimitBytes;
+        _blankRowAsNull = blankRowAsNull;
+        _breakOnBlankRow = breakOnBlankRow;
     }
 
     void onSheetDataStart(final Emitter out) {
@@ -67,7 +76,19 @@ final class NestedReadAlg {
         _rowBuffer.add(new Cell(column, value));
     }
 
-    void onRowEnd(final Emitter out) throws SheetStreamReadException {
+    /** Returns false when iteration should stop (BREAK_ON_BLANK_ROW). */
+    boolean onRowEnd(final Emitter out) throws SheetStreamReadException {
+        if (_rowBuffer.isEmpty()) {
+            if (_breakOnBlankRow) {
+                _closeRecordsAtOrDeeperThan(ColumnPointer.empty(), out);
+                return false;
+            }
+            if (_blankRowAsNull) {
+                _closeRecordsAtOrDeeperThan(ColumnPointer.empty(), out);
+                out.token(JsonToken.VALUE_NULL);
+            }
+            return true;
+        }
         for (final ColumnPointer scope : _anchorScopesByDepth) {
             final Column anchorCol = _schema.findAnchorColumn(scope);
             if (anchorCol == null) continue;
@@ -115,6 +136,7 @@ final class NestedReadAlg {
         }
 
         _checkBufferLimit();
+        return true;
     }
 
     void onSheetDataEnd(final Emitter out) {

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/RecordTreeBuffer.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/RecordTreeBuffer.java
@@ -37,6 +37,7 @@ final class RecordTreeBuffer {
     private final Set<ColumnPointer> _leafArrayScopes;
     private final Map<ColumnPointer, ColumnPointer> _parentArrayScopeOf;
     private final Map<Column, ColumnPointer> _immediateScopeByColumn;
+    private final Map<Column, Integer> _columnPositionByColumn;
     private final long _bufferLimitBytes;
     private final boolean _blankRowAsNull;
     private final boolean _breakOnBlankRow;
@@ -61,6 +62,7 @@ final class RecordTreeBuffer {
         _leafArrayScopes = _findLeafArrayScopes(schema);
         _parentArrayScopeOf = _computeParentScopeMap(schema);
         _immediateScopeByColumn = _computeImmediateScopeByColumn(schema);
+        _columnPositionByColumn = _computeColumnPositionByColumn(schema);
         _bufferLimitBytes = bufferLimitBytes;
         _blankRowAsNull = blankRowAsNull;
         _breakOnBlankRow = breakOnBlankRow;
@@ -72,6 +74,17 @@ final class RecordTreeBuffer {
         for (final Column c : schema) {
             if (c == null) continue;
             result.put(c, SpreadsheetSchema.immediateScope(c.getPointer()));
+        }
+        return result;
+    }
+
+    private static Map<Column, Integer> _computeColumnPositionByColumn(
+            final SpreadsheetSchema schema) {
+        final Map<Column, Integer> result = new HashMap<>();
+        int i = 0;
+        for (final Column c : schema) {
+            if (c != null) result.put(c, i);
+            i++;
         }
         return result;
     }
@@ -134,7 +147,7 @@ final class RecordTreeBuffer {
             for (final Cell c : _rowBuffer) {
                 if (c.value == null || c.value.getCellType() == CellType.BLANK) continue;
                 if (_immediateScopeByColumn.get(c.column).equals(scope)) {
-                    openRecord.outerCells.add(c);
+                    _addSortedByColumn(openRecord.outerCells, c);
                     _bufferedCells++;
                 }
             }
@@ -143,18 +156,15 @@ final class RecordTreeBuffer {
         }
 
         for (final ColumnPointer leafScope : _leafArrayScopes) {
-            final List<Cell> leafCells = new ArrayList<>();
+            final RecordNode leafRecord = new RecordNode(leafScope);
             for (final Cell c : _rowBuffer) {
                 if (c.value == null || c.value.getCellType() == CellType.BLANK) continue;
                 if (_immediateScopeByColumn.get(c.column).equals(leafScope)) {
-                    leafCells.add(c);
+                    _addSortedByColumn(leafRecord.outerCells, c);
                 }
             }
-            if (leafCells.isEmpty()) continue;
-
-            final RecordNode leafRecord = new RecordNode(leafScope);
-            leafRecord.outerCells.addAll(leafCells);
-            _bufferedCells += leafCells.size();
+            if (leafRecord.outerCells.isEmpty()) continue;
+            _bufferedCells += leafRecord.outerCells.size();
 
             final ColumnPointer parentScope = _parentArrayScopeOf.get(leafScope);
             final RecordNode parentRecord = _openRecords.get(parentScope);
@@ -223,6 +233,16 @@ final class RecordTreeBuffer {
             out.token(JsonToken.END_ARRAY);
         }
         out.token(JsonToken.END_OBJECT);
+    }
+
+    private void _addSortedByColumn(final List<Cell> cells, final Cell c) {
+        final int pos = _columnPositionByColumn.get(c.column);
+        int i = 0;
+        while (i < cells.size()
+                && _columnPositionByColumn.get(cells.get(i).column) < pos) {
+            i++;
+        }
+        cells.add(i, c);
     }
 
     private Cell _findCell(final Column column) {

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/RecordTreeBuffer.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/RecordTreeBuffer.java
@@ -20,17 +20,17 @@ import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.BackWriteProjection;
 
 /**
- * Read algorithm — record-tree buffer keyed by array scope. Each
- * anchored record (root or nested) carries its outer cells plus
- * sibling-grouped child records; close walks the tree depth-first to
- * emit JSON in {outer, child1[], child2[], ...} order. Sibling lists,
+ * Record-tree buffer keyed by array scope. Each anchored record
+ * (root or nested) carries its outer cells plus sibling-grouped
+ * child records; close walks the tree depth-first to emit JSON in
+ * {outer, child1[], child2[], ...} order. Sibling lists,
  * outer-after-list, and N-depth all fall out of the recursion.
  *
  * <p>Buffer footprint per record: outer Cell refs + LinkedHashMap of
  * child lists. Cells hold Column/CellValue refs only — no token
  * serialization overhead.
  */
-final class NestedReadAlg {
+final class RecordTreeBuffer {
 
     private final SpreadsheetSchema _schema;
     private final List<ColumnPointer> _anchorScopesByDepth;
@@ -46,15 +46,15 @@ final class NestedReadAlg {
     private final Map<ColumnPointer, Object> _lastAnchorByScope = new HashMap<>();
     private long _bufferedCells;
 
-    NestedReadAlg(final SpreadsheetSchema schema) {
+    RecordTreeBuffer(final SpreadsheetSchema schema) {
         this(schema, BackWriteProjection.backWriteBufferLimit(), true, false);
     }
 
-    NestedReadAlg(final SpreadsheetSchema schema, final long bufferLimitBytes) {
+    RecordTreeBuffer(final SpreadsheetSchema schema, final long bufferLimitBytes) {
         this(schema, bufferLimitBytes, true, false);
     }
 
-    NestedReadAlg(final SpreadsheetSchema schema, final long bufferLimitBytes,
+    RecordTreeBuffer(final SpreadsheetSchema schema, final long bufferLimitBytes,
                   final boolean blankRowAsNull, final boolean breakOnBlankRow) {
         _schema = schema;
         _anchorScopesByDepth = _collectAnchorScopes(schema);
@@ -187,7 +187,7 @@ final class NestedReadAlg {
         for (final ColumnPointer s : _openRecords.keySet()) {
             if (s.equals(scope) || s.startsWith(scope)) toClose.add(s);
         }
-        toClose.sort(Comparator.comparingInt(NestedReadAlg::_scopeDepth).reversed());
+        toClose.sort(Comparator.comparingInt(RecordTreeBuffer::_scopeDepth).reversed());
         for (final ColumnPointer s : toClose) {
             final RecordNode record = _openRecords.remove(s);
             _lastAnchorByScope.remove(s);
@@ -238,7 +238,7 @@ final class NestedReadAlg {
             scopes.add(ColumnPointer.empty());
         }
         final List<ColumnPointer> arrayScopes = new ArrayList<>(schema.allArrayScopes());
-        arrayScopes.sort(Comparator.comparingInt(NestedReadAlg::_scopeDepth));
+        arrayScopes.sort(Comparator.comparingInt(RecordTreeBuffer::_scopeDepth));
         for (final ColumnPointer s : arrayScopes) {
             if (schema.findAnchorColumn(s) != null) scopes.add(s);
         }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/RecordTreeBuffer.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/RecordTreeBuffer.java
@@ -18,6 +18,7 @@ import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.ColumnPointer;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.BackWriteProjection;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.SchemaAnchorInspector;
 
 /**
  * Record-tree buffer keyed by array scope. Each anchored record
@@ -73,7 +74,7 @@ final class RecordTreeBuffer {
         final Map<Column, ColumnPointer> result = new HashMap<>();
         for (final Column c : schema) {
             if (c == null) continue;
-            result.put(c, SpreadsheetSchema.immediateScope(c.getPointer()));
+            result.put(c, SchemaAnchorInspector.immediateScope(c.getPointer()));
         }
         return result;
     }
@@ -131,7 +132,7 @@ final class RecordTreeBuffer {
             return true;
         }
         for (final ColumnPointer scope : _anchorScopesByDepth) {
-            final Column anchorCol = _schema.findAnchorColumn(scope);
+            final Column anchorCol = SchemaAnchorInspector.findAnchorColumn(_schema, scope);
             if (anchorCol == null) continue;
             final Cell cell = _findCell(anchorCol);
             if (cell == null) continue;
@@ -254,19 +255,20 @@ final class RecordTreeBuffer {
 
     private static List<ColumnPointer> _collectAnchorScopes(final SpreadsheetSchema schema) {
         final List<ColumnPointer> scopes = new ArrayList<>();
-        if (schema.findAnchorColumn(ColumnPointer.empty()) != null) {
+        if (SchemaAnchorInspector.findAnchorColumn(schema, ColumnPointer.empty()) != null) {
             scopes.add(ColumnPointer.empty());
         }
-        final List<ColumnPointer> arrayScopes = new ArrayList<>(schema.allArrayScopes());
+        final List<ColumnPointer> arrayScopes =
+                new ArrayList<>(SchemaAnchorInspector.allArrayScopes(schema));
         arrayScopes.sort(Comparator.comparingInt(RecordTreeBuffer::_scopeDepth));
         for (final ColumnPointer s : arrayScopes) {
-            if (schema.findAnchorColumn(s) != null) scopes.add(s);
+            if (SchemaAnchorInspector.findAnchorColumn(schema, s) != null) scopes.add(s);
         }
         return scopes;
     }
 
     private static Set<ColumnPointer> _findLeafArrayScopes(final SpreadsheetSchema schema) {
-        final Set<ColumnPointer> all = schema.allArrayScopes();
+        final Set<ColumnPointer> all = SchemaAnchorInspector.allArrayScopes(schema);
         final Set<ColumnPointer> leafs = new LinkedHashSet<>();
         for (final ColumnPointer scope : all) {
             boolean hasChild = false;
@@ -281,7 +283,7 @@ final class RecordTreeBuffer {
     private static Map<ColumnPointer, ColumnPointer> _computeParentScopeMap(
             final SpreadsheetSchema schema) {
         final Map<ColumnPointer, ColumnPointer> result = new HashMap<>();
-        for (final ColumnPointer scope : schema.allArrayScopes()) {
+        for (final ColumnPointer scope : SchemaAnchorInspector.allArrayScopes(schema)) {
             result.put(scope, _parentArrayScopeOf(scope));
         }
         return result;

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/RecordTreeBuffer.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/RecordTreeBuffer.java
@@ -100,8 +100,7 @@ final class RecordTreeBuffer {
 
     void onCellValue(final Column column, final CellValue value) throws SheetStreamReadException {
         if (!_isSupportedCellType(value.getCellType())) {
-            throw new SheetStreamReadException(null,
-                    "Unexpected value: " + value.getCellType());
+            throw SheetStreamReadException.unexpected(null, value.getCellType());
         }
         _rowBuffer.add(new Cell(column, value));
     }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetParser.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetParser.java
@@ -243,7 +243,7 @@ public final class SheetParser extends ParserMinimalBase {
         }
     }
 
-    private void _prepareNextNested() {
+    private void _prepareNextNested() throws StreamReadException {
         final SheetToken token = _readNext();
         if (token == null) {
             _ended = true;
@@ -267,7 +267,11 @@ public final class SheetParser extends ParserMinimalBase {
                 _nestedAlg.onCellValue(column, value);
                 break;
             case ROW_END:
-                _nestedAlg.onRowEnd(_nestedEmitter);
+                try {
+                    _nestedAlg.onRowEnd(_nestedEmitter);
+                } catch (final SheetStreamReadException e) {
+                    throw e.withParser(this);
+                }
                 break;
             case SHEET_DATA_END:
                 _nestedAlg.onSheetDataEnd(_nestedEmitter);

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetParser.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetParser.java
@@ -268,7 +268,11 @@ public final class SheetParser extends ParserMinimalBase {
                 final CellValue value = _reader.getCellValue();
                 final Column column = _schema.findColumn(_referenceColumn);
                 if (column == null) break;
-                _nestedAlg.onCellValue(column, value);
+                try {
+                    _nestedAlg.onCellValue(column, value);
+                } catch (final SheetStreamReadException e) {
+                    throw e.withParser(this);
+                }
                 break;
             case ROW_END:
                 try {

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetParser.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetParser.java
@@ -27,6 +27,7 @@ import io.github.scndry.jackson.dataformat.spreadsheet.poi.POICompat;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.ColumnPointer;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.NestedAnchorValidator;
 
 /**
  * {@link com.fasterxml.jackson.core.JsonParser} implementation
@@ -44,12 +45,16 @@ public final class SheetParser extends ParserMinimalBase {
     private final IOContext _ioContext;
     private final SheetReader _reader;
     private final Deque<JsonToken> _nextTokens;
+    private final Deque<String> _nextNames = new ArrayDeque<>();
+    private final Deque<CellValue> _nextValues = new ArrayDeque<>();
     private final int _formatFeatures;
     private boolean _closed;
     private boolean _ended;
     private ObjectCodec _objectCodec;
     private SpreadsheetSchema _schema;
     private SheetStreamContext _parsingContext;
+    private NestedReadAlg _nestedAlg;
+    private NestedReadAlg.Emitter _nestedEmitter;
     private int _referenceRow = -1;
     private int _referenceColumn = -1;
     private CellValue _value;
@@ -98,6 +103,28 @@ public final class SheetParser extends ParserMinimalBase {
                     + " @DataColumnGroup annotations from the target class.");
         }
         _parsingContext = SheetStreamContext.createRootContext(_schema);
+        if (_schema.hasAnchor() || _schema.hasNestedList()) {
+            NestedAnchorValidator.validate(_schema);
+        }
+        if (_schema.hasAnchor()) {
+            _nestedAlg = new NestedReadAlg(_schema);
+            _nestedEmitter = new NestedReadAlg.Emitter() {
+                @Override
+                public void token(final JsonToken t) {
+                    _nextTokens.add(t);
+                }
+                @Override
+                public void fieldName(final String name) {
+                    _nextTokens.add(JsonToken.FIELD_NAME);
+                    _nextNames.add(name);
+                }
+                @Override
+                public void scalar(final CellValue value, final JsonToken scalarToken) {
+                    _nextTokens.add(scalarToken);
+                    _nextValues.add(value);
+                }
+            };
+        }
     }
 
     @Override
@@ -134,9 +161,13 @@ public final class SheetParser extends ParserMinimalBase {
                 _parsingContext = _parsingContext.clearAndGetParent();
                 break;
             case FIELD_NAME:
-                final Column column = _schema.getColumn(_referenceColumn);
-                final ColumnPointer pointer = _parsingContext.relativePointer(column.getPointer());
-                _parsingContext.setCurrentName(pointer.head().name());
+                if (_nestedAlg != null) {
+                    _parsingContext.setCurrentName(_nextNames.removeFirst());
+                } else {
+                    final Column column = _schema.getColumn(_referenceColumn);
+                    final ColumnPointer pointer = _parsingContext.relativePointer(column.getPointer());
+                    _parsingContext.setCurrentName(pointer.head().name());
+                }
                 break;
             case VALUE_EMBEDDED_OBJECT:
             case VALUE_STRING:
@@ -145,6 +176,9 @@ public final class SheetParser extends ParserMinimalBase {
             case VALUE_TRUE:
             case VALUE_FALSE:
             case VALUE_NULL:
+                if (_nestedAlg != null && !_nextValues.isEmpty()) {
+                    _value = _nextValues.removeFirst();
+                }
                 break;
             case NOT_AVAILABLE:
                 throw SheetStreamReadException.unexpected(this, token);
@@ -165,6 +199,14 @@ public final class SheetParser extends ParserMinimalBase {
     }
 
     private void _prepareNext() throws StreamReadException {
+        if (_nestedAlg != null) {
+            _prepareNextNested();
+        } else {
+            _prepareNextFlat();
+        }
+    }
+
+    private void _prepareNextFlat() throws StreamReadException {
         final SheetToken token = _readNext();
         if (token == null) {
             _ended = true;
@@ -197,6 +239,38 @@ public final class SheetParser extends ParserMinimalBase {
                 break;
             case SHEET_DATA_END:
                 _nextTokens.add(JsonToken.END_ARRAY);
+                break;
+        }
+    }
+
+    private void _prepareNextNested() {
+        final SheetToken token = _readNext();
+        if (token == null) {
+            _ended = true;
+            return;
+        }
+        switch (token) {
+            case SHEET_DATA_START:
+                _nestedAlg.onSheetDataStart(_nestedEmitter);
+                break;
+            case ROW_START:
+                _referenceRow = _reader.getRow();
+                _referenceColumn = -1;
+                _nestedAlg.onRowStart();
+                break;
+            case CELL_VALUE:
+                _referenceRow = _reader.getRow();
+                _referenceColumn = _reader.getColumn();
+                final CellValue value = _reader.getCellValue();
+                final Column column = _schema.findColumn(_referenceColumn);
+                if (column == null) break;
+                _nestedAlg.onCellValue(column, value);
+                break;
+            case ROW_END:
+                _nestedAlg.onRowEnd(_nestedEmitter);
+                break;
+            case SHEET_DATA_END:
+                _nestedAlg.onSheetDataEnd(_nestedEmitter);
                 break;
         }
     }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetParser.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetParser.java
@@ -27,6 +27,7 @@ import io.github.scndry.jackson.dataformat.spreadsheet.poi.POICompat;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.ColumnPointer;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.BackWriteProjection;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.NestedAnchorValidator;
 
 /**
@@ -107,7 +108,10 @@ public final class SheetParser extends ParserMinimalBase {
             NestedAnchorValidator.validate(_schema);
         }
         if (_schema.hasAnchor()) {
-            _nestedAlg = new NestedReadAlg(_schema);
+            _nestedAlg = new NestedReadAlg(_schema,
+                    BackWriteProjection.backWriteBufferLimit(),
+                    isEnabled(Feature.BLANK_ROW_AS_NULL),
+                    isEnabled(Feature.BREAK_ON_BLANK_ROW));
             _nestedEmitter = new NestedReadAlg.Emitter() {
                 @Override
                 public void token(final JsonToken t) {
@@ -268,7 +272,9 @@ public final class SheetParser extends ParserMinimalBase {
                 break;
             case ROW_END:
                 try {
-                    _nestedAlg.onRowEnd(_nestedEmitter);
+                    if (!_nestedAlg.onRowEnd(_nestedEmitter)) {
+                        _ended = true;
+                    }
                 } catch (final SheetStreamReadException e) {
                     throw e.withParser(this);
                 }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetParser.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetParser.java
@@ -29,6 +29,7 @@ import io.github.scndry.jackson.dataformat.spreadsheet.schema.ColumnPointer;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.BackWriteProjection;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.NestedAnchorValidator;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.SchemaAnchorInspector;
 
 /**
  * {@link com.fasterxml.jackson.core.JsonParser} implementation
@@ -104,10 +105,10 @@ public final class SheetParser extends ParserMinimalBase {
                     + " @DataColumnGroup annotations from the target class.");
         }
         _parsingContext = SheetStreamContext.createRootContext(_schema);
-        if (_schema.hasAnchor() || _schema.hasNestedList()) {
+        if (SchemaAnchorInspector.hasAnchor(_schema) || SchemaAnchorInspector.hasNestedList(_schema)) {
             NestedAnchorValidator.validate(_schema);
         }
-        if (_schema.hasAnchor()) {
+        if (SchemaAnchorInspector.hasAnchor(_schema)) {
             _recordBuffer = new RecordTreeBuffer(_schema,
                     BackWriteProjection.backWriteBufferLimit(),
                     isEnabled(Feature.BLANK_ROW_AS_NULL),

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetParser.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetParser.java
@@ -54,8 +54,8 @@ public final class SheetParser extends ParserMinimalBase {
     private ObjectCodec _objectCodec;
     private SpreadsheetSchema _schema;
     private SheetStreamContext _parsingContext;
-    private NestedReadAlg _nestedAlg;
-    private NestedReadAlg.Emitter _nestedEmitter;
+    private RecordTreeBuffer _recordBuffer;
+    private RecordTreeBuffer.Emitter _recordEmitter;
     private int _referenceRow = -1;
     private int _referenceColumn = -1;
     private CellValue _value;
@@ -108,11 +108,11 @@ public final class SheetParser extends ParserMinimalBase {
             NestedAnchorValidator.validate(_schema);
         }
         if (_schema.hasAnchor()) {
-            _nestedAlg = new NestedReadAlg(_schema,
+            _recordBuffer = new RecordTreeBuffer(_schema,
                     BackWriteProjection.backWriteBufferLimit(),
                     isEnabled(Feature.BLANK_ROW_AS_NULL),
                     isEnabled(Feature.BREAK_ON_BLANK_ROW));
-            _nestedEmitter = new NestedReadAlg.Emitter() {
+            _recordEmitter = new RecordTreeBuffer.Emitter() {
                 @Override
                 public void token(final JsonToken t) {
                     _nextTokens.add(t);
@@ -165,7 +165,7 @@ public final class SheetParser extends ParserMinimalBase {
                 _parsingContext = _parsingContext.clearAndGetParent();
                 break;
             case FIELD_NAME:
-                if (_nestedAlg != null) {
+                if (_recordBuffer != null) {
                     _parsingContext.setCurrentName(_nextNames.removeFirst());
                 } else {
                     final Column column = _schema.getColumn(_referenceColumn);
@@ -180,7 +180,7 @@ public final class SheetParser extends ParserMinimalBase {
             case VALUE_TRUE:
             case VALUE_FALSE:
             case VALUE_NULL:
-                if (_nestedAlg != null && !_nextValues.isEmpty()) {
+                if (_recordBuffer != null && !_nextValues.isEmpty()) {
                     _value = _nextValues.removeFirst();
                 }
                 break;
@@ -203,7 +203,7 @@ public final class SheetParser extends ParserMinimalBase {
     }
 
     private void _prepareNext() throws StreamReadException {
-        if (_nestedAlg != null) {
+        if (_recordBuffer != null) {
             _prepareNextNested();
         } else {
             _prepareNextFlat();
@@ -255,12 +255,12 @@ public final class SheetParser extends ParserMinimalBase {
         }
         switch (token) {
             case SHEET_DATA_START:
-                _nestedAlg.onSheetDataStart(_nestedEmitter);
+                _recordBuffer.onSheetDataStart(_recordEmitter);
                 break;
             case ROW_START:
                 _referenceRow = _reader.getRow();
                 _referenceColumn = -1;
-                _nestedAlg.onRowStart();
+                _recordBuffer.onRowStart();
                 break;
             case CELL_VALUE:
                 _referenceRow = _reader.getRow();
@@ -269,14 +269,14 @@ public final class SheetParser extends ParserMinimalBase {
                 final Column column = _schema.findColumn(_referenceColumn);
                 if (column == null) break;
                 try {
-                    _nestedAlg.onCellValue(column, value);
+                    _recordBuffer.onCellValue(column, value);
                 } catch (final SheetStreamReadException e) {
                     throw e.withParser(this);
                 }
                 break;
             case ROW_END:
                 try {
-                    if (!_nestedAlg.onRowEnd(_nestedEmitter)) {
+                    if (!_recordBuffer.onRowEnd(_recordEmitter)) {
                         _ended = true;
                     }
                 } catch (final SheetStreamReadException e) {
@@ -284,7 +284,7 @@ public final class SheetParser extends ParserMinimalBase {
                 }
                 break;
             case SHEET_DATA_END:
-                _nestedAlg.onSheetDataEnd(_nestedEmitter);
+                _recordBuffer.onSheetDataEnd(_recordEmitter);
                 break;
         }
     }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/Column.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/Column.java
@@ -100,6 +100,10 @@ public final class Column {
         return _value.isMerge();
     }
 
+    public boolean isAnchor() {
+        return _value.isAnchor();
+    }
+
     public JavaType getType() {
         if (isArray()) {
             return _type.getContentType();

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
@@ -96,12 +96,8 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
     }
 
     /**
-     * Internal hot-path cache for the per-cell pointer chain used by
-     * {@code SheetStreamContext.ObjectContext.currentPointer()}; returns
-     * the cached {@link ColumnPointer} when {@code (parent, name)} maps
-     * to a known schema column prefix, falling back to
-     * {@link ColumnPointer#resolve(String)} otherwise. External callers
-     * should invoke {@link ColumnPointer#resolve(String)} directly.
+     * Internal hot-path cache for per-cell pointer chains; external
+     * callers should use {@link ColumnPointer#resolve(String)}.
      */
     public ColumnPointer resolve(final ColumnPointer parent, final String name) {
         final Map<String, ColumnPointer> nameMap = _resolveTable.get(parent);
@@ -113,12 +109,8 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
     }
 
     /**
-     * Internal hot-path cache for the per-cell pointer chain used by
-     * {@code SheetStreamContext.ArrayContext.currentPointer()}; returns
-     * the cached array-scope {@link ColumnPointer} when {@code parent}
-     * maps to a known schema array prefix, falling back to
-     * {@link ColumnPointer#resolveArray()} otherwise. External callers
-     * should invoke {@link ColumnPointer#resolveArray()} directly.
+     * Internal hot-path cache for per-cell pointer chains; external
+     * callers should use {@link ColumnPointer#resolveArray()}.
      */
     public ColumnPointer resolveArray(final ColumnPointer parent) {
         final ColumnPointer cached = _resolveArrayTable.get(parent);

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
@@ -92,6 +92,13 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
         return false;
     }
 
+    public boolean hasNestedList() {
+        for (final Column col : _columns) {
+            if (col != null && col.getPointer().contains(ColumnPointer.array())) return true;
+        }
+        return false;
+    }
+
     public Set<ColumnPointer> allArrayScopes() {
         final Set<ColumnPointer> scopes = new LinkedHashSet<>();
         for (final Column col : _columns) {

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
@@ -2,7 +2,9 @@ package io.github.scndry.jackson.dataformat.spreadsheet.schema;
 
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.poi.ss.usermodel.Sheet;
@@ -73,6 +75,50 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
     @Override
     public Iterator<Column> iterator() {
         return _columns.iterator();
+    }
+
+    public Column findAnchorColumn(final ColumnPointer scope) {
+        for (final Column col : _columns) {
+            if (col == null || !col.isAnchor()) continue;
+            if (immediateScope(col.getPointer()).equals(scope)) return col;
+        }
+        return null;
+    }
+
+    public boolean hasAnchor() {
+        for (final Column col : _columns) {
+            if (col != null && col.isAnchor()) return true;
+        }
+        return false;
+    }
+
+    public Set<ColumnPointer> allArrayScopes() {
+        final Set<ColumnPointer> scopes = new LinkedHashSet<>();
+        for (final Column col : _columns) {
+            if (col == null) continue;
+            scopes.addAll(allArrayScopes(col.getPointer()));
+        }
+        return scopes;
+    }
+
+    public static ColumnPointer immediateScope(final ColumnPointer pointer) {
+        ColumnPointer head = ColumnPointer.empty();
+        ColumnPointer last = ColumnPointer.empty();
+        for (final ColumnPointer seg : pointer) {
+            head = head.resolve(seg);
+            if (seg.equals(ColumnPointer.array())) last = head;
+        }
+        return last;
+    }
+
+    public static List<ColumnPointer> allArrayScopes(final ColumnPointer pointer) {
+        final List<ColumnPointer> scopes = new ArrayList<>();
+        ColumnPointer head = ColumnPointer.empty();
+        for (final ColumnPointer seg : pointer) {
+            head = head.resolve(seg);
+            if (seg.equals(ColumnPointer.array())) scopes.add(head);
+        }
+        return scopes;
     }
 
     public Column findColumn(final CellAddress reference) {

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
@@ -1,8 +1,10 @@
 package io.github.scndry.jackson.dataformat.spreadsheet.schema;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.poi.ss.usermodel.Sheet;
@@ -46,8 +48,8 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
     // (parent, []) pairs can be enumerated at schema construction. Avoids
     // per-cell SegmentPointer / String[] allocation in
     // SheetStreamContext.ObjectContext/ArrayContext.currentPointer().
-    private final java.util.Map<ColumnPointer, java.util.Map<String, ColumnPointer>> _resolveTable;
-    private final java.util.Map<ColumnPointer, ColumnPointer> _resolveArrayTable;
+    private final Map<ColumnPointer, Map<String, ColumnPointer>> _resolveTable;
+    private final Map<ColumnPointer, ColumnPointer> _resolveArrayTable;
 
     public SpreadsheetSchema(
             final List<Column> columns,
@@ -61,8 +63,8 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
         _stylesBuilder = stylesBuilder;
         _gridConfigurer = gridConfigurer;
         _headerRowCount = _computeHeaderRowCount(columns);
-        _resolveTable = new java.util.HashMap<>();
-        _resolveArrayTable = new java.util.HashMap<>();
+        _resolveTable = new HashMap<>();
+        _resolveArrayTable = new HashMap<>();
         _buildResolveTables();
     }
 
@@ -80,8 +82,8 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
                     }
                 } else {
                     final String name = seg.name();
-                    final java.util.Map<String, ColumnPointer> nameMap =
-                            _resolveTable.computeIfAbsent(head, k -> new java.util.HashMap<>());
+                    final Map<String, ColumnPointer> nameMap =
+                            _resolveTable.computeIfAbsent(head, k -> new HashMap<>());
                     next = nameMap.get(name);
                     if (next == null) {
                         next = head.resolve(name);
@@ -102,7 +104,7 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
      * should invoke {@link ColumnPointer#resolve(String)} directly.
      */
     public ColumnPointer resolve(final ColumnPointer parent, final String name) {
-        final java.util.Map<String, ColumnPointer> nameMap = _resolveTable.get(parent);
+        final Map<String, ColumnPointer> nameMap = _resolveTable.get(parent);
         if (nameMap != null) {
             final ColumnPointer cached = nameMap.get(name);
             if (cached != null) return cached;

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
@@ -93,6 +93,14 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
         }
     }
 
+    /**
+     * Internal hot-path cache for the per-cell pointer chain used by
+     * {@code SheetStreamContext.ObjectContext.currentPointer()}; returns
+     * the cached {@link ColumnPointer} when {@code (parent, name)} maps
+     * to a known schema column prefix, falling back to
+     * {@link ColumnPointer#resolve(String)} otherwise. External callers
+     * should invoke {@link ColumnPointer#resolve(String)} directly.
+     */
     public ColumnPointer resolve(final ColumnPointer parent, final String name) {
         final java.util.Map<String, ColumnPointer> nameMap = _resolveTable.get(parent);
         if (nameMap != null) {
@@ -102,6 +110,14 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
         return parent.resolve(name);
     }
 
+    /**
+     * Internal hot-path cache for the per-cell pointer chain used by
+     * {@code SheetStreamContext.ArrayContext.currentPointer()}; returns
+     * the cached array-scope {@link ColumnPointer} when {@code parent}
+     * maps to a known schema array prefix, falling back to
+     * {@link ColumnPointer#resolveArray()} otherwise. External callers
+     * should invoke {@link ColumnPointer#resolveArray()} directly.
+     */
     public ColumnPointer resolveArray(final ColumnPointer parent) {
         final ColumnPointer cached = _resolveArrayTable.get(parent);
         if (cached != null) return cached;

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
@@ -42,6 +42,14 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
     private final StylesBuilder _stylesBuilder;
     private final GridConfigurer _gridConfigurer;
     private final int _headerRowCount;
+    // Pre-built lookup tables for resolve / resolveArray on the write path's
+    // per-cell currentPointer chain. Every cell's pointer is a prefix of
+    // some schema column pointer, so all needed (parent, name) and
+    // (parent, []) pairs can be enumerated at schema construction. Avoids
+    // per-cell SegmentPointer / String[] allocation in
+    // SheetStreamContext.ObjectContext/ArrayContext.currentPointer().
+    private final java.util.Map<ColumnPointer, java.util.Map<String, ColumnPointer>> _resolveTable;
+    private final java.util.Map<ColumnPointer, ColumnPointer> _resolveArrayTable;
 
     public SpreadsheetSchema(
             final List<Column> columns,
@@ -55,6 +63,51 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
         _stylesBuilder = stylesBuilder;
         _gridConfigurer = gridConfigurer;
         _headerRowCount = _computeHeaderRowCount(columns);
+        _resolveTable = new java.util.HashMap<>();
+        _resolveArrayTable = new java.util.HashMap<>();
+        _buildResolveTables();
+    }
+
+    private void _buildResolveTables() {
+        for (final Column col : _columns) {
+            if (col == null) continue;
+            ColumnPointer head = ColumnPointer.empty();
+            for (final ColumnPointer seg : col.getPointer()) {
+                ColumnPointer next;
+                if (seg.equals(ColumnPointer.array())) {
+                    next = _resolveArrayTable.get(head);
+                    if (next == null) {
+                        next = head.resolveArray();
+                        _resolveArrayTable.put(head, next);
+                    }
+                } else {
+                    final String name = seg.name();
+                    final java.util.Map<String, ColumnPointer> nameMap =
+                            _resolveTable.computeIfAbsent(head, k -> new java.util.HashMap<>());
+                    next = nameMap.get(name);
+                    if (next == null) {
+                        next = head.resolve(name);
+                        nameMap.put(name, next);
+                    }
+                }
+                head = next;
+            }
+        }
+    }
+
+    public ColumnPointer resolve(final ColumnPointer parent, final String name) {
+        final java.util.Map<String, ColumnPointer> nameMap = _resolveTable.get(parent);
+        if (nameMap != null) {
+            final ColumnPointer cached = nameMap.get(name);
+            if (cached != null) return cached;
+        }
+        return parent.resolve(name);
+    }
+
+    public ColumnPointer resolveArray(final ColumnPointer parent) {
+        final ColumnPointer cached = _resolveArrayTable.get(parent);
+        if (cached != null) return cached;
+        return parent.resolveArray();
     }
 
     private static int _computeHeaderRowCount(final List<Column> columns) {

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
@@ -2,9 +2,7 @@ package io.github.scndry.jackson.dataformat.spreadsheet.schema;
 
 import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.poi.ss.usermodel.Sheet;
@@ -128,57 +126,6 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
     @Override
     public Iterator<Column> iterator() {
         return _columns.iterator();
-    }
-
-    public Column findAnchorColumn(final ColumnPointer scope) {
-        for (final Column col : _columns) {
-            if (col == null || !col.isAnchor()) continue;
-            if (immediateScope(col.getPointer()).equals(scope)) return col;
-        }
-        return null;
-    }
-
-    public boolean hasAnchor() {
-        for (final Column col : _columns) {
-            if (col != null && col.isAnchor()) return true;
-        }
-        return false;
-    }
-
-    public boolean hasNestedList() {
-        for (final Column col : _columns) {
-            if (col != null && col.getPointer().contains(ColumnPointer.array())) return true;
-        }
-        return false;
-    }
-
-    public Set<ColumnPointer> allArrayScopes() {
-        final Set<ColumnPointer> scopes = new LinkedHashSet<>();
-        for (final Column col : _columns) {
-            if (col == null) continue;
-            scopes.addAll(allArrayScopes(col.getPointer()));
-        }
-        return scopes;
-    }
-
-    public static ColumnPointer immediateScope(final ColumnPointer pointer) {
-        ColumnPointer head = ColumnPointer.empty();
-        ColumnPointer last = ColumnPointer.empty();
-        for (final ColumnPointer seg : pointer) {
-            head = head.resolve(seg);
-            if (seg.equals(ColumnPointer.array())) last = head;
-        }
-        return last;
-    }
-
-    public static List<ColumnPointer> allArrayScopes(final ColumnPointer pointer) {
-        final List<ColumnPointer> scopes = new ArrayList<>();
-        ColumnPointer head = ColumnPointer.empty();
-        for (final ColumnPointer seg : pointer) {
-            head = head.resolve(seg);
-            if (seg.equals(ColumnPointer.array())) scopes.add(head);
-        }
-        return scopes;
     }
 
     public Column findColumn(final CellAddress reference) {

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/BackWriteProjection.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/BackWriteProjection.java
@@ -25,7 +25,7 @@ import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
  * (pre-list fail-fast check on {@code writeStartArray}).
  *
  * <p>The {@link #backWriteBufferLimit()} budget and
- * {@link #CELL_MEMORY_BYTES} are also reused by {@code NestedReadAlg} as a
+ * {@link #CELL_MEMORY_BYTES} are also reused by {@code RecordTreeBuffer} as a
  * ballpark on the read side. Read-side cells are object references
  * (Cell + List/Map overhead), not the SoA records — actual per-cell heap
  * is roughly 1.5–2× the SoA figure, so the limit triggers a little later

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/BackWriteProjection.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/BackWriteProjection.java
@@ -24,6 +24,14 @@ import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
  * {@code SheetDataBuffer} (per-cell memory) and {@code SheetGenerator}
  * (pre-list fail-fast check on {@code writeStartArray}).
  *
+ * <p>The {@link #backWriteBufferLimit()} budget and
+ * {@link #CELL_MEMORY_BYTES} are also reused by {@code NestedReadAlg} as a
+ * ballpark on the read side. Read-side cells are object references
+ * (Cell + List/Map overhead), not the SoA records — actual per-cell heap
+ * is roughly 1.5–2× the SoA figure, so the limit triggers a little later
+ * in bytes-of-heap but still serves the same OOM-protection role with
+ * the same guidance (USE_POI_USER_MODEL bypass / split the outer record).
+ *
  * <p>Not part of the public API. Classes under
  * {@code io.github.scndry.jackson.dataformat.spreadsheet.schema.internal}
  * may change without notice between releases — do not invoke directly

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/NestedAnchorValidator.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/NestedAnchorValidator.java
@@ -14,7 +14,7 @@ import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
 /**
  * Read-time validation for the depth-aware nested-list contract:
  * each nested-list-bearing record level must declare exactly one
- * {@code @DataColumn(anchor = TRUE)} column at its immediate scope.
+ * {@code @DataColumn(anchor = true)} column at its immediate scope.
  * Called from {@code SheetParser.setSchema} only when the schema has
  * at least one anchor — the write path is unaffected.
  *
@@ -96,7 +96,7 @@ public final class NestedAnchorValidator {
                     .append("': ").append(String.join(", ", names));
         }
         sb.append("\n\nEach nested-list-bearing record level requires exactly one"
-                + " @DataColumn(anchor = TRUE) column at its immediate scope.");
+                + " @DataColumn(anchor = true) column at its immediate scope.");
         return sb.toString();
     }
 

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/NestedAnchorValidator.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/NestedAnchorValidator.java
@@ -1,0 +1,107 @@
+package io.github.scndry.jackson.dataformat.spreadsheet.schema.internal;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.ColumnPointer;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
+
+/**
+ * Read-time validation for the depth-aware nested-list contract:
+ * each nested-list-bearing record level must declare exactly one
+ * {@code @DataColumn(anchor = TRUE)} column at its immediate scope.
+ * Called from {@code SheetParser.setSchema} only when the schema has
+ * at least one anchor — the write path is unaffected.
+ *
+ * <p>Not part of the public API. Classes under
+ * {@code io.github.scndry.jackson.dataformat.spreadsheet.schema.internal}
+ * may change without notice between releases — do not invoke directly
+ * from application code.
+ */
+public final class NestedAnchorValidator {
+
+    private NestedAnchorValidator() {
+    }
+
+    /** Throws {@link IllegalStateException} when the schema violates the
+     *  anchor invariant — exactly one anchor per nested-list-bearing
+     *  record level, no anchors elsewhere. */
+    public static void validate(final SpreadsheetSchema schema) {
+        final Set<ColumnPointer> expected = _listBearingScopes(schema);
+        final Map<ColumnPointer, List<Column>> anchorsByScope = _anchorsByScope(schema);
+
+        final List<ColumnPointer> missing = new ArrayList<>();
+        for (final ColumnPointer scope : expected) {
+            if (!anchorsByScope.containsKey(scope)) missing.add(scope);
+        }
+        final List<ColumnPointer> extra = new ArrayList<>();
+        final List<Map.Entry<ColumnPointer, List<Column>>> duplicate = new ArrayList<>();
+        for (final Map.Entry<ColumnPointer, List<Column>> e : anchorsByScope.entrySet()) {
+            if (!expected.contains(e.getKey())) extra.add(e.getKey());
+            else if (e.getValue().size() > 1) duplicate.add(e);
+        }
+        if (missing.isEmpty() && extra.isEmpty() && duplicate.isEmpty()) return;
+        throw new IllegalStateException(_buildMessage(missing, extra, duplicate));
+    }
+
+    private static Set<ColumnPointer> _listBearingScopes(final SpreadsheetSchema schema) {
+        final Set<ColumnPointer> scopes = new LinkedHashSet<>();
+        for (final Column c : schema) {
+            if (c == null) continue;
+            ColumnPointer parent = ColumnPointer.empty();
+            ColumnPointer head = ColumnPointer.empty();
+            for (final ColumnPointer seg : c.getPointer()) {
+                head = head.resolve(seg);
+                if (seg.equals(ColumnPointer.array())) {
+                    scopes.add(parent);
+                    parent = head;
+                }
+            }
+        }
+        return scopes;
+    }
+
+    private static Map<ColumnPointer, List<Column>> _anchorsByScope(final SpreadsheetSchema schema) {
+        final Map<ColumnPointer, List<Column>> result = new LinkedHashMap<>();
+        for (final Column c : schema) {
+            if (c == null || !c.isAnchor()) continue;
+            result.computeIfAbsent(SpreadsheetSchema.immediateScope(c.getPointer()),
+                    k -> new ArrayList<>()).add(c);
+        }
+        return result;
+    }
+
+    private static String _buildMessage(
+            final List<ColumnPointer> missing,
+            final List<ColumnPointer> extra,
+            final List<Map.Entry<ColumnPointer, List<Column>>> duplicate) {
+        final StringBuilder sb = new StringBuilder("Anchor invariant violation:");
+        for (final ColumnPointer scope : missing) {
+            sb.append("\n - Missing anchor at scope '").append(_scopeName(scope))
+                    .append("': record contains a nested list");
+        }
+        for (final ColumnPointer scope : extra) {
+            sb.append("\n - Extra anchor at scope '").append(_scopeName(scope))
+                    .append("': record has no nested list");
+        }
+        for (final Map.Entry<ColumnPointer, List<Column>> e : duplicate) {
+            final List<String> names = new ArrayList<>();
+            for (final Column c : e.getValue()) names.add(c.getName());
+            sb.append("\n - Multiple anchors at scope '").append(_scopeName(e.getKey()))
+                    .append("': ").append(String.join(", ", names));
+        }
+        sb.append("\n\nEach nested-list-bearing record level requires exactly one"
+                + " @DataColumn(anchor = TRUE) column at its immediate scope.");
+        return sb.toString();
+    }
+
+    private static String _scopeName(final ColumnPointer scope) {
+        final String s = scope.toString();
+        return s.isEmpty() ? "<root>" : s;
+    }
+}

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/NestedAnchorValidator.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/NestedAnchorValidator.java
@@ -70,7 +70,7 @@ public final class NestedAnchorValidator {
         final Map<ColumnPointer, List<Column>> result = new LinkedHashMap<>();
         for (final Column c : schema) {
             if (c == null || !c.isAnchor()) continue;
-            result.computeIfAbsent(SpreadsheetSchema.immediateScope(c.getPointer()),
+            result.computeIfAbsent(SchemaAnchorInspector.immediateScope(c.getPointer()),
                     k -> new ArrayList<>()).add(c);
         }
         return result;

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/SchemaAnchorInspector.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/SchemaAnchorInspector.java
@@ -1,0 +1,81 @@
+package io.github.scndry.jackson.dataformat.spreadsheet.schema.internal;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.ColumnPointer;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
+
+/**
+ * Schema queries that support nested-list reads — anchor lookup,
+ * array-scope enumeration, and the {@code immediateScope} /
+ * {@code allArrayScopes} pointer helpers. Extracted from
+ * {@link SpreadsheetSchema} so the schema retains only its core
+ * column data plus the hot-path resolve cache; nested-list-specific
+ * lookups live next to {@link BackWriteProjection} and
+ * {@link NestedAnchorValidator}.
+ *
+ * <p>Not part of the public API. Classes under
+ * {@code io.github.scndry.jackson.dataformat.spreadsheet.schema.internal}
+ * may change without notice between releases — do not invoke directly
+ * from application code.
+ */
+public final class SchemaAnchorInspector {
+
+    private SchemaAnchorInspector() {
+    }
+
+    public static boolean hasAnchor(final SpreadsheetSchema schema) {
+        for (final Column col : schema) {
+            if (col != null && col.isAnchor()) return true;
+        }
+        return false;
+    }
+
+    public static boolean hasNestedList(final SpreadsheetSchema schema) {
+        for (final Column col : schema) {
+            if (col != null && col.getPointer().contains(ColumnPointer.array())) return true;
+        }
+        return false;
+    }
+
+    public static Column findAnchorColumn(final SpreadsheetSchema schema, final ColumnPointer scope) {
+        for (final Column col : schema) {
+            if (col == null || !col.isAnchor()) continue;
+            if (immediateScope(col.getPointer()).equals(scope)) return col;
+        }
+        return null;
+    }
+
+    public static Set<ColumnPointer> allArrayScopes(final SpreadsheetSchema schema) {
+        final Set<ColumnPointer> scopes = new LinkedHashSet<>();
+        for (final Column col : schema) {
+            if (col == null) continue;
+            scopes.addAll(allArrayScopes(col.getPointer()));
+        }
+        return scopes;
+    }
+
+    public static ColumnPointer immediateScope(final ColumnPointer pointer) {
+        ColumnPointer head = ColumnPointer.empty();
+        ColumnPointer last = ColumnPointer.empty();
+        for (final ColumnPointer seg : pointer) {
+            head = head.resolve(seg);
+            if (seg.equals(ColumnPointer.array())) last = head;
+        }
+        return last;
+    }
+
+    public static List<ColumnPointer> allArrayScopes(final ColumnPointer pointer) {
+        final List<ColumnPointer> scopes = new ArrayList<>();
+        ColumnPointer head = ColumnPointer.empty();
+        for (final ColumnPointer seg : pointer) {
+            head = head.resolve(seg);
+            if (seg.equals(ColumnPointer.array())) scopes.add(head);
+        }
+        return scopes;
+    }
+}

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/AnnotationValueTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/AnnotationValueTest.java
@@ -72,7 +72,7 @@ class AnnotationValueTest {
 
     @Test
     void dataColumnWithName() {
-        DataColumn.Value val = new DataColumn.Value("original", "", "", "", 0, OptBoolean.DEFAULT, 0, 0, OptBoolean.DEFAULT, OptBoolean.DEFAULT);
+        DataColumn.Value val = new DataColumn.Value("original", "", "", "", 0, OptBoolean.DEFAULT, 0, 0, OptBoolean.DEFAULT, false);
         DataColumn.Value renamed = val.withName("renamed");
         assertThat(renamed.getName()).isEqualTo("renamed");
         assertThat(renamed.getStyle()).isEqualTo(val.getStyle());
@@ -80,7 +80,7 @@ class AnnotationValueTest {
 
     @Test
     void dataColumnWithDefaults() {
-        DataColumn.Value field = new DataColumn.Value("field", "", "fieldStyle", "", 10, OptBoolean.DEFAULT, 0, 0, OptBoolean.DEFAULT, OptBoolean.DEFAULT);
+        DataColumn.Value field = new DataColumn.Value("field", "", "fieldStyle", "", 10, OptBoolean.DEFAULT, 0, 0, OptBoolean.DEFAULT, false);
         DataGrid.Value grid = new DataGrid.Value("gridStyle", "gridHeaderStyle", "",
                 20, OptBoolean.TRUE, 5, 50, OptBoolean.TRUE);
         DataColumn.Value result = field.withDefaults(grid);

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/AnnotationValueTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/AnnotationValueTest.java
@@ -72,7 +72,7 @@ class AnnotationValueTest {
 
     @Test
     void dataColumnWithName() {
-        DataColumn.Value val = new DataColumn.Value("original", "", "", "", 0, OptBoolean.DEFAULT, 0, 0, OptBoolean.DEFAULT);
+        DataColumn.Value val = new DataColumn.Value("original", "", "", "", 0, OptBoolean.DEFAULT, 0, 0, OptBoolean.DEFAULT, OptBoolean.DEFAULT);
         DataColumn.Value renamed = val.withName("renamed");
         assertThat(renamed.getName()).isEqualTo("renamed");
         assertThat(renamed.getStyle()).isEqualTo(val.getStyle());
@@ -80,7 +80,7 @@ class AnnotationValueTest {
 
     @Test
     void dataColumnWithDefaults() {
-        DataColumn.Value field = new DataColumn.Value("field", "", "fieldStyle", "", 10, OptBoolean.DEFAULT, 0, 0, OptBoolean.DEFAULT);
+        DataColumn.Value field = new DataColumn.Value("field", "", "fieldStyle", "", 10, OptBoolean.DEFAULT, 0, 0, OptBoolean.DEFAULT, OptBoolean.DEFAULT);
         DataGrid.Value grid = new DataGrid.Value("gridStyle", "gridHeaderStyle", "",
                 20, OptBoolean.TRUE, 5, 50, OptBoolean.TRUE);
         DataColumn.Value result = field.withDefaults(grid);

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedAnchorValidatorTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedAnchorValidatorTest.java
@@ -1,0 +1,159 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.OptBoolean;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.junit.jupiter.api.Test;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.NestedAnchorValidator;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Read-time anchor invariant checks — exactly one
+ * {@code @DataColumn(anchor = TRUE)} at each nested-list-bearing record
+ * level, none elsewhere. Driven from {@code SheetParser.setSchema}
+ * when the schema has any anchor; the write path is untouched.
+ */
+class NestedAnchorValidatorTest {
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class Inner {
+        @DataColumn("x") int x;
+        @DataColumn("y") int y;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class Valid {
+        @DataColumn(value = "id", anchor = OptBoolean.TRUE) int id;
+        List<Inner> items;
+    }
+
+    @Test
+    void valid_anchorAtListBearingScope_doesNotThrow() throws Exception {
+        final SpreadsheetSchema schema = _schemaFor(Valid.class);
+        assertThatCode(() -> NestedAnchorValidator.validate(schema)).doesNotThrowAnyException();
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class MidNoAnchor {
+        @DataColumn("midId") String midId;
+        List<Inner> details;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class MissingAtNested {
+        @DataColumn(value = "id", anchor = OptBoolean.TRUE) int id;
+        List<MidNoAnchor> items;
+    }
+
+    @Test
+    void missing_anchorAtNestedScope_throws() throws Exception {
+        final SpreadsheetSchema schema = _schemaFor(MissingAtNested.class);
+        assertThatThrownBy(() -> NestedAnchorValidator.validate(schema))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Missing anchor")
+                .hasMessageContaining("items/[]");
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class MidWithAnchor {
+        @DataColumn(value = "midId", anchor = OptBoolean.TRUE) String midId;
+        List<Inner> details;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class MissingAtRoot {
+        @DataColumn("id") int id;
+        List<MidWithAnchor> items;
+    }
+
+    @Test
+    void missing_anchorAtRootScope_throws() throws Exception {
+        final SpreadsheetSchema schema = _schemaFor(MissingAtRoot.class);
+        assertThatThrownBy(() -> NestedAnchorValidator.validate(schema))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Missing anchor")
+                .hasMessageContaining("<root>");
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class MissingAll {
+        @DataColumn("id") int id;
+        List<Inner> items;
+    }
+
+    @Test
+    void missing_noAnchorAnywhereWithNestedList_throws() throws Exception {
+        final SpreadsheetSchema schema = _schemaFor(MissingAll.class);
+        assertThatThrownBy(() -> NestedAnchorValidator.validate(schema))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Missing anchor")
+                .hasMessageContaining("<root>");
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class InnerWithAnchor {
+        @DataColumn(value = "x", anchor = OptBoolean.TRUE) int x;
+        @DataColumn("y") int y;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class ExtraAtInnermost {
+        @DataColumn(value = "id", anchor = OptBoolean.TRUE) int id;
+        List<InnerWithAnchor> items;
+    }
+
+    @Test
+    void extra_anchorAtInnermostScope_throws() throws Exception {
+        final SpreadsheetSchema schema = _schemaFor(ExtraAtInnermost.class);
+        assertThatThrownBy(() -> NestedAnchorValidator.validate(schema))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Extra anchor")
+                .hasMessageContaining("items/[]");
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class ExtraOnFlat {
+        @DataColumn(value = "id", anchor = OptBoolean.TRUE) int id;
+        @DataColumn("name") String name;
+    }
+
+    @Test
+    void extra_anchorOnFlatSchema_throws() throws Exception {
+        final SpreadsheetSchema schema = _schemaFor(ExtraOnFlat.class);
+        assertThatThrownBy(() -> NestedAnchorValidator.validate(schema))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Extra anchor")
+                .hasMessageContaining("<root>");
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class DuplicateAtRoot {
+        @DataColumn(value = "id", anchor = OptBoolean.TRUE) int id;
+        @DataColumn(value = "name", anchor = OptBoolean.TRUE) String name;
+        List<Inner> items;
+    }
+
+    @Test
+    void duplicate_anchorAtSameScope_throws() throws Exception {
+        final SpreadsheetSchema schema = _schemaFor(DuplicateAtRoot.class);
+        assertThatThrownBy(() -> NestedAnchorValidator.validate(schema))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Multiple anchors")
+                .hasMessageContaining("id")
+                .hasMessageContaining("name");
+    }
+
+    private static SpreadsheetSchema _schemaFor(final Class<?> type) throws Exception {
+        return new SpreadsheetMapper().sheetSchemaFor(type);
+    }
+}

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedAnchorValidatorTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedAnchorValidatorTest.java
@@ -2,8 +2,6 @@ package io.github.scndry.jackson.dataformat.spreadsheet;
 
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.OptBoolean;
-
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -19,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Read-time anchor invariant checks — exactly one
- * {@code @DataColumn(anchor = TRUE)} at each nested-list-bearing record
+ * {@code @DataColumn(anchor = true)} at each nested-list-bearing record
  * level, none elsewhere. Driven from {@code SheetParser.setSchema}
  * when the schema has any anchor; the write path is untouched.
  */
@@ -33,7 +31,7 @@ class NestedAnchorValidatorTest {
 
     @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
     static class Valid {
-        @DataColumn(value = "id", anchor = OptBoolean.TRUE) int id;
+        @DataColumn(value = "id", anchor = true) int id;
         List<Inner> items;
     }
 
@@ -51,7 +49,7 @@ class NestedAnchorValidatorTest {
 
     @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
     static class MissingAtNested {
-        @DataColumn(value = "id", anchor = OptBoolean.TRUE) int id;
+        @DataColumn(value = "id", anchor = true) int id;
         List<MidNoAnchor> items;
     }
 
@@ -66,7 +64,7 @@ class NestedAnchorValidatorTest {
 
     @Data @NoArgsConstructor @AllArgsConstructor
     static class MidWithAnchor {
-        @DataColumn(value = "midId", anchor = OptBoolean.TRUE) String midId;
+        @DataColumn(value = "midId", anchor = true) String midId;
         List<Inner> details;
     }
 
@@ -102,13 +100,13 @@ class NestedAnchorValidatorTest {
 
     @Data @NoArgsConstructor @AllArgsConstructor
     static class InnerWithAnchor {
-        @DataColumn(value = "x", anchor = OptBoolean.TRUE) int x;
+        @DataColumn(value = "x", anchor = true) int x;
         @DataColumn("y") int y;
     }
 
     @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
     static class ExtraAtInnermost {
-        @DataColumn(value = "id", anchor = OptBoolean.TRUE) int id;
+        @DataColumn(value = "id", anchor = true) int id;
         List<InnerWithAnchor> items;
     }
 
@@ -123,7 +121,7 @@ class NestedAnchorValidatorTest {
 
     @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
     static class ExtraOnFlat {
-        @DataColumn(value = "id", anchor = OptBoolean.TRUE) int id;
+        @DataColumn(value = "id", anchor = true) int id;
         @DataColumn("name") String name;
     }
 
@@ -138,8 +136,8 @@ class NestedAnchorValidatorTest {
 
     @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
     static class DuplicateAtRoot {
-        @DataColumn(value = "id", anchor = OptBoolean.TRUE) int id;
-        @DataColumn(value = "name", anchor = OptBoolean.TRUE) String name;
+        @DataColumn(value = "id", anchor = true) int id;
+        @DataColumn(value = "name", anchor = true) String name;
         List<Inner> items;
     }
 

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedBlankRowFeatureTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedBlankRowFeatureTest.java
@@ -38,7 +38,7 @@ class NestedBlankRowFeatureTest {
 
     @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
     static class BlankOrder {
-        @DataColumn(value = "id", anchor = OptBoolean.TRUE, merge = OptBoolean.TRUE) Integer id;
+        @DataColumn(value = "id", anchor = true, merge = OptBoolean.TRUE) Integer id;
         @DataColumnGroup("Items") List<BlankItem> items;
     }
 

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedBlankRowFeatureTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedBlankRowFeatureTest.java
@@ -1,0 +1,145 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.OptBoolean;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.Test;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+import io.github.scndry.jackson.dataformat.spreadsheet.deser.SheetParser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * BLANK_ROW_AS_NULL and BREAK_ON_BLANK_ROW carry the same semantics in
+ * nested mode as in the flat path: a completely blank row closes the
+ * currently-open outer record, then BLANK_ROW_AS_NULL inserts a null
+ * entry into the result list and BREAK_ON_BLANK_ROW terminates the
+ * iteration. With both flags off the blank row is silently dropped and
+ * reading continues — matching the flat path's _handleEmptyObject
+ * clear-and-continue behaviour.
+ */
+class NestedBlankRowFeatureTest {
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class BlankItem {
+        @DataColumn("sku") String sku;
+        @DataColumn("qty") int qty;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class BlankOrder {
+        @DataColumn(value = "id", anchor = OptBoolean.TRUE, merge = OptBoolean.TRUE) Integer id;
+        @DataColumnGroup("Items") List<BlankItem> items;
+    }
+
+    /**
+     * Schema headerRowCount is 2 because {@code @DataColumnGroup("Items")}
+     * gives the leaf inner columns a depth-1 hierarchy. Layout (0-indexed):
+     *   row 0 (header depth 0): id, "Items", ""
+     *   row 1 (header depth 1, leaf): "", sku, qty
+     *   row 2: 1, A, 10        ← record 1 first row
+     *   row 3:  , B, 20        ← record 1 continuation
+     *   row 4: (blank)         ← blank separator
+     *   row 5: 2, C, 30        ← record 2 first row
+     *   row 6:  , D, 40        ← record 2 continuation
+     */
+    private static Sheet _fixtureWithBlankSeparator(final XSSFWorkbook wb) {
+        Sheet sheet = wb.createSheet();
+        Row h0 = sheet.createRow(0);
+        h0.createCell(0).setCellValue("id");
+        h0.createCell(1).setCellValue("Items");
+        Row h1 = sheet.createRow(1);
+        h1.createCell(1).setCellValue("sku");
+        h1.createCell(2).setCellValue("qty");
+
+        Row r2 = sheet.createRow(2);
+        r2.createCell(0).setCellValue(1);
+        r2.createCell(1).setCellValue("A");
+        r2.createCell(2).setCellValue(10);
+
+        Row r3 = sheet.createRow(3);
+        r3.createCell(1).setCellValue("B");
+        r3.createCell(2).setCellValue(20);
+
+        sheet.createRow(4); // blank
+
+        Row r5 = sheet.createRow(5);
+        r5.createCell(0).setCellValue(2);
+        r5.createCell(1).setCellValue("C");
+        r5.createCell(2).setCellValue(30);
+
+        Row r6 = sheet.createRow(6);
+        r6.createCell(1).setCellValue("D");
+        r6.createCell(2).setCellValue(40);
+        return sheet;
+    }
+
+    @Test
+    void defaultFlags_blankRowAsNullEntry() throws Exception {
+        // Default: BLANK_ROW_AS_NULL=true, BREAK_ON_BLANK_ROW=false.
+        // Blank row → close record 1 (emit) + null entry + continue.
+        SpreadsheetMapper mapper = new SpreadsheetMapper();
+        try (XSSFWorkbook wb = new XSSFWorkbook()) {
+            Sheet sheet = _fixtureWithBlankSeparator(wb);
+            List<BlankOrder> results = mapper.readValues(sheet, BlankOrder.class);
+
+            assertThat(results).hasSize(3);
+            assertThat(results.get(0).getId()).isEqualTo(1);
+            assertThat(results.get(0).getItems()).extracting(BlankItem::getSku)
+                    .containsExactly("A", "B");
+            assertThat(results.get(1)).isNull();
+            assertThat(results.get(2).getId()).isEqualTo(2);
+            assertThat(results.get(2).getItems()).extracting(BlankItem::getSku)
+                    .containsExactly("C", "D");
+        }
+    }
+
+    @Test
+    void breakOnBlankRow_stopsIteration() throws Exception {
+        // Blank row → close record 1 + iteration ends; record 2 is never read.
+        SpreadsheetMapper mapper = SpreadsheetMapper.builder()
+                .disable(SheetParser.Feature.BLANK_ROW_AS_NULL)
+                .enable(SheetParser.Feature.BREAK_ON_BLANK_ROW)
+                .build();
+        try (XSSFWorkbook wb = new XSSFWorkbook()) {
+            Sheet sheet = _fixtureWithBlankSeparator(wb);
+            List<BlankOrder> results = mapper.readValues(sheet, BlankOrder.class);
+
+            assertThat(results).hasSize(1);
+            assertThat(results.get(0).getId()).isEqualTo(1);
+            assertThat(results.get(0).getItems()).extracting(BlankItem::getSku)
+                    .containsExactly("A", "B");
+        }
+    }
+
+    @Test
+    void bothFlagsOff_blankRowSilentlyDropped() throws Exception {
+        // Blank row → close record 1 + drop (no null entry) + continue.
+        SpreadsheetMapper mapper = SpreadsheetMapper.builder()
+                .disable(SheetParser.Feature.BLANK_ROW_AS_NULL)
+                .disable(SheetParser.Feature.BREAK_ON_BLANK_ROW)
+                .build();
+        try (XSSFWorkbook wb = new XSSFWorkbook()) {
+            Sheet sheet = _fixtureWithBlankSeparator(wb);
+            List<BlankOrder> results = mapper.readValues(sheet, BlankOrder.class);
+
+            assertThat(results).hasSize(2);
+            assertThat(results.get(0).getId()).isEqualTo(1);
+            assertThat(results.get(0).getItems()).extracting(BlankItem::getSku)
+                    .containsExactly("A", "B");
+            assertThat(results.get(1).getId()).isEqualTo(2);
+            assertThat(results.get(1).getItems()).extracting(BlankItem::getSku)
+                    .containsExactly("C", "D");
+        }
+    }
+}

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedErrorCellTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedErrorCellTest.java
@@ -1,0 +1,93 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.OptBoolean;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.poi.ss.usermodel.FormulaError;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.Test;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Confirms that ERROR (and other unsupported) cells in nested reads
+ * fail the same way as in the flat path — both raise
+ * {@link SheetStreamReadException} so silent data loss cannot occur.
+ * NestedReadAlg rejects unsupported cell types at cell-arrival time
+ * (onCellValue), matching the flat path's _scalarValueToken throw.
+ */
+class NestedErrorCellTest {
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class ErrItem {
+        @DataColumn("sku") String sku;
+        @DataColumn("qty") Integer qty;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class ErrOrder {
+        @DataColumn(value = "id", anchor = OptBoolean.TRUE, merge = OptBoolean.TRUE) Integer id;
+        @DataColumnGroup("Items") List<ErrItem> items;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class FlatRow {
+        @DataColumn("sku") String sku;
+        @DataColumn("qty") Integer qty;
+    }
+
+    /** Inner cell holds #N/A — nested rejects at cell-arrival time. */
+    @Test
+    void nested_innerErrorCell_throwsUnexpected() throws Exception {
+        SpreadsheetMapper mapper = new SpreadsheetMapper();
+        try (XSSFWorkbook wb = new XSSFWorkbook()) {
+            Sheet sheet = wb.createSheet();
+            Row h0 = sheet.createRow(0);
+            h0.createCell(0).setCellValue("id");
+            h0.createCell(1).setCellValue("Items");
+            Row h1 = sheet.createRow(1);
+            h1.createCell(1).setCellValue("sku");
+            h1.createCell(2).setCellValue("qty");
+
+            Row r2 = sheet.createRow(2);
+            r2.createCell(0).setCellValue(1);
+            r2.createCell(1).setCellValue("A");
+            r2.createCell(2).setCellErrorValue(FormulaError.NA.getCode());
+
+            assertThatThrownBy(() -> mapper.readValues(sheet, ErrOrder.class))
+                    .isInstanceOf(SheetStreamReadException.class)
+                    .hasMessageContaining("ERROR");
+        }
+    }
+
+    /** Flat path raises SheetStreamReadException — semantic baseline for
+     *  comparison with the nested path's silent behaviour. */
+    @Test
+    void flat_errorCell_throwsUnexpected() throws Exception {
+        SpreadsheetMapper mapper = new SpreadsheetMapper();
+        try (XSSFWorkbook wb = new XSSFWorkbook()) {
+            Sheet sheet = wb.createSheet();
+            Row h = sheet.createRow(0);
+            h.createCell(0).setCellValue("sku");
+            h.createCell(1).setCellValue("qty");
+
+            Row r = sheet.createRow(1);
+            r.createCell(0).setCellValue("A");
+            r.createCell(1).setCellErrorValue(FormulaError.NA.getCode());
+
+            assertThatThrownBy(() -> mapper.readValues(sheet, FlatRow.class))
+                    .isInstanceOf(SheetStreamReadException.class);
+        }
+    }
+}

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedErrorCellTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedErrorCellTest.java
@@ -37,7 +37,7 @@ class NestedErrorCellTest {
 
     @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
     static class ErrOrder {
-        @DataColumn(value = "id", anchor = OptBoolean.TRUE, merge = OptBoolean.TRUE) Integer id;
+        @DataColumn(value = "id", anchor = true, merge = OptBoolean.TRUE) Integer id;
         @DataColumnGroup("Items") List<ErrItem> items;
     }
 

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedErrorCellTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedErrorCellTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * Confirms that ERROR (and other unsupported) cells in nested reads
  * fail the same way as in the flat path — both raise
  * {@link SheetStreamReadException} so silent data loss cannot occur.
- * NestedReadAlg rejects unsupported cell types at cell-arrival time
+ * RecordTreeBuffer rejects unsupported cell types at cell-arrival time
  * (onCellValue), matching the flat path's _scalarValueToken throw.
  */
 class NestedErrorCellTest {

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedListEdgeCaseTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedListEdgeCaseTest.java
@@ -1,0 +1,194 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.OptBoolean;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.Test;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Edge cases for the nested-list read/write paths — input shapes that
+ * common-case fixtures in {@link NestedListReadTest} and
+ * {@link NestedBlankRowFeatureTest} do not exercise: trailing blank
+ * cells, anchor-blank continuation rows, partial-null inner fields,
+ * and cross-mode (SSML / POI) round-trips.
+ */
+class NestedListEdgeCaseTest {
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class EdgeItem {
+        @DataColumn("sku") String sku;
+        @DataColumn("qty") Integer qty;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class EdgeOrder {
+        @DataColumn(value = "id", anchor = true, merge = OptBoolean.TRUE) Integer id;
+        @DataColumnGroup("Items") List<EdgeItem> items;
+    }
+
+    /**
+     * Outer cell missing (anchor only present in first row, then
+     * continuation rows omit it entirely) plus inner cell missing on
+     * the last continuation row. The reader must continue the same
+     * record and emit {@code null} for the missing inner field.
+     */
+    @Test
+    void trailingBlankCells_continuationAndPartialInner() throws Exception {
+        SpreadsheetMapper mapper = new SpreadsheetMapper();
+        try (XSSFWorkbook wb = new XSSFWorkbook()) {
+            Sheet sheet = wb.createSheet();
+            Row h0 = sheet.createRow(0);
+            h0.createCell(0).setCellValue("id");
+            h0.createCell(1).setCellValue("Items");
+            Row h1 = sheet.createRow(1);
+            h1.createCell(1).setCellValue("sku");
+            h1.createCell(2).setCellValue("qty");
+
+            Row r2 = sheet.createRow(2);
+            r2.createCell(0).setCellValue(1);
+            r2.createCell(1).setCellValue("A");
+            r2.createCell(2).setCellValue(10);
+
+            Row r3 = sheet.createRow(3);
+            r3.createCell(1).setCellValue("B"); // qty omitted, anchor omitted
+
+            List<EdgeOrder> result = mapper.readValues(sheet, EdgeOrder.class);
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getId()).isEqualTo(1);
+            assertThat(result.get(0).getItems()).hasSize(2);
+            assertThat(result.get(0).getItems().get(0).getSku()).isEqualTo("A");
+            assertThat(result.get(0).getItems().get(0).getQty()).isEqualTo(10);
+            assertThat(result.get(0).getItems().get(1).getSku()).isEqualTo("B");
+            assertThat(result.get(0).getItems().get(1).getQty()).isNull();
+        }
+    }
+
+    /**
+     * Anchor cell blank in continuation rows is treated as "still the
+     * same outer record". Three continuation rows after the anchored
+     * row collapse into one outer with four inner items.
+     */
+    @Test
+    void anchorBlankInContinuationRow_treatedAsSameRecord() throws Exception {
+        SpreadsheetMapper mapper = new SpreadsheetMapper();
+        try (XSSFWorkbook wb = new XSSFWorkbook()) {
+            Sheet sheet = wb.createSheet();
+            Row h0 = sheet.createRow(0);
+            h0.createCell(0).setCellValue("id");
+            h0.createCell(1).setCellValue("Items");
+            Row h1 = sheet.createRow(1);
+            h1.createCell(1).setCellValue("sku");
+            h1.createCell(2).setCellValue("qty");
+
+            Row r2 = sheet.createRow(2);
+            r2.createCell(0).setCellValue(1);
+            r2.createCell(1).setCellValue("A");
+            r2.createCell(2).setCellValue(10);
+
+            for (int i = 0; i < 3; i++) {
+                Row r = sheet.createRow(3 + i);
+                r.createCell(1).setCellValue("X" + i);
+                r.createCell(2).setCellValue(20 + i);
+            }
+
+            List<EdgeOrder> result = mapper.readValues(sheet, EdgeOrder.class);
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getId()).isEqualTo(1);
+            assertThat(result.get(0).getItems()).extracting(EdgeItem::getSku)
+                    .containsExactly("A", "X0", "X1", "X2");
+            assertThat(result.get(0).getItems()).extracting(EdgeItem::getQty)
+                    .containsExactly(10, 20, 21, 22);
+        }
+    }
+
+    /**
+     * Inner fields missing in alternation — first inner row omits
+     * {@code sku}, second omits {@code qty}. Each inner record
+     * carries the missing field as {@code null}.
+     */
+    @Test
+    void innerFieldNull_perRecordCorrect() throws Exception {
+        SpreadsheetMapper mapper = new SpreadsheetMapper();
+        try (XSSFWorkbook wb = new XSSFWorkbook()) {
+            Sheet sheet = wb.createSheet();
+            Row h0 = sheet.createRow(0);
+            h0.createCell(0).setCellValue("id");
+            h0.createCell(1).setCellValue("Items");
+            Row h1 = sheet.createRow(1);
+            h1.createCell(1).setCellValue("sku");
+            h1.createCell(2).setCellValue("qty");
+
+            Row r2 = sheet.createRow(2);
+            r2.createCell(0).setCellValue(1);
+            r2.createCell(2).setCellValue(10); // sku omitted
+
+            Row r3 = sheet.createRow(3);
+            r3.createCell(1).setCellValue("B"); // qty omitted
+
+            List<EdgeOrder> result = mapper.readValues(sheet, EdgeOrder.class);
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getItems()).hasSize(2);
+            assertThat(result.get(0).getItems().get(0).getSku()).isNull();
+            assertThat(result.get(0).getItems().get(0).getQty()).isEqualTo(10);
+            assertThat(result.get(0).getItems().get(1).getSku()).isEqualTo("B");
+            assertThat(result.get(0).getItems().get(1).getQty()).isNull();
+        }
+    }
+
+    /**
+     * Cross-mode round-trip — SSML write read back through POI and the
+     * reverse — should produce identical objects, confirming neither
+     * writer leaves the other reader out of sync.
+     */
+    @Test
+    void crossRoundtrip_ssmlAndPoiAgree() throws Exception {
+        SpreadsheetMapper ssml = new SpreadsheetMapper();
+        SpreadsheetMapper poiRead = new SpreadsheetMapper(
+                new SpreadsheetFactory(XSSFWorkbook::new,
+                        SpreadsheetFactory.DEFAULT_SHEET_PARSER_FEATURE_FLAGS)
+                        .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL));
+        SpreadsheetMapper poiWrite = new SpreadsheetMapper(
+                new SpreadsheetFactory(SXSSFWorkbook::new,
+                        SpreadsheetFactory.DEFAULT_SHEET_PARSER_FEATURE_FLAGS)
+                        .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL));
+
+        List<EdgeOrder> data = Arrays.asList(
+                new EdgeOrder(1, Arrays.asList(
+                        new EdgeItem("A", 10), new EdgeItem("B", 20))),
+                new EdgeOrder(2, Arrays.asList(new EdgeItem("C", 30))));
+
+        // SSML write -> POI read
+        ByteArrayOutputStream ssmlOut = new ByteArrayOutputStream();
+        ssml.writeValue(ssmlOut, data, EdgeOrder.class);
+        List<EdgeOrder> readViaPoi = poiRead.readValues(
+                new ByteArrayInputStream(ssmlOut.toByteArray()), EdgeOrder.class);
+        assertThat(readViaPoi).isEqualTo(data);
+
+        // POI write -> SSML read
+        ByteArrayOutputStream poiOut = new ByteArrayOutputStream();
+        poiWrite.writeValue(poiOut, data, EdgeOrder.class);
+        List<EdgeOrder> readViaSsml = ssml.readValues(
+                new ByteArrayInputStream(poiOut.toByteArray()), EdgeOrder.class);
+        assertThat(readViaSsml).isEqualTo(data);
+    }
+}

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedListEdgeCaseTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedListEdgeCaseTest.java
@@ -2,6 +2,9 @@ package io.github.scndry.jackson.dataformat.spreadsheet;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -15,6 +18,7 @@ import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
@@ -31,6 +35,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class NestedListEdgeCaseTest {
 
+    @TempDir Path tempDir;
+
     @Data @NoArgsConstructor @AllArgsConstructor
     static class EdgeItem {
         @DataColumn("sku") String sku;
@@ -40,6 +46,12 @@ class NestedListEdgeCaseTest {
     @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
     static class EdgeOrder {
         @DataColumn(value = "id", anchor = true, merge = OptBoolean.TRUE) Integer id;
+        @DataColumnGroup("Items") List<EdgeItem> items;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class BoolOrder {
+        @DataColumn(value = "active", anchor = true, merge = OptBoolean.TRUE) Boolean active;
         @DataColumnGroup("Items") List<EdgeItem> items;
     }
 
@@ -190,5 +202,97 @@ class NestedListEdgeCaseTest {
         List<EdgeOrder> readViaSsml = ssml.readValues(
                 new ByteArrayInputStream(poiOut.toByteArray()), EdgeOrder.class);
         assertThat(readViaSsml).isEqualTo(data);
+    }
+
+    /**
+     * Streaming iterator path — {@code sheetReaderFor} +
+     * {@link SheetMappingIterator} — should yield the same outer
+     * records as the eager {@code readValues} call.
+     */
+    @Test
+    void streamingIterator_nestedRoundtrip() throws Exception {
+        File file = tempDir.resolve("nested-stream.xlsx").toFile();
+        SpreadsheetMapper mapper = new SpreadsheetMapper();
+        List<EdgeOrder> data = Arrays.asList(
+                new EdgeOrder(1, Arrays.asList(
+                        new EdgeItem("A", 10), new EdgeItem("B", 20))),
+                new EdgeOrder(2, Arrays.asList(new EdgeItem("C", 30))),
+                new EdgeOrder(3, Arrays.asList(
+                        new EdgeItem("D", 40), new EdgeItem("E", 50))));
+        mapper.writeValue(file, data, EdgeOrder.class);
+
+        SpreadsheetReader reader = mapper.sheetReaderFor(EdgeOrder.class);
+        List<EdgeOrder> read = new ArrayList<>();
+        try (SheetMappingIterator<EdgeOrder> iter = reader.readValues(file)) {
+            while (iter.hasNext()) read.add(iter.next());
+        }
+        assertThat(read).isEqualTo(data);
+    }
+
+    /**
+     * Boolean anchor — only two possible distinct values, so the
+     * outer-record stream partitions into at most two records per
+     * contiguous true/false run.
+     */
+    @Test
+    void booleanAnchor_partitionsByTrueFalse() throws Exception {
+        File file = tempDir.resolve("nested-bool-anchor.xlsx").toFile();
+        SpreadsheetMapper mapper = new SpreadsheetMapper();
+        List<BoolOrder> data = Arrays.asList(
+                new BoolOrder(true, Arrays.asList(
+                        new EdgeItem("A", 10), new EdgeItem("B", 20))),
+                new BoolOrder(false, Arrays.asList(
+                        new EdgeItem("C", 30), new EdgeItem("D", 40))));
+        mapper.writeValue(file, data, BoolOrder.class);
+
+        List<BoolOrder> read = mapper.readValues(file, BoolOrder.class);
+        assertThat(read).isEqualTo(data);
+    }
+
+    /**
+     * All rows share the same anchor value — single outer record
+     * collapses an arbitrary number of inner rows into one
+     * {@code items} list.
+     */
+    @Test
+    void sameAnchorAllRows_singleOuterRecord() throws Exception {
+        File file = tempDir.resolve("nested-same-anchor.xlsx").toFile();
+        SpreadsheetMapper mapper = new SpreadsheetMapper();
+        final int innerCount = 25;
+        List<EdgeItem> items = new ArrayList<>(innerCount);
+        for (int i = 0; i < innerCount; i++) items.add(new EdgeItem("sku-" + i, i));
+        List<EdgeOrder> data = Arrays.asList(new EdgeOrder(1, items));
+        mapper.writeValue(file, data, EdgeOrder.class);
+
+        List<EdgeOrder> read = mapper.readValues(file, EdgeOrder.class);
+        assertThat(read).hasSize(1);
+        assertThat(read.get(0).getId()).isEqualTo(1);
+        assertThat(read.get(0).getItems()).hasSize(innerCount);
+        assertThat(read.get(0).getItems()).isEqualTo(items);
+    }
+
+    /**
+     * Single outer record with a large inner list — exercises the
+     * record-tree buffer under the default heap-aware limit. 5000
+     * inner rows stay well under the default buffer cap on a
+     * typical JVM heap.
+     */
+    @Test
+    void veryLargeOuterRecord_singleOuterManyInner() throws Exception {
+        File file = tempDir.resolve("nested-large-outer.xlsx").toFile();
+        SpreadsheetMapper mapper = new SpreadsheetMapper();
+        final int innerCount = 5000;
+        List<EdgeItem> items = new ArrayList<>(innerCount);
+        for (int i = 0; i < innerCount; i++) items.add(new EdgeItem("sku-" + i, i));
+        List<EdgeOrder> data = Arrays.asList(new EdgeOrder(42, items));
+        mapper.writeValue(file, data, EdgeOrder.class);
+
+        List<EdgeOrder> read = mapper.readValues(file, EdgeOrder.class);
+        assertThat(read).hasSize(1);
+        assertThat(read.get(0).getId()).isEqualTo(42);
+        assertThat(read.get(0).getItems()).hasSize(innerCount);
+        assertThat(read.get(0).getItems().get(0).getSku()).isEqualTo("sku-0");
+        assertThat(read.get(0).getItems().get(innerCount - 1).getSku())
+                .isEqualTo("sku-" + (innerCount - 1));
     }
 }

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedListHeaderTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedListHeaderTest.java
@@ -1,0 +1,97 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.OptBoolean;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.util.CellRangeAddress;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Direct assertions on the written header layout for nested-list
+ * schemas — group header text, leaf header text, vertical merge on
+ * outer columns, and horizontal merge on the group cell.
+ * NestedListReadTest's round-trip cases verify these indirectly via
+ * deserialisation; this test pins them as visible Excel content.
+ */
+class NestedListHeaderTest {
+
+    @TempDir Path tempDir;
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class HeaderItem {
+        @DataColumn("sku") String sku;
+        @DataColumn("qty") Integer qty;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class HeaderOrder {
+        @DataColumn(value = "id", anchor = true, merge = OptBoolean.TRUE) Integer id;
+        @DataColumn("name") String name;
+        @DataColumnGroup("Items") List<HeaderItem> items;
+    }
+
+    @Test
+    void headerLayout_groupCellAndLeafRow() throws Exception {
+        File file = tempDir.resolve("nested-header.xlsx").toFile();
+        SpreadsheetMapper mapper = new SpreadsheetMapper();
+        mapper.writeValue(file, Arrays.asList(
+                new HeaderOrder(1, "Alice",
+                        Arrays.asList(new HeaderItem("A", 10)))),
+                HeaderOrder.class);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            Row h0 = sheet.getRow(0);
+            Row h1 = sheet.getRow(1);
+
+            // depth 0: outer column headers + group header cell
+            assertThat(h0.getCell(0).getStringCellValue()).isEqualTo("id");
+            assertThat(h0.getCell(1).getStringCellValue()).isEqualTo("name");
+            assertThat(h0.getCell(2).getStringCellValue()).isEqualTo("Items");
+
+            // depth 1 (leaf): inner column headers
+            assertThat(h1.getCell(2).getStringCellValue()).isEqualTo("sku");
+            assertThat(h1.getCell(3).getStringCellValue()).isEqualTo("qty");
+
+            // vertical merge of outer columns (id, name) across rows 0-1
+            List<CellRangeAddress> regions = sheet.getMergedRegions();
+            assertThat(regions).anySatisfy(r -> {
+                assertThat(r.getFirstRow()).isEqualTo(0);
+                assertThat(r.getLastRow()).isEqualTo(1);
+                assertThat(r.getFirstColumn()).isEqualTo(0);
+                assertThat(r.getLastColumn()).isEqualTo(0);
+            });
+            assertThat(regions).anySatisfy(r -> {
+                assertThat(r.getFirstRow()).isEqualTo(0);
+                assertThat(r.getLastRow()).isEqualTo(1);
+                assertThat(r.getFirstColumn()).isEqualTo(1);
+                assertThat(r.getLastColumn()).isEqualTo(1);
+            });
+
+            // horizontal merge of group cell ("Items") across columns 2-3
+            assertThat(regions).anySatisfy(r -> {
+                assertThat(r.getFirstRow()).isEqualTo(0);
+                assertThat(r.getLastRow()).isEqualTo(0);
+                assertThat(r.getFirstColumn()).isEqualTo(2);
+                assertThat(r.getLastColumn()).isEqualTo(3);
+            });
+        }
+    }
+}

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedListReadTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedListReadTest.java
@@ -26,7 +26,7 @@ class NestedListReadTest {
 
     @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
     static class Order {
-        @DataColumn(value = "ID", merge = OptBoolean.TRUE, anchor = OptBoolean.TRUE) int id;
+        @DataColumn(value = "ID", merge = OptBoolean.TRUE, anchor = true) int id;
         @DataColumn(value = "Customer", merge = OptBoolean.TRUE) String customer;
         @DataColumnGroup("Items") List<LineItem> items;
         @DataColumn(value = "Total", merge = OptBoolean.TRUE) int total;
@@ -77,13 +77,13 @@ class NestedListReadTest {
 
     @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
     static class DeepOuter {
-        @DataColumn(value = "OID", merge = OptBoolean.TRUE, anchor = OptBoolean.TRUE) int id;
+        @DataColumn(value = "OID", merge = OptBoolean.TRUE, anchor = true) int id;
         @DataColumnGroup("Mid") List<MidLevel> items;
     }
 
     @Data @NoArgsConstructor @AllArgsConstructor
     static class MidLevel {
-        @DataColumn(value = "MID", merge = OptBoolean.TRUE, anchor = OptBoolean.TRUE) String midId;
+        @DataColumn(value = "MID", merge = OptBoolean.TRUE, anchor = true) String midId;
         @DataColumnGroup("Detail") List<Inner> details;
         @DataColumn(value = "MNAME", merge = OptBoolean.TRUE) String midName;
     }
@@ -112,19 +112,19 @@ class NestedListReadTest {
 
     @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
     static class TopLevel {
-        @DataColumn(value = "TID", merge = OptBoolean.TRUE, anchor = OptBoolean.TRUE) int id;
+        @DataColumn(value = "TID", merge = OptBoolean.TRUE, anchor = true) int id;
         @DataColumnGroup("Mid") List<MidNode> mids;
     }
 
     @Data @NoArgsConstructor @AllArgsConstructor
     static class MidNode {
-        @DataColumn(value = "MID", merge = OptBoolean.TRUE, anchor = OptBoolean.TRUE) String mid;
+        @DataColumn(value = "MID", merge = OptBoolean.TRUE, anchor = true) String mid;
         @DataColumnGroup("Sub") List<SubNode> subs;
     }
 
     @Data @NoArgsConstructor @AllArgsConstructor
     static class SubNode {
-        @DataColumn(value = "SID", merge = OptBoolean.TRUE, anchor = OptBoolean.TRUE) String sid;
+        @DataColumn(value = "SID", merge = OptBoolean.TRUE, anchor = true) String sid;
         @DataColumnGroup("Leaf") List<Inner> leaves;
     }
 
@@ -161,7 +161,7 @@ class NestedListReadTest {
 
     @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
     static class SiblingOrder {
-        @DataColumn(value = "ID", merge = OptBoolean.TRUE, anchor = OptBoolean.TRUE) int id;
+        @DataColumn(value = "ID", merge = OptBoolean.TRUE, anchor = true) int id;
         @DataColumnGroup("Items") List<SiblingItem> items;
         @DataColumnGroup("Payments") List<SiblingPayment> payments;
     }
@@ -184,7 +184,7 @@ class NestedListReadTest {
 
     @Data @NoArgsConstructor @AllArgsConstructor
     static class GroupItem {
-        @DataColumn(value = "GID", merge = OptBoolean.TRUE, anchor = OptBoolean.TRUE) String gid;
+        @DataColumn(value = "GID", merge = OptBoolean.TRUE, anchor = true) String gid;
         @DataColumnGroup("Detail") List<Inner> details;
     }
 
@@ -196,7 +196,7 @@ class NestedListReadTest {
 
     @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
     static class Invoice {
-        @DataColumn(value = "INV", merge = OptBoolean.TRUE, anchor = OptBoolean.TRUE) int id;
+        @DataColumn(value = "INV", merge = OptBoolean.TRUE, anchor = true) int id;
         @DataColumnGroup("Groups") List<GroupItem> groups;
         @DataColumnGroup("Receipts") List<Receipt> receipts;
     }
@@ -240,14 +240,14 @@ class NestedListReadTest {
 
     @Data @NoArgsConstructor @AllArgsConstructor
     static class NestedSiblingMid {
-        @DataColumn(value = "MID", anchor = OptBoolean.TRUE, merge = OptBoolean.TRUE) String mid;
+        @DataColumn(value = "MID", anchor = true, merge = OptBoolean.TRUE) String mid;
         @DataColumnGroup("As") List<Inner> as;
         @DataColumnGroup("Bs") List<Inner> bs;
     }
 
     @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
     static class NestedSiblingTop {
-        @DataColumn(value = "ID", anchor = OptBoolean.TRUE, merge = OptBoolean.TRUE) int id;
+        @DataColumn(value = "ID", anchor = true, merge = OptBoolean.TRUE) int id;
         @DataColumnGroup("Mids") List<NestedSiblingMid> mids;
     }
 

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedListReadTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedListReadTest.java
@@ -22,6 +22,14 @@ import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Round-trip tests for nested-list read/write — single record,
+ * 1/2/3-depth nesting, sibling lists, empty list, {@code @JsonView}
+ * filtering, and SSML/POI cross-mode parity. Common-case shapes
+ * live here; partial-cell edge cases in
+ * {@link NestedListEdgeCaseTest}, blank-row semantics in
+ * {@link NestedBlankRowFeatureTest}.
+ */
 class NestedListReadTest {
 
     @TempDir Path tempDir;

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedListReadTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedListReadTest.java
@@ -271,7 +271,7 @@ class NestedListReadTest {
         assertThat(read.get(0)).isEqualTo(expected);
     }
 
-    // POI User Model parity — NestedReadAlg sits at the parser level so the
+    // POI User Model parity — RecordTreeBuffer sits at the parser level so the
     // read path (SSML vs POI object model) should be transparent. Spot-check
     // one case per shape (single-record, 2-depth + outer-after-list, sibling).
 

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedListReadTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedListReadTest.java
@@ -6,7 +6,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.annotation.OptBoolean;
+import com.fasterxml.jackson.databind.MapperFeature;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -328,5 +330,131 @@ class NestedListReadTest {
         List<SiblingOrder> read = mapper.readValues(file, SiblingOrder.class);
         assertThat(read).hasSize(1);
         assertThat(read.get(0)).isEqualTo(expected);
+    }
+
+    /**
+     * Three-depth fixture round-tripped across SSML and POI modes —
+     * SSML write then POI read, POI write then SSML read — confirms
+     * the deepest nesting layout is reader-agnostic.
+     */
+    @Test
+    void roundTrip_threeDepth_crossPoiSsml() throws Exception {
+        SpreadsheetMapper ssml = new SpreadsheetMapper();
+        SpreadsheetMapper poi = _poiMapper();
+
+        TopLevel expected = new TopLevel(1, Arrays.asList(
+                new MidNode("M1", Arrays.asList(
+                        new SubNode("S1A", Arrays.asList(new Inner(1, 2), new Inner(3, 4))),
+                        new SubNode("S1B", Arrays.asList(new Inner(5, 6))))),
+                new MidNode("M2", Arrays.asList(
+                        new SubNode("S2A", Arrays.asList(new Inner(7, 8)))))));
+
+        File ssmlFile = tempDir.resolve("three-depth-ssml-write.xlsx").toFile();
+        ssml.writeValue(ssmlFile, expected);
+        List<TopLevel> readViaPoi = poi.readValues(ssmlFile, TopLevel.class);
+        assertThat(readViaPoi).hasSize(1);
+        assertThat(readViaPoi.get(0)).isEqualTo(expected);
+
+        File poiFile = tempDir.resolve("three-depth-poi-write.xlsx").toFile();
+        poi.writeValue(poiFile, expected);
+        List<TopLevel> readViaSsml = ssml.readValues(poiFile, TopLevel.class);
+        assertThat(readViaSsml).hasSize(1);
+        assertThat(readViaSsml.get(0)).isEqualTo(expected);
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class ComplexMid {
+        @DataColumn(value = "CMID", anchor = true, merge = OptBoolean.TRUE) String mid;
+        @DataColumnGroup("Subs") List<SubNode> subs;
+        @DataColumnGroup("Notes") List<Inner> notes;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class ComplexTop {
+        @DataColumn(value = "CTID", anchor = true, merge = OptBoolean.TRUE) int id;
+        @DataColumnGroup("Mids") List<ComplexMid> mids;
+    }
+
+    /**
+     * Three-depth path (Top -> Mid -> Sub -> Leaf) combined with a
+     * sibling list at the Mid level (Subs alongside Notes). Exercises
+     * the record-tree close path when both a deep descendant and a
+     * sibling close at the same scope.
+     */
+    @Test
+    void roundTrip_threeDepthWithSibling() throws Exception {
+        File file = tempDir.resolve("three-depth-sibling.xlsx").toFile();
+        SpreadsheetMapper mapper = new SpreadsheetMapper();
+
+        // Sibling lists must share row span (write-side invariant):
+        // M1.subs leaves total 3 -> M1.notes also 3 items.
+        // M2.subs leaves total 1 -> M2.notes also 1 item.
+        ComplexTop expected = new ComplexTop(1, Arrays.asList(
+                new ComplexMid("M1",
+                        Arrays.asList(
+                                new SubNode("S1A", Arrays.asList(new Inner(1, 2), new Inner(3, 4))),
+                                new SubNode("S1B", Arrays.asList(new Inner(5, 6)))),
+                        Arrays.asList(new Inner(10, 20), new Inner(30, 40), new Inner(50, 60))),
+                new ComplexMid("M2",
+                        Arrays.asList(
+                                new SubNode("S2A", Arrays.asList(new Inner(7, 8)))),
+                        Arrays.asList(new Inner(70, 80)))));
+
+        mapper.writeValue(file, expected);
+
+        List<ComplexTop> read = mapper.readValues(file, ComplexTop.class);
+        assertThat(read).hasSize(1);
+        assertThat(read.get(0)).isEqualTo(expected);
+    }
+
+    interface Views {
+        interface Summary {}
+        interface Detail extends Summary {}
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class ViewItem {
+        @DataColumn("sku") @JsonView(Views.Summary.class) String sku;
+        @DataColumn("qty") @JsonView(Views.Detail.class) Integer qty;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class ViewOrder {
+        @DataColumn(value = "id", anchor = true, merge = OptBoolean.TRUE)
+        @JsonView(Views.Summary.class) Integer id;
+        @DataColumnGroup("Items")
+        @JsonView(Views.Summary.class) List<ViewItem> items;
+        @DataColumn("total")
+        @JsonView(Views.Detail.class) Integer total;
+    }
+
+    /**
+     * {@code @JsonView} + nested round-trip. Summary view writes
+     * anchor + items.sku only; Detail-only fields (items.qty, total)
+     * are absent from the sheet, so the subsequent default read sees
+     * them as {@code null}.
+     */
+    @Test
+    void roundTrip_jsonView_nested_summary() throws Exception {
+        SpreadsheetMapper viewMapper = SpreadsheetMapper.builder()
+                .configure(MapperFeature.DEFAULT_VIEW_INCLUSION, false)
+                .build();
+        File file = tempDir.resolve("nested-view-summary.xlsx").toFile();
+
+        ViewOrder data = new ViewOrder(1,
+                Arrays.asList(new ViewItem("A", 10), new ViewItem("B", 20)), 100);
+        viewMapper.sheetWriterForWithView(ViewOrder.class, Views.Summary.class)
+                .writeValue(file, Arrays.asList(data));
+
+        List<ViewOrder> read = viewMapper.readValues(file, ViewOrder.class);
+        assertThat(read).hasSize(1);
+        assertThat(read.get(0).getId()).isEqualTo(1);
+        assertThat(read.get(0).getItems()).hasSize(2);
+        assertThat(read.get(0).getItems()).extracting(ViewItem::getSku)
+                .containsExactly("A", "B");
+        // Detail-only fields not written under Summary view
+        assertThat(read.get(0).getItems()).extracting(ViewItem::getQty)
+                .containsExactly(null, null);
+        assertThat(read.get(0).getTotal()).isNull();
     }
 }

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedListReadTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedListReadTest.java
@@ -251,14 +251,10 @@ class NestedListReadTest {
         @DataColumnGroup("Mids") List<NestedSiblingMid> mids;
     }
 
-    // POI mode only: BackWriteProjection.hasMultipleSiblingLists currently
-    // counts top-level arrays only, so SSML skips flush suspension when
-    // the sibling lists live inside a nested scope and write fails.
-    // V2 read-side handles the shape — exercised here via POI random access.
     @Test
     void roundTrip_nestedSiblingLists() throws Exception {
         File file = tempDir.resolve("nested-sibling.xlsx").toFile();
-        SpreadsheetMapper mapper = _poiMapper();
+        SpreadsheetMapper mapper = new SpreadsheetMapper();
 
         NestedSiblingTop expected = new NestedSiblingTop(1, Arrays.asList(
                 new NestedSiblingMid("M1",

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedListReadTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedListReadTest.java
@@ -1,0 +1,336 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.OptBoolean;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NestedListReadTest {
+
+    @TempDir Path tempDir;
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class Order {
+        @DataColumn(value = "ID", merge = OptBoolean.TRUE, anchor = OptBoolean.TRUE) int id;
+        @DataColumn(value = "Customer", merge = OptBoolean.TRUE) String customer;
+        @DataColumnGroup("Items") List<LineItem> items;
+        @DataColumn(value = "Total", merge = OptBoolean.TRUE) int total;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class LineItem {
+        @DataColumn("SKU") String sku;
+        @DataColumn("Qty") int qty;
+        @DataColumn("Amount") int amount;
+    }
+
+    @Test
+    void roundTrip_singleOrder() throws Exception {
+        File file = tempDir.resolve("single-order.xlsx").toFile();
+        SpreadsheetMapper mapper = new SpreadsheetMapper();
+
+        Order expected = new Order(1, "Alice",
+                Arrays.asList(new LineItem("A-01", 3, 30), new LineItem("B-02", 5, 65)),
+                95);
+
+        mapper.writeValue(file, expected);
+
+        List<Order> read = mapper.readValues(file, Order.class);
+        assertThat(read).hasSize(1);
+        assertThat(read.get(0)).isEqualTo(expected);
+    }
+
+    @Test
+    void roundTrip_multipleOrders() throws Exception {
+        File file = tempDir.resolve("multi-order.xlsx").toFile();
+        SpreadsheetMapper mapper = new SpreadsheetMapper();
+
+        List<Order> expected = Arrays.asList(
+                new Order(1, "Alice", Arrays.asList(
+                        new LineItem("A-01", 3, 30),
+                        new LineItem("B-02", 5, 65)),
+                        95),
+                new Order(2, "Bob", Arrays.asList(
+                        new LineItem("C-03", 1, 10)),
+                        10));
+
+        mapper.writeValue(file, expected, Order.class);
+
+        List<Order> read = mapper.readValues(file, Order.class);
+        assertThat(read).isEqualTo(expected);
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class DeepOuter {
+        @DataColumn(value = "OID", merge = OptBoolean.TRUE, anchor = OptBoolean.TRUE) int id;
+        @DataColumnGroup("Mid") List<MidLevel> items;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class MidLevel {
+        @DataColumn(value = "MID", merge = OptBoolean.TRUE, anchor = OptBoolean.TRUE) String midId;
+        @DataColumnGroup("Detail") List<Inner> details;
+        @DataColumn(value = "MNAME", merge = OptBoolean.TRUE) String midName;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class Inner {
+        @DataColumn("X") int x;
+        @DataColumn("Y") int y;
+    }
+
+      @Test
+    void roundTrip_twoDepth() throws Exception {
+        File file = tempDir.resolve("two-depth.xlsx").toFile();
+        SpreadsheetMapper mapper = new SpreadsheetMapper();
+
+        DeepOuter expected = new DeepOuter(1, Arrays.asList(
+                new MidLevel("X", Arrays.asList(new Inner(1, 2), new Inner(3, 4)), "Name-X"),
+                new MidLevel("Y", Arrays.asList(new Inner(5, 6)), "Name-Y")));
+
+        mapper.writeValue(file, expected);
+
+        List<DeepOuter> read = mapper.readValues(file, DeepOuter.class);
+        assertThat(read).hasSize(1);
+        assertThat(read.get(0)).isEqualTo(expected);
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class TopLevel {
+        @DataColumn(value = "TID", merge = OptBoolean.TRUE, anchor = OptBoolean.TRUE) int id;
+        @DataColumnGroup("Mid") List<MidNode> mids;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class MidNode {
+        @DataColumn(value = "MID", merge = OptBoolean.TRUE, anchor = OptBoolean.TRUE) String mid;
+        @DataColumnGroup("Sub") List<SubNode> subs;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class SubNode {
+        @DataColumn(value = "SID", merge = OptBoolean.TRUE, anchor = OptBoolean.TRUE) String sid;
+        @DataColumnGroup("Leaf") List<Inner> leaves;
+    }
+
+    @Test
+    void roundTrip_threeDepth() throws Exception {
+        File file = tempDir.resolve("three-depth.xlsx").toFile();
+        SpreadsheetMapper mapper = new SpreadsheetMapper();
+
+        TopLevel expected = new TopLevel(1, Arrays.asList(
+                new MidNode("M1", Arrays.asList(
+                        new SubNode("S1A", Arrays.asList(new Inner(1, 2), new Inner(3, 4))),
+                        new SubNode("S1B", Arrays.asList(new Inner(5, 6))))),
+                new MidNode("M2", Arrays.asList(
+                        new SubNode("S2A", Arrays.asList(new Inner(7, 8)))))));
+
+        mapper.writeValue(file, expected);
+
+        List<TopLevel> read = mapper.readValues(file, TopLevel.class);
+        assertThat(read).hasSize(1);
+        assertThat(read.get(0)).isEqualTo(expected);
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class SiblingItem {
+        @DataColumn("SKU") String sku;
+        @DataColumn("Qty") int qty;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class SiblingPayment {
+        @DataColumn("Method") String method;
+        @DataColumn("Amount") int amount;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class SiblingOrder {
+        @DataColumn(value = "ID", merge = OptBoolean.TRUE, anchor = OptBoolean.TRUE) int id;
+        @DataColumnGroup("Items") List<SiblingItem> items;
+        @DataColumnGroup("Payments") List<SiblingPayment> payments;
+    }
+
+    @Test
+    void roundTrip_siblingLists() throws Exception {
+        File file = tempDir.resolve("sibling.xlsx").toFile();
+        SpreadsheetMapper mapper = new SpreadsheetMapper();
+
+        SiblingOrder expected = new SiblingOrder(1,
+                Arrays.asList(new SiblingItem("A", 10), new SiblingItem("B", 20)),
+                Arrays.asList(new SiblingPayment("card", 100), new SiblingPayment("cash", 200)));
+
+        mapper.writeValue(file, expected);
+
+        List<SiblingOrder> read = mapper.readValues(file, SiblingOrder.class);
+        assertThat(read).hasSize(1);
+        assertThat(read.get(0)).isEqualTo(expected);
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class GroupItem {
+        @DataColumn(value = "GID", merge = OptBoolean.TRUE, anchor = OptBoolean.TRUE) String gid;
+        @DataColumnGroup("Detail") List<Inner> details;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class Receipt {
+        @DataColumn("Note") String note;
+        @DataColumn("Total") int total;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class Invoice {
+        @DataColumn(value = "INV", merge = OptBoolean.TRUE, anchor = OptBoolean.TRUE) int id;
+        @DataColumnGroup("Groups") List<GroupItem> groups;
+        @DataColumnGroup("Receipts") List<Receipt> receipts;
+    }
+
+    @Test
+    void roundTrip_siblingWithNested() throws Exception {
+        File file = tempDir.resolve("sibling-nested.xlsx").toFile();
+        SpreadsheetMapper mapper = new SpreadsheetMapper();
+
+        Invoice expected = new Invoice(1,
+                Arrays.asList(
+                        new GroupItem("G1", Arrays.asList(new Inner(1, 2), new Inner(3, 4))),
+                        new GroupItem("G2", Arrays.asList(new Inner(5, 6)))),
+                Arrays.asList(
+                        new Receipt("first", 10),
+                        new Receipt("second", 20),
+                        new Receipt("third", 30)));
+
+        mapper.writeValue(file, expected);
+
+        List<Invoice> read = mapper.readValues(file, Invoice.class);
+        assertThat(read).hasSize(1);
+        assertThat(read.get(0)).isEqualTo(expected);
+    }
+
+    // Empty list — write produces zero inner rows; Jackson convention
+    // makes the missing array field deserialize as null (use
+    // @JsonSetter(nulls = AS_EMPTY) on the field for empty-list semantics).
+    @Test
+    void roundTrip_emptyList() throws Exception {
+        File file = tempDir.resolve("empty-list.xlsx").toFile();
+        SpreadsheetMapper mapper = new SpreadsheetMapper();
+
+        Order written = new Order(1, "Alice", Collections.emptyList(), 0);
+        mapper.writeValue(file, written);
+
+        List<Order> read = mapper.readValues(file, Order.class);
+        assertThat(read).hasSize(1);
+        assertThat(read.get(0)).isEqualTo(new Order(1, "Alice", null, 0));
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class NestedSiblingMid {
+        @DataColumn(value = "MID", anchor = OptBoolean.TRUE, merge = OptBoolean.TRUE) String mid;
+        @DataColumnGroup("As") List<Inner> as;
+        @DataColumnGroup("Bs") List<Inner> bs;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class NestedSiblingTop {
+        @DataColumn(value = "ID", anchor = OptBoolean.TRUE, merge = OptBoolean.TRUE) int id;
+        @DataColumnGroup("Mids") List<NestedSiblingMid> mids;
+    }
+
+    // POI mode only: BackWriteProjection.hasMultipleSiblingLists currently
+    // counts top-level arrays only, so SSML skips flush suspension when
+    // the sibling lists live inside a nested scope and write fails.
+    // V2 read-side handles the shape — exercised here via POI random access.
+    @Test
+    void roundTrip_nestedSiblingLists() throws Exception {
+        File file = tempDir.resolve("nested-sibling.xlsx").toFile();
+        SpreadsheetMapper mapper = _poiMapper();
+
+        NestedSiblingTop expected = new NestedSiblingTop(1, Arrays.asList(
+                new NestedSiblingMid("M1",
+                        Arrays.asList(new Inner(1, 2), new Inner(3, 4)),
+                        Arrays.asList(new Inner(11, 12), new Inner(13, 14))),
+                new NestedSiblingMid("M2",
+                        Arrays.asList(new Inner(5, 6)),
+                        Arrays.asList(new Inner(15, 16)))));
+
+        mapper.writeValue(file, expected);
+
+        List<NestedSiblingTop> read = mapper.readValues(file, NestedSiblingTop.class);
+        assertThat(read).hasSize(1);
+        assertThat(read.get(0)).isEqualTo(expected);
+    }
+
+    // POI User Model parity — NestedReadAlg sits at the parser level so the
+    // read path (SSML vs POI object model) should be transparent. Spot-check
+    // one case per shape (single-record, 2-depth + outer-after-list, sibling).
+
+    private SpreadsheetMapper _poiMapper() {
+        return new SpreadsheetMapper(
+                new SpreadsheetFactory(SXSSFWorkbook::new,
+                        SpreadsheetFactory.DEFAULT_SHEET_PARSER_FEATURE_FLAGS)
+                        .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL));
+    }
+
+    @Test
+    void roundTrip_singleOrder_poi() throws Exception {
+        File file = tempDir.resolve("single-order-poi.xlsx").toFile();
+        SpreadsheetMapper mapper = _poiMapper();
+
+        Order expected = new Order(1, "Alice",
+                Arrays.asList(new LineItem("A-01", 3, 30), new LineItem("B-02", 5, 65)),
+                95);
+
+        mapper.writeValue(file, expected);
+
+        List<Order> read = mapper.readValues(file, Order.class);
+        assertThat(read).hasSize(1);
+        assertThat(read.get(0)).isEqualTo(expected);
+    }
+
+    @Test
+    void roundTrip_twoDepth_poi() throws Exception {
+        File file = tempDir.resolve("two-depth-poi.xlsx").toFile();
+        SpreadsheetMapper mapper = _poiMapper();
+
+        DeepOuter expected = new DeepOuter(1, Arrays.asList(
+                new MidLevel("X", Arrays.asList(new Inner(1, 2), new Inner(3, 4)), "Name-X"),
+                new MidLevel("Y", Arrays.asList(new Inner(5, 6)), "Name-Y")));
+
+        mapper.writeValue(file, expected);
+
+        List<DeepOuter> read = mapper.readValues(file, DeepOuter.class);
+        assertThat(read).hasSize(1);
+        assertThat(read.get(0)).isEqualTo(expected);
+    }
+
+    @Test
+    void roundTrip_siblingLists_poi() throws Exception {
+        File file = tempDir.resolve("sibling-poi.xlsx").toFile();
+        SpreadsheetMapper mapper = _poiMapper();
+
+        SiblingOrder expected = new SiblingOrder(1,
+                Arrays.asList(new SiblingItem("A", 10), new SiblingItem("B", 20)),
+                Arrays.asList(new SiblingPayment("card", 100), new SiblingPayment("cash", 200)));
+
+        mapper.writeValue(file, expected);
+
+        List<SiblingOrder> read = mapper.readValues(file, SiblingOrder.class);
+        assertThat(read).hasSize(1);
+        assertThat(read.get(0)).isEqualTo(expected);
+    }
+}

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedReorderTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedReorderTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * SheetParser.setSchema rejects the combination of {@code
  * columnReordering=true} and any schema carrying
  * {@code @DataColumnGroup} (multi-row headers) — which all nested-list
- * schemas necessarily do. The check fires before NestedReadAlg is
+ * schemas necessarily do. The check fires before RecordTreeBuffer is
  * created, so the algorithm never sees a reordered schema and the
  * snapshot it holds at construction stays authoritative.
  */

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedReorderTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedReorderTest.java
@@ -1,0 +1,64 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.OptBoolean;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.Test;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Pins down the FEATURE_COLUMN_REORDERING boundary for nested schemas.
+ * SheetParser.setSchema rejects the combination of {@code
+ * columnReordering=true} and any schema carrying
+ * {@code @DataColumnGroup} (multi-row headers) — which all nested-list
+ * schemas necessarily do. The check fires before NestedReadAlg is
+ * created, so the algorithm never sees a reordered schema and the
+ * snapshot it holds at construction stays authoritative.
+ */
+class NestedReorderTest {
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class ROItem {
+        @DataColumn("sku") String sku;
+        @DataColumn("qty") int qty;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class ROOrder {
+        @DataColumn(value = "id", anchor = OptBoolean.TRUE, merge = OptBoolean.TRUE) Integer id;
+        @DataColumn("name") String name;
+        @DataColumnGroup("Items") List<ROItem> items;
+    }
+
+    @Test
+    void nested_withColumnReordering_isRejectedAtSetSchema() throws Exception {
+        SpreadsheetMapper mapper = SpreadsheetMapper.builder()
+                .columnReordering(true).build();
+        try (XSSFWorkbook wb = new XSSFWorkbook()) {
+            Sheet sheet = wb.createSheet();
+            Row h0 = sheet.createRow(0);
+            h0.createCell(0).setCellValue("id");
+            h0.createCell(1).setCellValue("name");
+            h0.createCell(2).setCellValue("Items");
+            Row h1 = sheet.createRow(1);
+            h1.createCell(2).setCellValue("sku");
+            h1.createCell(3).setCellValue("qty");
+
+            assertThatThrownBy(() -> mapper.readValues(sheet, ROOrder.class))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("Column reordering is not supported with multi-row headers");
+        }
+    }
+}

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedReorderTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedReorderTest.java
@@ -37,7 +37,7 @@ class NestedReorderTest {
 
     @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
     static class ROOrder {
-        @DataColumn(value = "id", anchor = OptBoolean.TRUE, merge = OptBoolean.TRUE) Integer id;
+        @DataColumn(value = "id", anchor = true, merge = OptBoolean.TRUE) Integer id;
         @DataColumn("name") String name;
         @DataColumnGroup("Items") List<ROItem> items;
     }

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/NestedReadAlgBufferLimitTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/NestedReadAlgBufferLimitTest.java
@@ -1,0 +1,103 @@
+package io.github.scndry.jackson.dataformat.spreadsheet.deser;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.OptBoolean;
+import com.fasterxml.jackson.core.JsonToken;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.junit.jupiter.api.Test;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.SheetStreamReadException;
+import io.github.scndry.jackson.dataformat.spreadsheet.SpreadsheetMapper;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Direct unit checks on the buffer fail-fast — exercises NestedReadAlg
+ * with a small bufferLimitBytes so the per-cell footprint quickly trips
+ * the limit. Bypasses SheetParser to keep the test boilerplate-free.
+ */
+class NestedReadAlgBufferLimitTest {
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class Inner {
+        @DataColumn("x") int x;
+        @DataColumn("y") int y;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class Outer {
+        @DataColumn(value = "id", anchor = OptBoolean.TRUE) int id;
+        List<Inner> items;
+    }
+
+    @Test
+    void onRowEnd_bufferUnderLimit_doesNotThrow() throws Exception {
+        // 21 cells × 20 bytes = 420 → well under 10_000
+        assertThatCode(_runNRows(10_000L, 10)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void onRowEnd_bufferOverLimit_throws() throws Exception {
+        // small limit (~5 cells) — first inner row already trips it
+        assertThatThrownBy(_runNRows(100L, 5))
+                .isInstanceOf(SheetStreamReadException.class)
+                .hasMessageContaining("Nested-list buffer")
+                .hasMessageContaining("exceeds limit")
+                .hasMessageContaining("USE_POI_USER_MODEL");
+    }
+
+    private static ThrowingRunnable _runNRows(final long bufferLimitBytes, final int innerRows)
+            throws Exception {
+        final SpreadsheetSchema schema = new SpreadsheetMapper().sheetSchemaFor(Outer.class);
+        final Column idCol = _findColumn(schema, "id");
+        final Column xCol = _findColumn(schema, "x");
+        final Column yCol = _findColumn(schema, "y");
+
+        return () -> {
+            final NestedReadAlg alg = new NestedReadAlg(schema, bufferLimitBytes);
+            final CountingEmitter out = new CountingEmitter();
+            alg.onSheetDataStart(out);
+            // anchor row carries id + first inner cells
+            alg.onRowStart();
+            alg.onCellValue(idCol, new CellValue(1.0));
+            alg.onCellValue(xCol, new CellValue(1.0));
+            alg.onCellValue(yCol, new CellValue(2.0));
+            alg.onRowEnd(out);
+            // continuation rows accumulate inner cells without freeing
+            for (int i = 1; i < innerRows; i++) {
+                alg.onRowStart();
+                alg.onCellValue(xCol, new CellValue(1.0 + i));
+                alg.onCellValue(yCol, new CellValue(2.0 + i));
+                alg.onRowEnd(out);
+            }
+            alg.onSheetDataEnd(out);
+        };
+    }
+
+    private static Column _findColumn(final SpreadsheetSchema schema, final String name) {
+        for (final Column c : schema) {
+            if (c != null && name.equals(c.getName())) return c;
+        }
+        throw new AssertionError("no column " + name);
+    }
+
+    interface ThrowingRunnable extends org.assertj.core.api.ThrowableAssert.ThrowingCallable {
+        void run() throws Exception;
+        @Override default void call() throws Throwable { run(); }
+    }
+
+    private static final class CountingEmitter implements NestedReadAlg.Emitter {
+        @Override public void token(final JsonToken t) { /* ignore */ }
+        @Override public void fieldName(final String n) { /* ignore */ }
+        @Override public void scalar(final CellValue v, final JsonToken s) { /* ignore */ }
+    }
+}

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/RecordTreeBufferLimitTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/RecordTreeBufferLimitTest.java
@@ -21,11 +21,11 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Direct unit checks on the buffer fail-fast — exercises NestedReadAlg
+ * Direct unit checks on the buffer fail-fast — exercises RecordTreeBuffer
  * with a small bufferLimitBytes so the per-cell footprint quickly trips
  * the limit. Bypasses SheetParser to keep the test boilerplate-free.
  */
-class NestedReadAlgBufferLimitTest {
+class RecordTreeBufferLimitTest {
 
     @Data @NoArgsConstructor @AllArgsConstructor
     static class Inner {
@@ -63,7 +63,7 @@ class NestedReadAlgBufferLimitTest {
         final Column yCol = _findColumn(schema, "y");
 
         return () -> {
-            final NestedReadAlg alg = new NestedReadAlg(schema, bufferLimitBytes);
+            final RecordTreeBuffer alg = new RecordTreeBuffer(schema, bufferLimitBytes);
             final CountingEmitter out = new CountingEmitter();
             alg.onSheetDataStart(out);
             // anchor row carries id + first inner cells
@@ -95,7 +95,7 @@ class NestedReadAlgBufferLimitTest {
         @Override default void call() throws Throwable { run(); }
     }
 
-    private static final class CountingEmitter implements NestedReadAlg.Emitter {
+    private static final class CountingEmitter implements RecordTreeBuffer.Emitter {
         @Override public void token(final JsonToken t) { /* ignore */ }
         @Override public void fieldName(final String n) { /* ignore */ }
         @Override public void scalar(final CellValue v, final JsonToken s) { /* ignore */ }

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/RecordTreeBufferLimitTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/RecordTreeBufferLimitTest.java
@@ -2,7 +2,6 @@ package io.github.scndry.jackson.dataformat.spreadsheet.deser;
 
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.OptBoolean;
 import com.fasterxml.jackson.core.JsonToken;
 
 import lombok.AllArgsConstructor;
@@ -35,7 +34,7 @@ class RecordTreeBufferLimitTest {
 
     @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
     static class Outer {
-        @DataColumn(value = "id", anchor = OptBoolean.TRUE) int id;
+        @DataColumn(value = "id", anchor = true) int id;
         List<Inner> items;
     }
 


### PR DESCRIPTION
## Summary

- Bidirectional nested-list mapping completes the I/O symmetry — `List<T>` fields now round-trip through Excel. Read collapses multi-row blocks into one outer record when a column is marked with `@DataColumn(anchor = true)`; write was already supported and stays backward-compatible.
- `RecordTreeBuffer` (deser/) assembles the record tree keyed by array scope and emits each outer record on anchor change / blank row / sheet end. Sibling lists, outer-after-list, and N-depth all fall out of the recursion.
- Allocation cuts on the write path from the schema-static `resolve` / `resolveArray` cache: `nestedWrite` -40%, `flatWrite` -18%, `nestedWritePoi` -18% (no throughput regression at any flat scale). `nestedRead` -22% from the per-Column `immediateScope` cache.
- New test surface (37 tests across 8 files): round-trip shapes (1/2/3-depth, sibling, empty, JsonView), edge cases (trailing blank cells, anchor-blank continuation, partial inner null, streaming iterator, boolean anchor, same anchor across all rows, large outer), header layout, anchor invariant validation, reorder rejection, ERROR-cell rejection, buffer fail-fast, cross-mode (SSML/POI) round-trip.
- New benchmark surface: NestedReadBenchmark, NestedWriteBenchmark, NestedCellParityBenchmark, NestedIntParityBenchmark, NestedStringParityBenchmark, NestedSustainedThroughputBenchmark, plus CellTypeOverheadBenchmark covering eight Java types (int/long/double/boolean/String/BigDecimal/LocalDate/LocalDateTime) on the flat path.

## Breaking changes (1.7.0)

- `DataColumn.Value` constructor extended from 9 to 10 args — the new last parameter is `boolean anchor`. Application code that calls the constructor directly (rare; the annotation path is unaffected) needs the extra argument.
- `DataColumn.anchor()` is declared `boolean` rather than `OptBoolean`. There is no `DataGrid` default to cascade from, so the 3-state value collapsed to 2-state. Migration: `@DataColumn(anchor = OptBoolean.TRUE)` → `@DataColumn(anchor = true)`.

## Public API surface

- New: `@DataColumn(anchor)` field, `DataColumn.Value.getAnchor()` / `isAnchor()`, `Column.isAnchor()`, `SpreadsheetSchema.resolve(parent, name)` / `resolveArray(parent)` (internal hot-path cache, javadoc-documented as internal-use). Nested schema queries (`hasAnchor` / `hasNestedList` / `findAnchorColumn` / `allArrayScopes` / `immediateScope`) live under `schema.internal.SchemaAnchorInspector` to keep `SpreadsheetSchema` focused on column data plus the resolve cache. Same `schema.internal` convention as `BackWriteProjection`.

## Read semantics

- `BLANK_ROW_AS_NULL` and `BREAK_ON_BLANK_ROW` honor the same meaning as in the flat path — a fully blank row closes the open outer record and either inserts a null entry or terminates iteration.
- ERROR cells now throw `SheetStreamReadException` at cell-arrival time, matching the flat path (silent VALUE_NULL substitution is gone).
- `FEATURE_COLUMN_REORDERING` and nested schemas (which always carry `@DataColumnGroup`) remain mutually exclusive — `SheetParser.setSchema` rejects the combination as before.
- Outer cells emit in schema column order (insertion sort on add). Cell-arrival order of the source sheet no longer leaks into the token stream — deterministic regardless of how the producer laid the columns out.

## Test plan

- [x] Full unit test suite passes (37 new nested tests + pre-existing suites; no regressions)
- [x] Read/Write/Sustained/SharedStrings benchmarks re-run against `aba0498` — write alloc -7~9% vs documented baseline, throughput within noise (±5%), read unchanged
- [x] CPU profile (event=cpu, 1M targetCells) and alloc profile (event=alloc) used to verify hot-path / dominant-alloc decisions
- [x] Cross-mode SSML/POI round-trip covered at 1-depth (edge case suite) and 3-depth (read suite)
- [x] Edge cases pinned: trailing blank cells, anchor-blank continuation rows, partial inner null, ERROR cells, streaming iterator, boolean anchor, single-record-with-many-inner, 5K-inner-row buffer fit, JsonView Summary filter
- [x] Public API surface audit — 6 schema query methods extracted to `schema.internal.SchemaAnchorInspector` to keep `SpreadsheetSchema` minimal
- [x] `RecordTreeBuffer.onCellValue` aligned to use `SheetStreamReadException.unexpected` factory like the flat path

## Documentation

- README: nested-list round-trip noted in the Complex Objects section and the FAQ
- GUIDE: new "Reading Nested Lists" subsection covering anchor declaration, invariants, blank-row semantics, the reorder incompatibility, and ERROR-cell behaviour
- DESIGN: nested `List<T>` extends the flattening/reconstruction story across rows when an anchor column is present
- ARCHITECTURE: `RecordTreeBuffer` named as the anchor-path branch of `SheetParser.nextToken`; flat schemas keep the single-pass StAX path
- BENCHMARK.md update deferred to the 1.7.0 release (full re-measurement at release-time, layout proposal agreed)
