### PR TITLE
Trim nested-list docs and javadocs to match write-side tone

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -189,12 +189,11 @@ mapper.readValue(file, Employee.class)
        ├─ SheetReader.next() → SheetToken
        ├─ row/column bounds check against schema
        ├─ ColumnPointer scope tracking
-       ├─ Flat path → JsonToken emission (with nesting)
-       ├─ Anchor path → RecordTreeBuffer assembles record tree, emits per outer
+       ├─ JsonToken emission (with nesting)
        └─ Jackson BeanDeserializer consumes tokens → Employee
 ```
 
-The anchor path engages when the schema declares any `@DataColumn(anchor = true)`. `RecordTreeBuffer` buffers cells row-by-row into a record tree keyed by array scope and emits each outer record (with its nested lists attached) once an anchor change, blank row, or end of sheet closes the boundary. Flat schemas bypass the buffer — the read path stays a single-pass StAX consume.
+Schemas with `@DataColumn(anchor = true)` buffer cells into a record tree until an anchor change closes the outer record.
 
 ### Dual Reader Strategy
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -95,7 +95,7 @@ POJO:         Employee { name="Alice", address=Address { city="Seoul", zip="1234
 
 Why automate this? Because nested objects are the norm in Java, but spreadsheets are flat. Every other Excel library forces you to manually bridge this gap — either flattening on write or reconstructing on read. This library does both directions automatically via Jackson's token model.
 
-Nested `List<T>` fields extend the same idea across rows: write expands the list into a multi-row block; read collapses the block back into the outer record when one column per record level is marked as the anchor. The anchor is the only explicit declaration the read side needs — the buffering, record-tree assembly, and back-write boundaries fall out of the same token model.
+Nested `List<T>` fields extend the same idea across rows: write expands the list into a multi-row block; read collapses the block back into the outer record when one column per record level is marked as the anchor. The anchor is the only explicit declaration the read side needs — the rest falls out of the same token model.
 
 ### Format I/O → Format detection
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -460,7 +460,7 @@ SpreadsheetMapper mapper = new SpreadsheetMapper(
 
 #### Reading Nested Lists
 
-Mark one column per nested-list-bearing record level with `@DataColumn(anchor = true)`. The reader watches that column for value changes to detect record boundaries — a sequence of rows sharing the same anchor value collapses into one outer record with the inner rows as its list.
+Mark one column per record level with `@DataColumn(anchor = true)`. Rows sharing the anchor value collapse into one outer record.
 
 ```java
 @DataGrid(mergeColumn = OptBoolean.TRUE)
@@ -469,26 +469,9 @@ class Order {
     List<Item> items;
     @DataColumn("Total") int total;
 }
-```
 
-```java
 List<Order> orders = mapper.readValues(file, Order.class);
-// One Order per distinct Order ID, items[] holds the inner rows.
 ```
-
-Anchor invariants are checked at `setSchema` time and surface as `IllegalStateException`:
-
-- Each nested-list-bearing record level needs exactly one anchor column at its immediate scope.
-- Anchor columns on records without a nested list are rejected.
-- Multiple anchors at the same scope are rejected.
-
-The read path buffers cells into a record tree keyed by array scope and emits each outer record once its boundary closes (anchor change, blank row, or end of sheet). Buffer growth is capped by the same heap-aware bound used on the write side — split large outer records or switch to `USE_POI_USER_MODEL` if a single record cannot fit.
-
-`BLANK_ROW_AS_NULL` and `BREAK_ON_BLANK_ROW` carry the same semantics as in the flat path: a fully blank row closes the currently open outer record, then either inserts a `null` entry into the result list or terminates iteration.
-
-`FEATURE_COLUMN_REORDERING` is incompatible with nested-list schemas (every nested-list schema uses `@DataColumnGroup`, which forces multi-row headers); enabling both raises `IllegalStateException` at `setSchema`.
-
-ERROR cells (`#N/A`, `#DIV/0!`, etc.) in nested reads raise `SheetStreamReadException` at cell-arrival time — matching the flat path. The reader does not silently substitute `null` for an ERROR cell.
 
 ## Annotations
 

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/BackWriteProjection.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/BackWriteProjection.java
@@ -24,13 +24,8 @@ import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
  * {@code SheetDataBuffer} (per-cell memory) and {@code SheetGenerator}
  * (pre-list fail-fast check on {@code writeStartArray}).
  *
- * <p>The {@link #backWriteBufferLimit()} budget and
- * {@link #CELL_MEMORY_BYTES} are also reused by {@code RecordTreeBuffer} as a
- * ballpark on the read side. Read-side cells are object references
- * (Cell + List/Map overhead), not the SoA records — actual per-cell heap
- * is roughly 1.5–2× the SoA figure, so the limit triggers a little later
- * in bytes-of-heap but still serves the same OOM-protection role with
- * the same guidance (USE_POI_USER_MODEL bypass / split the outer record).
+ * <p>{@link #backWriteBufferLimit()} and {@link #CELL_MEMORY_BYTES}
+ * are also reused by {@code RecordTreeBuffer} as a read-side ballpark.
  *
  * <p>Not part of the public API. Classes under
  * {@code io.github.scndry.jackson.dataformat.spreadsheet.schema.internal}

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/NestedAnchorValidator.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/NestedAnchorValidator.java
@@ -15,8 +15,6 @@ import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
  * Read-time validation for the depth-aware nested-list contract:
  * each nested-list-bearing record level must declare exactly one
  * {@code @DataColumn(anchor = true)} column at its immediate scope.
- * Called from {@code SheetParser.setSchema} only when the schema has
- * at least one anchor — the write path is unaffected.
  *
  * <p>Not part of the public API. Classes under
  * {@code io.github.scndry.jackson.dataformat.spreadsheet.schema.internal}

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/SchemaAnchorInspector.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/SchemaAnchorInspector.java
@@ -12,11 +12,7 @@ import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
 /**
  * Schema queries that support nested-list reads — anchor lookup,
  * array-scope enumeration, and the {@code immediateScope} /
- * {@code allArrayScopes} pointer helpers. Extracted from
- * {@link SpreadsheetSchema} so the schema retains only its core
- * column data plus the hot-path resolve cache; nested-list-specific
- * lookups live next to {@link BackWriteProjection} and
- * {@link NestedAnchorValidator}.
+ * {@code allArrayScopes} pointer helpers.
  *
  * <p>Not part of the public API. Classes under
  * {@code io.github.scndry.jackson.dataformat.spreadsheet.schema.internal}

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedAnchorValidatorTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedAnchorValidatorTest.java
@@ -17,9 +17,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Read-time anchor invariant checks — exactly one
- * {@code @DataColumn(anchor = true)} at each nested-list-bearing record
- * level, none elsewhere. Driven from {@code SheetParser.setSchema}
- * when the schema has any anchor; the write path is untouched.
+ * {@code @DataColumn(anchor = true)} per nested-list-bearing record
+ * level, none elsewhere.
  */
 class NestedAnchorValidatorTest {
 

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedBlankRowFeatureTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedBlankRowFeatureTest.java
@@ -21,12 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * BLANK_ROW_AS_NULL and BREAK_ON_BLANK_ROW carry the same semantics in
- * nested mode as in the flat path: a completely blank row closes the
- * currently-open outer record, then BLANK_ROW_AS_NULL inserts a null
- * entry into the result list and BREAK_ON_BLANK_ROW terminates the
- * iteration. With both flags off the blank row is silently dropped and
- * reading continues — matching the flat path's _handleEmptyObject
- * clear-and-continue behaviour.
+ * nested mode as in the flat path.
  */
 class NestedBlankRowFeatureTest {
 

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedErrorCellTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedErrorCellTest.java
@@ -21,11 +21,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Confirms that ERROR (and other unsupported) cells in nested reads
- * fail the same way as in the flat path — both raise
- * {@link SheetStreamReadException} so silent data loss cannot occur.
- * RecordTreeBuffer rejects unsupported cell types at cell-arrival time
- * (onCellValue), matching the flat path's _scalarValueToken throw.
+ * ERROR (and other unsupported) cells in nested reads raise
+ * {@link SheetStreamReadException} — same as the flat path.
  */
 class NestedErrorCellTest {
 

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedReorderTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedReorderTest.java
@@ -19,13 +19,9 @@ import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
- * Pins down the FEATURE_COLUMN_REORDERING boundary for nested schemas.
- * SheetParser.setSchema rejects the combination of {@code
- * columnReordering=true} and any schema carrying
- * {@code @DataColumnGroup} (multi-row headers) — which all nested-list
- * schemas necessarily do. The check fires before RecordTreeBuffer is
- * created, so the algorithm never sees a reordered schema and the
- * snapshot it holds at construction stays authoritative.
+ * FEATURE_COLUMN_REORDERING and nested-list schemas (which always
+ * carry {@code @DataColumnGroup}) are mutually exclusive — the
+ * combination is rejected at {@code setSchema}.
  */
 class NestedReorderTest {
 


### PR DESCRIPTION
## Summary

Polish follow-up to #169 — nested-list docs (ARCHITECTURE / DESIGN / GUIDE) and javadocs (4 test classes + 3 schema.internal classes) trimmed to match the write-side tone. No behaviour change.

## Test plan

- [x] Full unit test suite passes