### PR TITLE
Bump to 1.7.1-SNAPSHOT

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "io.github.scndry"
-version = "1.7.0"
+version = "1.7.1-SNAPSHOT"
 description = "Support for reading and writing Excel (XLSX/XLS) via Jackson abstractions."
 
 val title = "Jackson dataformat: Spreadsheet"


### PR DESCRIPTION
## Summary

Bump version from 1.7.0 to 1.7.1-SNAPSHOT (post-release).

## Test plan

- [ ] CI green