### PR TITLE
Fix nested object emit in anchor records + RecordTreeBuffer perf

### DIFF
--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/RecordTreeBuffer.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/RecordTreeBuffer.java
@@ -39,6 +39,7 @@ final class RecordTreeBuffer {
     private final Map<ColumnPointer, ColumnPointer> _parentArrayScopeOf;
     private final Map<Column, ColumnPointer> _immediateScopeByColumn;
     private final Map<Column, Integer> _columnPositionByColumn;
+    private final Map<Column, List<String>> _relativeSegmentsByColumn;
     private final long _bufferLimitBytes;
     private final boolean _blankRowAsNull;
     private final boolean _breakOnBlankRow;
@@ -64,6 +65,7 @@ final class RecordTreeBuffer {
         _parentArrayScopeOf = _computeParentScopeMap(schema);
         _immediateScopeByColumn = _computeImmediateScopeByColumn(schema);
         _columnPositionByColumn = _computeColumnPositionByColumn(schema);
+        _relativeSegmentsByColumn = _computeRelativeSegmentsByColumn(schema);
         _bufferLimitBytes = bufferLimitBytes;
         _blankRowAsNull = blankRowAsNull;
         _breakOnBlankRow = breakOnBlankRow;
@@ -86,6 +88,21 @@ final class RecordTreeBuffer {
         for (final Column c : schema) {
             if (c != null) result.put(c, i);
             i++;
+        }
+        return result;
+    }
+
+    private static Map<Column, List<String>> _computeRelativeSegmentsByColumn(
+            final SpreadsheetSchema schema) {
+        final Map<Column, List<String>> result = new HashMap<>();
+        for (final Column c : schema) {
+            if (c == null) continue;
+            final ColumnPointer scope = SchemaAnchorInspector.immediateScope(c.getPointer());
+            final List<String> segs = new ArrayList<>();
+            for (final ColumnPointer seg : scope.relativize(c.getPointer())) {
+                segs.add(seg.name());
+            }
+            result.put(c, java.util.Collections.unmodifiableList(segs));
         }
         return result;
     }
@@ -222,7 +239,7 @@ final class RecordTreeBuffer {
         out.token(JsonToken.START_OBJECT);
         final List<String> openPath = new ArrayList<>();
         for (final Cell c : record.outerCells) {
-            final List<String> path = _relativeSegments(record.scope, c.column.getPointer());
+            final List<String> path = _relativeSegmentsByColumn.get(c.column);
             final int common = _commonPrefixLength(openPath, path, path.size() - 1);
             for (int i = openPath.size() - common; i > 0; i--) {
                 out.token(JsonToken.END_OBJECT);
@@ -248,14 +265,6 @@ final class RecordTreeBuffer {
             out.token(JsonToken.END_ARRAY);
         }
         out.token(JsonToken.END_OBJECT);
-    }
-
-    private static List<String> _relativeSegments(final ColumnPointer scope, final ColumnPointer pointer) {
-        final List<String> result = new ArrayList<>();
-        for (final ColumnPointer seg : scope.relativize(pointer)) {
-            result.add(seg.name());
-        }
-        return result;
     }
 
     private static int _commonPrefixLength(final List<String> a, final List<String> b, final int bLimit) {

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/RecordTreeBuffer.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/RecordTreeBuffer.java
@@ -220,9 +220,24 @@ final class RecordTreeBuffer {
 
     private void _emitRecord(final RecordNode record, final Emitter out) {
         out.token(JsonToken.START_OBJECT);
+        final List<String> openPath = new ArrayList<>();
         for (final Cell c : record.outerCells) {
-            out.fieldName(c.column.getPointer().name());
+            final List<String> path = _relativeSegments(record.scope, c.column.getPointer());
+            final int common = _commonPrefixLength(openPath, path, path.size() - 1);
+            for (int i = openPath.size() - common; i > 0; i--) {
+                out.token(JsonToken.END_OBJECT);
+            }
+            for (int i = common; i < path.size() - 1; i++) {
+                out.fieldName(path.get(i));
+                out.token(JsonToken.START_OBJECT);
+            }
+            out.fieldName(path.get(path.size() - 1));
             out.scalar(c.value, _scalarToken(c.value));
+            openPath.clear();
+            openPath.addAll(path.subList(0, path.size() - 1));
+        }
+        for (int i = openPath.size(); i > 0; i--) {
+            out.token(JsonToken.END_OBJECT);
         }
         for (final Map.Entry<ColumnPointer, List<RecordNode>> e : record.childRecords.entrySet()) {
             out.fieldName(e.getKey().getParent().name());
@@ -233,6 +248,21 @@ final class RecordTreeBuffer {
             out.token(JsonToken.END_ARRAY);
         }
         out.token(JsonToken.END_OBJECT);
+    }
+
+    private static List<String> _relativeSegments(final ColumnPointer scope, final ColumnPointer pointer) {
+        final List<String> result = new ArrayList<>();
+        for (final ColumnPointer seg : scope.relativize(pointer)) {
+            result.add(seg.name());
+        }
+        return result;
+    }
+
+    private static int _commonPrefixLength(final List<String> a, final List<String> b, final int bLimit) {
+        final int n = Math.min(a.size(), bLimit);
+        int i = 0;
+        while (i < n && a.get(i).equals(b.get(i))) i++;
+        return i;
     }
 
     private void _addSortedByColumn(final List<Cell> cells, final Cell c) {

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/Column.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/Column.java
@@ -20,7 +20,7 @@ import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGrou
  * @see SpreadsheetSchema
  * @see ColumnPointer
  */
-@EqualsAndHashCode
+@EqualsAndHashCode(cacheStrategy = EqualsAndHashCode.CacheStrategy.LAZY)
 public final class Column {
 
     private static final String[] NO_ALIASES = new String[0];

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedListReadTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedListReadTest.java
@@ -465,4 +465,33 @@ class NestedListReadTest {
                 .containsExactly(null, null);
         assertThat(read.get(0).getTotal()).isNull();
     }
+
+    @DataGrid(mergeColumn = OptBoolean.TRUE)
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class GroupedOuter {
+        @DataColumn(anchor = true) int orderId;
+        @DataColumnGroup("Customer") CustomerInfo customer;
+        @DataColumnGroup("Items") List<LineItem> items;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class CustomerInfo {
+        @DataColumn("Name") String name;
+        @DataColumn("Region") String region;
+    }
+
+    @Test
+    void roundTrip_groupOnSingleNested_plus_groupOnList() throws Exception {
+        File file = tempDir.resolve("grouped-outer.xlsx").toFile();
+        SpreadsheetMapper m = new SpreadsheetMapper();
+        List<GroupedOuter> in = Arrays.asList(
+                new GroupedOuter(1, new CustomerInfo("Acme", "Seoul"),
+                        Arrays.asList(new LineItem("A", 3, 9), new LineItem("B", 5, 25))),
+                new GroupedOuter(2, new CustomerInfo("Globex", "Busan"),
+                        Arrays.asList(new LineItem("C", 7, 70))));
+        m.writeValue(file, in, GroupedOuter.class);
+
+        List<GroupedOuter> out = m.readValues(file, GroupedOuter.class);
+        assertThat(out).isEqualTo(in);
+    }
 }

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedListReadTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedListReadTest.java
@@ -494,4 +494,50 @@ class NestedListReadTest {
         List<GroupedOuter> out = m.readValues(file, GroupedOuter.class);
         assertThat(out).isEqualTo(in);
     }
+
+    @com.fasterxml.jackson.annotation.JsonTypeInfo(
+            use = com.fasterxml.jackson.annotation.JsonTypeInfo.Id.NAME,
+            include = com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY,
+            property = "method")
+    @com.fasterxml.jackson.annotation.JsonSubTypes({
+            @com.fasterxml.jackson.annotation.JsonSubTypes.Type(value = CardPay.class, name = "card"),
+            @com.fasterxml.jackson.annotation.JsonSubTypes.Type(value = CashPay.class, name = "cash")
+    })
+    interface PaymentMethod {}
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class CardPay implements PaymentMethod {
+        @DataColumn("Last4") String last4;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class CashPay implements PaymentMethod {
+        @DataColumn("Tendered") int tendered;
+    }
+
+    @DataGrid(mergeColumn = OptBoolean.TRUE)
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class PolymorphicOrder {
+        @DataColumn(anchor = true) int orderId;
+        @DataColumnGroup("Customer") CustomerInfo customer;
+        PaymentMethod payment;
+        @DataColumnGroup("Items") List<LineItem> items;
+    }
+
+    @Test
+    void roundTrip_polymorphic_plus_groupOnSingleNested_plus_groupOnList() throws Exception {
+        File file = tempDir.resolve("polymorphic-grouped-outer.xlsx").toFile();
+        SpreadsheetMapper m = new SpreadsheetMapper();
+        List<PolymorphicOrder> in = Arrays.asList(
+                new PolymorphicOrder(1, new CustomerInfo("Acme", "Seoul"),
+                        new CardPay("4242"),
+                        Arrays.asList(new LineItem("A", 3, 9))),
+                new PolymorphicOrder(2, new CustomerInfo("Globex", "Busan"),
+                        new CashPay(50),
+                        Arrays.asList(new LineItem("B", 5, 25))));
+        m.writeValue(file, in, PolymorphicOrder.class);
+
+        List<PolymorphicOrder> out = m.readValues(file, PolymorphicOrder.class);
+        assertThat(out).isEqualTo(in);
+    }
 }


### PR DESCRIPTION
## Summary

- **Bug fix**: `RecordTreeBuffer._emitRecord` emitted only the leaf segment of a column's pointer (`c.column.getPointer().name()`) as the JSON field name, which collapsed nested object paths (e.g. `customer/Name`) onto the outer record. Outer classes that did not declare the leaf field directly threw `UnrecognizedPropertyException` at read time. Reproduced via the integration example covered in #176 follow-up; isolated to `@DataColumnGroup` on a single nested object + nested-list + anchor combinations that `NestedListReadTest` did not previously cover.
- **Fix**: track the open-object path across cells and emit `START_OBJECT` / `END_OBJECT` for each prefix transition so the emitted JSON mirrors the column pointer hierarchy.
- **Regression test**: `NestedListReadTest.roundTrip_groupOnSingleNested_plus_groupOnList` and `roundTrip_polymorphic_plus_groupOnSingleNested_plus_groupOnList` pin the fix and exercise polymorphic + group + anchor union schema.
- **Perf**: `Column.hashCode` is `@EqualsAndHashCode(cacheStrategy = LAZY)` — the deep recursive hash (DataColumn.Value + DataColumnGroup.Hierarchy + SegmentPointer.hashCode) is computed once per Column instance instead of per HashMap lookup. async-profiler showed `Column.hashCode` going from 38 samples on the hot path to 0.
- **Perf**: `RecordTreeBuffer` now precomputes `Map<Column, List<String>> _relativeSegmentsByColumn` at construction, replacing the per-cell `scope.relativize(pointer)` + `new ArrayList<>()` work in `_emitRecord`.

## Measured impact

`NestedListBenchmark.nestedRead` @ `targetCells = 100000` (JMH default fork/warmup/measurement, GC profiler):

| | wall-time (ms/op) | gc.alloc.norm (B/op) |
|---|---|---|
| baseline (before this PR) | 57.894 | 76,063,794 |
| after `Column.hashCode` cache | 43.398 | 76,059,759 |
| after `relativeSegments` precompute | **39.424** | **56,235,410** |
| total change | **−32%** | **−26%** |

## Test plan

- [x] `./gradlew test` — full suite passes including the two new round-trip regressions.
- [x] `./gradlew jmh -Pjmh.includes='\.NestedListBenchmark\.nestedRead$' -Pjmh.params='targetCells=100000'` — wall-time and allocation numbers above.
- [x] async-profiler collapsed-cpu inspection — `Column.hashCode` no longer appears on the read hot path; remaining dominant frame is `SheetParser._readNext` (POI XML parsing, out of scope here).