### PR TITLE
Bump to 1.7.1

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -57,13 +57,13 @@ POI types (`Sheet`, `Workbook`) are first-class I/O targets — see [POI Integra
 <dependency>
     <groupId>io.github.scndry</groupId>
     <artifactId>jackson-dataformat-spreadsheet</artifactId>
-    <version>1.7.0</version>
+    <version>1.7.1</version>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-implementation "io.github.scndry:jackson-dataformat-spreadsheet:1.7.0"
+implementation "io.github.scndry:jackson-dataformat-spreadsheet:1.7.1"
 ```
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ Available on Maven Central:
 <dependency>
     <groupId>io.github.scndry</groupId>
     <artifactId>jackson-dataformat-spreadsheet</artifactId>
-    <version>1.7.0</version>
+    <version>1.7.1</version>
 </dependency>
 ```
 
 **Gradle:**
 ```groovy
-implementation "io.github.scndry:jackson-dataformat-spreadsheet:1.7.0"
+implementation "io.github.scndry:jackson-dataformat-spreadsheet:1.7.1"
 ```
 
 ### Requirements

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "io.github.scndry"
-version = "1.7.1-SNAPSHOT"
+version = "1.7.1"
 description = "Support for reading and writing Excel (XLSX/XLS) via Jackson abstractions."
 
 val title = "Jackson dataformat: Spreadsheet"


### PR DESCRIPTION
## Summary

Release 1.7.1 — bug fix + RecordTreeBuffer perf improvements (#177).

- Fix: nested object emit in anchor records (`RecordTreeBuffer._emitRecord` now tracks the open-object path so `@DataColumnGroup` on a single nested object + nested-list + anchor combinations read back correctly).
- Perf: `Column.hashCode` lazy cache + per-Column `relativeSegments` precompute. `NestedListBenchmark.nestedRead` @ 100K cells: −32% wall-time (57.9 → 39.4 ms/op), −26% allocation (76 → 56 MB/op).

## Test plan

- [x] `./gradlew test` — full suite passes (current main HEAD).
- [x] JMH measurements captured in #177.