### PR TITLE
Emit BigDecimal and BigInteger as numeric cells by default

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -627,7 +627,7 @@ class Bar {
 | `@JsonValue` / `@JsonCreator` on enum | Yes | Yes | Custom enum cell values |
 | `@JsonEnumDefaultValue` | Yes | — | Unknown enum fallback |
 | `@JsonSerialize` / `@JsonDeserialize` | Yes | Yes | Custom type conversion |
-| `@JsonFormat(shape = STRING)` | — | Yes | Force string cell for numeric types |
+| `@JsonFormat(shape = STRING)` | — | Yes | Force string cell for numeric types — use on `BigDecimal` / `BigInteger` to preserve precision |
 | `@JsonUnwrapped` | Yes | Yes | Flatten nested object — headers use leaf name (`x`) instead of path (`inner/x`); supports `prefix`/`suffix` for collision avoidance |
 | `@JsonIncludeProperties` | Yes | Yes | Whitelist fields |
 | `@JsonFilter` | — | Yes | Programmatic column filtering |

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/ser/SheetGenerator.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/ser/SheetGenerator.java
@@ -252,7 +252,7 @@ public final class SheetGenerator extends GeneratorBase {
     @Override
     public void writeNumber(final BigInteger v) throws IOException {
         _verifyValueWrite(WRITE_NUMBER);
-        _writer.writeString(v.toString());
+        _writer.writeNumeric(v.doubleValue());
     }
 
     @Override
@@ -270,8 +270,7 @@ public final class SheetGenerator extends GeneratorBase {
     @Override
     public void writeNumber(final BigDecimal v) throws IOException {
         _verifyValueWrite(WRITE_NUMBER);
-        _writer.writeString(isEnabled(StreamWriteFeature.WRITE_BIGDECIMAL_AS_PLAIN)
-                ? v.toPlainString() : v.toString());
+        _writer.writeNumeric(v.doubleValue());
     }
 
     @Override

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/BigNumberCellTypeTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/BigNumberCellTypeTest.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+import org.apache.poi.ss.usermodel.Cell;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -66,6 +67,57 @@ class BigNumberCellTypeTest {
             assertThat(wb.getSheetAt(0).getRow(1).getCell(0).getStringCellValue()).isEqualTo("1234.56");
             assertThat(wb.getSheetAt(0).getRow(1).getCell(1).getCellType()).isEqualTo(CellType.STRING);
             assertThat(wb.getSheetAt(0).getRow(1).getCell(1).getStringCellValue()).isEqualTo("987");
+        }
+    }
+
+    @Test
+    void bigDecimalPrecisionLoss_silentInDefaultPath() throws Exception {
+        final BigDecimal original = new BigDecimal("1.234567890123456789");
+        final double expected = original.doubleValue();
+        assertThat(new BigDecimal(Double.toString(expected))).isNotEqualTo(original);
+
+        File file = tempDir.resolve("precision-bigdecimal.xlsx").toFile();
+        new SpreadsheetMapper().writeValue(file,
+                Arrays.asList(new NumericDefault(original, BigInteger.ZERO)), NumericDefault.class);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Cell cell = wb.getSheetAt(0).getRow(1).getCell(0);
+            assertThat(cell.getCellType()).isEqualTo(CellType.NUMERIC);
+            assertThat(cell.getNumericCellValue()).isEqualTo(expected);
+        }
+    }
+
+    @Test
+    void bigIntegerBeyondDoubleRange_silentInDefaultPath() throws Exception {
+        final BigInteger original = BigInteger.valueOf(2).pow(60).add(BigInteger.ONE);
+        final double expected = original.doubleValue();
+        assertThat(java.math.BigDecimal.valueOf(expected).toBigInteger()).isNotEqualTo(original);
+
+        File file = tempDir.resolve("precision-biginteger.xlsx").toFile();
+        new SpreadsheetMapper().writeValue(file,
+                Arrays.asList(new NumericDefault(BigDecimal.ZERO, original)), NumericDefault.class);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Cell cell = wb.getSheetAt(0).getRow(1).getCell(1);
+            assertThat(cell.getCellType()).isEqualTo(CellType.NUMERIC);
+            assertThat(cell.getNumericCellValue()).isEqualTo(expected);
+        }
+    }
+
+    @Test
+    void poiUserModel_alsoEmitsNumeric() throws Exception {
+        File file = tempDir.resolve("poi-user-model.xlsx").toFile();
+        SpreadsheetMapper poiMapper = SpreadsheetMapper.builder()
+                .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL)
+                .build();
+        poiMapper.writeValue(file, Arrays.asList(new NumericDefault(
+                new BigDecimal("1234.56"), BigInteger.valueOf(987))), NumericDefault.class);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            assertThat(wb.getSheetAt(0).getRow(1).getCell(0).getCellType()).isEqualTo(CellType.NUMERIC);
+            assertThat(wb.getSheetAt(0).getRow(1).getCell(0).getNumericCellValue()).isEqualTo(1234.56);
+            assertThat(wb.getSheetAt(0).getRow(1).getCell(1).getCellType()).isEqualTo(CellType.NUMERIC);
+            assertThat(wb.getSheetAt(0).getRow(1).getCell(1).getNumericCellValue()).isEqualTo(987.0);
         }
     }
 }

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/BigNumberCellTypeTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/BigNumberCellTypeTest.java
@@ -1,0 +1,71 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import java.io.File;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BigNumberCellTypeTest {
+
+    @TempDir Path tempDir;
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class NumericDefault {
+        @DataColumn("amount") BigDecimal amount;
+        @DataColumn("ticks") BigInteger ticks;
+    }
+
+    @Test
+    void bigDecimalAndBigInteger_writeAsNumericByDefault() throws Exception {
+        File file = tempDir.resolve("default.xlsx").toFile();
+        SpreadsheetMapper mapper = new SpreadsheetMapper();
+        mapper.writeValue(file, Arrays.asList(new NumericDefault(
+                new BigDecimal("1234.56"), BigInteger.valueOf(987))), NumericDefault.class);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            assertThat(wb.getSheetAt(0).getRow(1).getCell(0).getCellType()).isEqualTo(CellType.NUMERIC);
+            assertThat(wb.getSheetAt(0).getRow(1).getCell(0).getNumericCellValue()).isEqualTo(1234.56);
+            assertThat(wb.getSheetAt(0).getRow(1).getCell(1).getCellType()).isEqualTo(CellType.NUMERIC);
+            assertThat(wb.getSheetAt(0).getRow(1).getCell(1).getNumericCellValue()).isEqualTo(987.0);
+        }
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class StringOptIn {
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        @DataColumn("amount") BigDecimal amount;
+        @JsonFormat(shape = JsonFormat.Shape.STRING)
+        @DataColumn("ticks") BigInteger ticks;
+    }
+
+    @Test
+    void jsonFormatStringOptIn_writesAsStringCell() throws Exception {
+        File file = tempDir.resolve("optin.xlsx").toFile();
+        SpreadsheetMapper mapper = new SpreadsheetMapper();
+        mapper.writeValue(file, Arrays.asList(new StringOptIn(
+                new BigDecimal("1234.56"), BigInteger.valueOf(987))), StringOptIn.class);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            assertThat(wb.getSheetAt(0).getRow(1).getCell(0).getCellType()).isEqualTo(CellType.STRING);
+            assertThat(wb.getSheetAt(0).getRow(1).getCell(0).getStringCellValue()).isEqualTo("1234.56");
+            assertThat(wb.getSheetAt(0).getRow(1).getCell(1).getCellType()).isEqualTo(CellType.STRING);
+            assertThat(wb.getSheetAt(0).getRow(1).getCell(1).getStringCellValue()).isEqualTo("987");
+        }
+    }
+}


### PR DESCRIPTION
Closes #176.

## Summary

- `SheetGenerator.writeNumber(BigDecimal)` and `writeNumber(BigInteger)` now call `_writer.writeNumeric(v.doubleValue())` instead of forcing string output. Default cell type for `BigDecimal` / `BigInteger` fields becomes `NUMERIC`, aligning with Jackson's `NumberSerializer.serialize` default contract.
- Precision-preserving opt-in uses the standard `@JsonFormat(shape = JsonFormat.Shape.STRING)` on the field. Jackson's `NumberSerializer.createContextual` switches to `bigDecimalAsStringSerializer()` automatically — no library-side serializer is added.
- Side effects unlocked: `@DataColumn(style = "currency")` (`#,##0.00` etc.) now applies; numeric `conditionalFormatting` operators (`greaterThan`, `between`, ...) compare against the actual value; Excel `SUM` / `AVERAGE` formulas evaluate correctly over the column.
- GUIDE Jackson Annotations table flags `@JsonFormat(shape = STRING)` as the precision opt-in for `BigDecimal` / `BigInteger`.

## Breaking change (1.8.0)

Users who relied on the implicit string default for precision preservation must add `@JsonFormat(shape = JsonFormat.Shape.STRING)` to the affected `BigDecimal` / `BigInteger` fields. `BigDecimal` values with `scale > 15` or `BigInteger` values with `bitLength > 53` lose precision silently in the default path (matches Jackson convention) — the opt-in keeps the original digits.

## Test plan

- [x] `./gradlew test` — full suite passes; existing round-trip tests for `BigDecimal` / `BigInteger` work under either cell type.
- [x] `BigNumberCellTypeTest`:
  - default `NUMERIC` cell type + value for both `BigDecimal` and `BigInteger`
  - `@JsonFormat(shape = STRING)` opt-in path emits `STRING` cells with the original digits
  - precision-loss is silent on the default path (`BigDecimal` scale > 15, `BigInteger` past 2^53) — freezes the contract
  - POI User Model write path (`USE_POI_USER_MODEL`) emits `NUMERIC` consistently with the streaming path