### PR TITLE
Add @DataColumn(shift) and @DataColumnGroup(shift) for column-position offset

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -514,7 +514,7 @@ Customizes individual column properties. Unset attributes inherit from the enclo
 
 When `USE_POI_USER_MODEL` is enabled, `autoSize` samples rows for bounded overhead (~1.5× write time at 100K rows) and may miss outliers between sample rows — pin a known column with `width` if exact fit matters.
 
-`shift` leaves N blank columns before a field on both read and write. Bounds: `0 ≤ shift ≤` Excel max columns; out-of-range values throw at schema build time. With `useHeader(true)`, a shift nested inside a `@DataColumnGroup` collapses the multi-row header to a single leaf row (group labels are skipped while cascade attributes still apply per-column). Shift inside a polymorphic subtype (`@JsonTypeInfo`) is rejected — polymorphic union is pointer-based dedup, incompatible with column-position adjustment. Apply shift on the polymorphic field itself instead.
+`shift` applies on both read and write. With `useHeader(true)`, a shift nested inside a `@DataColumnGroup` collapses the multi-row header to a single leaf row (group labels are skipped while cascade attributes still apply per-column).
 
 ### @DataColumnGroup
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -472,6 +472,8 @@ class Order {
 List<Order> orders = mapper.readValues(file, Order.class);
 ```
 
+The `anchor` flag is read-side only — the write path derives the multi-row layout from the nested list structure and ignores it.
+
 ## Annotations
 
 ### @DataGrid

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -342,6 +342,17 @@ try (XSSFWorkbook wb = new XSSFWorkbook(new File("template.xlsx"))) {
 }
 ```
 
+For columns whose values come from a template formula, leave the slot blank with [`@DataColumn(shift = N)`](#datacolumn):
+
+```java
+@DataGrid
+class Row {
+    @DataColumn String name;
+    @DataColumn int qty;
+    @DataColumn(shift = 1) double total;  // col 2 = template formula, col 3 = total
+}
+```
+
 **Reading from an open workbook:**
 
 ```java
@@ -493,12 +504,15 @@ Customizes individual column properties. Unset attributes inherit from the enclo
 | `minWidth` | `-1` (none) | Minimum column width |
 | `maxWidth` | `255` | Maximum column width |
 | `merge` | `DEFAULT` | Merge cells vertically |
+| `shift` | `0` | Number of blank columns to leave before this field |
 
 `autoSize` may not be accurate for [fullwidth forms](https://en.wikipedia.org/wiki/Halfwidth_and_fullwidth_forms) like [CJK characters](https://en.wikipedia.org/wiki/CJK_characters).
 
 `autoSize` is not supported in the default streaming write path — enable `USE_POI_USER_MODEL` or set `width` explicitly.
 
 When `USE_POI_USER_MODEL` is enabled, `autoSize` samples rows for bounded overhead (~1.5× write time at 100K rows) and may miss outliers between sample rows — pin a known column with `width` if exact fit matters.
+
+`shift` leaves N blank columns before a field on both read and write. With `useHeader(true)`, a shift nested inside a `@DataColumnGroup` collapses the multi-row header to a single leaf row (group labels are skipped while cascade attributes still apply per-column).
 
 ### @DataColumnGroup
 
@@ -516,6 +530,7 @@ Renders flattened columns from a nested object field under a shared group header
 | `minColumnWidth` | `-1` (none) | Default minimum width for child columns (cascade) |
 | `maxColumnWidth` | `255` | Default maximum width for child columns (cascade) |
 | `mergeColumn` | `DEFAULT` | Default merge for child columns (cascade) |
+| `shift` | `0` | Number of blank columns to leave before this group |
 
 The seven cascade attributes mirror `@DataGrid`'s corresponding defaults and act as an intermediate layer between the leaf `@DataColumn` and the enclosing `@DataGrid` — see *Attribute Resolution Order* below.
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -347,9 +347,9 @@ For columns whose values come from a template formula, leave the slot blank with
 ```java
 @DataGrid
 class Row {
-    @DataColumn String name;
-    @DataColumn int qty;
-    @DataColumn(shift = 1) double total;  // col 2 = template formula, col 3 = total
+    @DataColumn String name;   // column A
+    @DataColumn int qty;       // column B
+    @DataColumn(shift = 1) double total;  // column C left blank for template formula; total written to column D
 }
 ```
 
@@ -514,7 +514,7 @@ Customizes individual column properties. Unset attributes inherit from the enclo
 
 When `USE_POI_USER_MODEL` is enabled, `autoSize` samples rows for bounded overhead (~1.5× write time at 100K rows) and may miss outliers between sample rows — pin a known column with `width` if exact fit matters.
 
-`shift` leaves N blank columns before a field on both read and write. With `useHeader(true)`, a shift nested inside a `@DataColumnGroup` collapses the multi-row header to a single leaf row (group labels are skipped while cascade attributes still apply per-column).
+`shift` leaves N blank columns before a field on both read and write. Bounds: `0 ≤ shift ≤` Excel max columns; out-of-range values throw at schema build time. With `useHeader(true)`, a shift nested inside a `@DataColumnGroup` collapses the multi-row header to a single leaf row (group labels are skipped while cascade attributes still apply per-column). Shift inside a polymorphic subtype (`@JsonTypeInfo`) is rejected — polymorphic union is pointer-based dedup, incompatible with column-position adjustment. Apply shift on the polymorphic field itself instead.
 
 ### @DataColumnGroup
 
@@ -535,6 +535,8 @@ Renders flattened columns from a nested object field under a shared group header
 | `shift` | `0` | Number of blank columns to leave before this group |
 
 The seven cascade attributes mirror `@DataGrid`'s corresponding defaults and act as an intermediate layer between the leaf `@DataColumn` and the enclosing `@DataGrid` — see *Attribute Resolution Order* below.
+
+`shift` on a group leaves N blank columns before the group's first child column. Same bounds as `@DataColumn(shift)`.
 
 ```java
 @DataGrid

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SchemaGenerator.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SchemaGenerator.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.util.ClassUtil;
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.BackWriteProjection;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.SchemaShiftValidator;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.grid.GridConfigurer;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.generator.ColumnNameResolver;
@@ -82,7 +83,7 @@ public final class SchemaGenerator {
         final List<Column> columns = new ArrayList<>();
         for (final Column column : visitor) {
             columns.add(column);
-            if (log.isTraceEnabled()) {
+            if (column != null && log.isTraceEnabled()) {
                 log.trace(column.toString());
             }
         }
@@ -97,6 +98,7 @@ public final class SchemaGenerator {
                 _generatorSettings._stylesBuilder,
                 _generatorSettings._gridConfigurer);
         BackWriteProjection.warnIfScenario(schema);
+        SchemaShiftValidator.validate(schema);
         return schema;
     }
 

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SchemaGenerator.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SchemaGenerator.java
@@ -1,5 +1,12 @@
 package io.github.scndry.jackson.dataformat.spreadsheet;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.poi.ss.util.CellAddress;
+
+import lombok.extern.slf4j.Slf4j;
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -8,20 +15,16 @@ import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
 import com.fasterxml.jackson.databind.ser.DefaultSerializerProvider;
 import com.fasterxml.jackson.databind.ser.SerializerFactory;
 import com.fasterxml.jackson.databind.util.ClassUtil;
+
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
-import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.BackWriteProjection;
-import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.SchemaShiftValidator;
-import io.github.scndry.jackson.dataformat.spreadsheet.schema.grid.GridConfigurer;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.generator.ColumnNameResolver;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.generator.FormatVisitorWrapper;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.grid.GridConfigurer;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.BackWriteProjection;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.SchemaShiftValidator;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.style.StylesBuilder;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.poi.ss.util.CellAddress;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Slf4j
 public final class SchemaGenerator {

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/annotation/DataColumn.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/annotation/DataColumn.java
@@ -56,7 +56,11 @@ public @interface DataColumn {
     /** Row anchor for nested-list records (read-side only; the write path ignores this attribute). */
     boolean anchor() default false;
 
-    /** Number of blank columns to leave before this column. */
+    /**
+     * Number of blank columns to leave before this column. Must be {@code >= 0};
+     * values exceeding the spreadsheet max column count are rejected at schema
+     * build time. Inside a polymorphic subtype, any positive shift is rejected.
+     */
     int shift() default 0;
 
     @EqualsAndHashCode
@@ -76,6 +80,8 @@ public @interface DataColumn {
         private final boolean _anchor;
         private final int _shift;
 
+        /** @deprecated use the constructor that also accepts {@code shift}. */
+        @Deprecated
         public Value(final String name, final String comment,
                      final String style, final String headerStyle,
                      final int width, final OptBoolean autoSize,

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/annotation/DataColumn.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/annotation/DataColumn.java
@@ -56,11 +56,7 @@ public @interface DataColumn {
     /** Row anchor for nested-list records (read-side only; the write path ignores this attribute). */
     boolean anchor() default false;
 
-    /**
-     * Number of blank columns to leave before this column. Must be {@code >= 0};
-     * values exceeding the spreadsheet max column count are rejected at schema
-     * build time. Inside a polymorphic subtype, any positive shift is rejected.
-     */
+    /** Number of blank columns before this column (must be {@code >= 0}). */
     int shift() default 0;
 
     @EqualsAndHashCode

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/annotation/DataColumn.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/annotation/DataColumn.java
@@ -17,6 +17,10 @@ import com.fasterxml.jackson.annotation.OptBoolean;
  * Unset attributes inherit defaults from the enclosing
  * {@link DataGrid}.
  *
+ * <p>If combined with {@link com.fasterxml.jackson.annotation.JsonUnwrapped @JsonUnwrapped}
+ * on the same field, the column annotation is silently ignored — only the
+ * unwrapped inner properties contribute to the schema.
+ *
  * @see DataGrid
  * @see io.github.scndry.jackson.dataformat.spreadsheet.schema.Column
  */

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/annotation/DataColumn.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/annotation/DataColumn.java
@@ -53,11 +53,11 @@ public @interface DataColumn {
     /** Whether to merge cells vertically for repeated values. */
     OptBoolean merge() default OptBoolean.DEFAULT;
 
-    /**
-     * Marks this column as the row anchor for nested-list records.
-     * Read-side only — the write path ignores this attribute.
-     */
+    /** Row anchor for nested-list records (read-side only; the write path ignores this attribute). */
     boolean anchor() default false;
+
+    /** Number of blank columns to leave before this column. */
+    int shift() default 0;
 
     @EqualsAndHashCode
     final class Value implements JacksonAnnotationValue<DataColumn> {
@@ -74,12 +74,22 @@ public @interface DataColumn {
         private final int _maxWidth;
         private final OptBoolean _merge;
         private final boolean _anchor;
+        private final int _shift;
 
         public Value(final String name, final String comment,
                      final String style, final String headerStyle,
                      final int width, final OptBoolean autoSize,
                      final int minWidth, final int maxWidth, final OptBoolean merge,
                      final boolean anchor) {
+            this(name, comment, style, headerStyle, width, autoSize,
+                    minWidth, maxWidth, merge, anchor, 0);
+        }
+
+        public Value(final String name, final String comment,
+                     final String style, final String headerStyle,
+                     final int width, final OptBoolean autoSize,
+                     final int minWidth, final int maxWidth, final OptBoolean merge,
+                     final boolean anchor, final int shift) {
             _name = name;
             _comment = comment;
             _style = style;
@@ -90,17 +100,19 @@ public @interface DataColumn {
             _maxWidth = maxWidth;
             _merge = merge;
             _anchor = anchor;
+            _shift = shift;
         }
 
         private Value() {
             this("", "", "", "", DataGrid.DEFAULT_COLUMN_WIDTH, OptBoolean.DEFAULT,
                     DataGrid.DEFAULT_MIN_COLUMN_WIDTH, DataGrid.DEFAULT_MAX_COLUMN_WIDTH,
-                    OptBoolean.DEFAULT, false);
+                    OptBoolean.DEFAULT, false, 0);
         }
 
         private Value(final DataColumn ann) {
             this(ann.value(), ann.comment(), ann.style(), ann.headerStyle(), ann.width(),
-                    ann.autoSize(), ann.minWidth(), ann.maxWidth(), ann.merge(), ann.anchor()
+                    ann.autoSize(), ann.minWidth(), ann.maxWidth(), ann.merge(), ann.anchor(),
+                    ann.shift()
             );
         }
 
@@ -120,11 +132,12 @@ public @interface DataColumn {
         public int getMaxWidth() { return _maxWidth; }
         public OptBoolean getMerge() { return _merge; }
         public boolean getAnchor() { return _anchor; }
+        public int getShift() { return _shift; }
 
         public Value withName(final String name) {
             if (name == null || name.isEmpty()) return this;
             return new Value(name, _comment, _style, _headerStyle, _width, _autoSize,
-                    _minWidth, _maxWidth, _merge, _anchor);
+                    _minWidth, _maxWidth, _merge, _anchor, _shift);
         }
 
         public Value withDefaults(final DataGrid.Value defaults) {
@@ -139,7 +152,7 @@ public @interface DataColumn {
                     _maxWidth == DataGrid.DEFAULT_MAX_COLUMN_WIDTH
                             ? defaults.getMaxColumnWidth() : _maxWidth,
                     _merge == OptBoolean.DEFAULT ? defaults.getMergeColumn() : _merge,
-                    _anchor
+                    _anchor, _shift
             );
         }
 
@@ -170,6 +183,7 @@ public @interface DataColumn {
                     + ", maxWidth=" + _maxWidth
                     + ", merge=" + _merge
                     + ", anchor=" + _anchor
+                    + ", shift=" + _shift
                     + ")";
         }
     }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/annotation/DataColumnGroup.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/annotation/DataColumnGroup.java
@@ -79,6 +79,9 @@ public @interface DataColumnGroup {
     /** Whether to merge child cells vertically for repeated values. */
     OptBoolean mergeColumn() default OptBoolean.DEFAULT;
 
+    /** Number of blank columns to leave before this group. */
+    int shift() default 0;
+
     @EqualsAndHashCode
     final class Value implements JacksonAnnotationValue<DataColumnGroup> {
 
@@ -94,12 +97,23 @@ public @interface DataColumnGroup {
         private final int _minColumnWidth;
         private final int _maxColumnWidth;
         private final OptBoolean _mergeColumn;
+        private final int _shift;
 
         public Value(final String name, final String comment, final String headerStyle,
                      final String columnStyle, final String columnHeaderStyle,
                      final int columnWidth, final OptBoolean autoSizeColumn,
                      final int minColumnWidth, final int maxColumnWidth,
                      final OptBoolean mergeColumn) {
+            this(name, comment, headerStyle, columnStyle, columnHeaderStyle,
+                    columnWidth, autoSizeColumn,
+                    minColumnWidth, maxColumnWidth, mergeColumn, 0);
+        }
+
+        public Value(final String name, final String comment, final String headerStyle,
+                     final String columnStyle, final String columnHeaderStyle,
+                     final int columnWidth, final OptBoolean autoSizeColumn,
+                     final int minColumnWidth, final int maxColumnWidth,
+                     final OptBoolean mergeColumn, final int shift) {
             _name = name;
             _comment = comment;
             _headerStyle = headerStyle;
@@ -110,19 +124,21 @@ public @interface DataColumnGroup {
             _minColumnWidth = minColumnWidth;
             _maxColumnWidth = maxColumnWidth;
             _mergeColumn = mergeColumn;
+            _shift = shift;
         }
 
         private Value() {
             this("", "", "", "", "", DataGrid.DEFAULT_COLUMN_WIDTH, OptBoolean.DEFAULT,
                     DataGrid.DEFAULT_MIN_COLUMN_WIDTH, DataGrid.DEFAULT_MAX_COLUMN_WIDTH,
-                    OptBoolean.DEFAULT);
+                    OptBoolean.DEFAULT, 0);
         }
 
         private Value(final DataColumnGroup ann) {
             this(ann.value(), ann.comment(), ann.headerStyle(),
                     ann.columnStyle(), ann.columnHeaderStyle(),
                     ann.columnWidth(), ann.autoSizeColumn(),
-                    ann.minColumnWidth(), ann.maxColumnWidth(), ann.mergeColumn());
+                    ann.minColumnWidth(), ann.maxColumnWidth(), ann.mergeColumn(),
+                    ann.shift());
         }
 
         public static Value empty() { return EMPTY; }
@@ -141,6 +157,7 @@ public @interface DataColumnGroup {
         public int getMinColumnWidth() { return _minColumnWidth; }
         public int getMaxColumnWidth() { return _maxColumnWidth; }
         public OptBoolean getMergeColumn() { return _mergeColumn; }
+        public int getShift() { return _shift; }
 
         public boolean isEmpty() { return _name.isEmpty(); }
 
@@ -150,7 +167,7 @@ public @interface DataColumnGroup {
                     _headerStyle.isEmpty() ? defaults.getGroupHeaderStyle() : _headerStyle,
                     _columnStyle, _columnHeaderStyle,
                     _columnWidth, _autoSizeColumn,
-                    _minColumnWidth, _maxColumnWidth, _mergeColumn);
+                    _minColumnWidth, _maxColumnWidth, _mergeColumn, _shift);
         }
 
         /** Returns this group's child-column defaults as a
@@ -176,7 +193,8 @@ public @interface DataColumnGroup {
                     + ", autoSizeColumn=" + _autoSizeColumn
                     + ", minColumnWidth=" + _minColumnWidth
                     + ", maxColumnWidth=" + _maxColumnWidth
-                    + ", mergeColumn=" + _mergeColumn + ")";
+                    + ", mergeColumn=" + _mergeColumn
+                    + ", shift=" + _shift + ")";
         }
     }
 

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/annotation/DataColumnGroup.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/annotation/DataColumnGroup.java
@@ -79,11 +79,7 @@ public @interface DataColumnGroup {
     /** Whether to merge child cells vertically for repeated values. */
     OptBoolean mergeColumn() default OptBoolean.DEFAULT;
 
-    /**
-     * Number of blank columns to leave before this group. Must be {@code >= 0};
-     * values exceeding the spreadsheet max column count are rejected at schema
-     * build time.
-     */
+    /** Number of blank columns before this group (must be {@code >= 0}). */
     int shift() default 0;
 
     @EqualsAndHashCode

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/annotation/DataColumnGroup.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/annotation/DataColumnGroup.java
@@ -79,7 +79,11 @@ public @interface DataColumnGroup {
     /** Whether to merge child cells vertically for repeated values. */
     OptBoolean mergeColumn() default OptBoolean.DEFAULT;
 
-    /** Number of blank columns to leave before this group. */
+    /**
+     * Number of blank columns to leave before this group. Must be {@code >= 0};
+     * values exceeding the spreadsheet max column count are rejected at schema
+     * build time.
+     */
     int shift() default 0;
 
     @EqualsAndHashCode
@@ -99,6 +103,8 @@ public @interface DataColumnGroup {
         private final OptBoolean _mergeColumn;
         private final int _shift;
 
+        /** @deprecated use the constructor that also accepts {@code shift}. */
+        @Deprecated
         public Value(final String name, final String comment, final String headerStyle,
                      final String columnStyle, final String columnHeaderStyle,
                      final int columnWidth, final OptBoolean autoSizeColumn,

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLSheetWriter.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLSheetWriter.java
@@ -134,6 +134,7 @@ public final class SSMLSheetWriter implements SheetWriter {
 
     private void _warnIfAutoSizeUsed() {
         for (final Column column : _schema) {
+            if (column == null) continue;
             if (column.getValue().isAutoSize()) {
                 log.warn("autoSize on column '{}' is ignored in default streaming mode."
                         + " Enable USE_POI_USER_MODEL or set an explicit width to apply autoSize.",
@@ -269,6 +270,7 @@ public final class SSMLSheetWriter implements SheetWriter {
         if (size <= 1) return;
         final List<Column> columns = _schema.getColumns(pointer);
         for (final Column column : columns) {
+            if (column == null) continue;
             if (!column.isMerge()) continue;
             if (pointer.relativize(column.getPointer()).contains(ColumnPointer.array())) continue;
             final int col = _schema.columnIndexOf(column);
@@ -491,6 +493,7 @@ public final class SSMLSheetWriter implements SheetWriter {
         final int[] columnStyleIndex = new int[columns.size()];
         for (int i = 0; i < columns.size(); i++) {
             final Column column = columns.get(i);
+            if (column == null) continue;
             final String name = header
                     ? column.getValue().getHeaderStyle()
                     : column.getValue().getStyle();

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ss/POISheetWriter.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ss/POISheetWriter.java
@@ -216,6 +216,7 @@ public final class POISheetWriter implements SheetWriter {
         if (size <= 1) return;
         final List<Column> columns = _schema.getColumns(filter);
         for (final Column column : columns) {
+            if (column == null) continue;
             if (!column.isMerge()) continue;
             if (filter.relativize(column.getPointer()).contains(ColumnPointer.array())) continue;
             final int col = _schema.columnIndexOf(column);

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ss/POISheetWriter.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ss/POISheetWriter.java
@@ -271,6 +271,7 @@ public final class POISheetWriter implements SheetWriter {
     @Override
     public void adjustColumnWidth() {
         for (final Column column : _schema) {
+            if (column == null) continue;
             final int col = _schema.columnIndexOf(column);
             final DataColumn.Value value = column.getValue();
             double width;

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
@@ -162,17 +162,37 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
     }
 
     public int getDataRow() {
-        return _origin.getRow() + (usesHeader() ? _headerRowCount : 0);
+        return _origin.getRow() + (usesHeader() ? effectiveHeaderRowCount() : 0);
     }
 
     public int getHeaderRowCount() {
-        return _headerRowCount;
+        return effectiveHeaderRowCount();
     }
 
     /** Row index of the leaf header row (the row carrying column names).
      *  Collapses to the origin row when {@link #usesHeader()} is disabled. */
     public int getLeafHeaderRow() {
-        return _origin.getRow() + (usesHeader() ? _headerRowCount - 1 : 0);
+        return _origin.getRow() + (usesHeader() ? effectiveHeaderRowCount() - 1 : 0);
+    }
+
+    /** Effective header rows: shift collapses the layout to a single leaf row
+     *  (group label rows are skipped; cascade attributes still apply per-column). */
+    private int effectiveHeaderRowCount() {
+        return anyNestedShift() ? 1 : _headerRowCount;
+    }
+
+    /** Whether any column inside a {@code @DataColumnGroup} carries a positive
+     *  shift — the only case that collapses the multi-row header to a single
+     *  leaf row (the gap would otherwise leave a torn-tooth slot inside a
+     *  group label span). Flat shift and group-level shift leave the header
+     *  layout intact (sparse cells or external blank gaps). */
+    public boolean anyNestedShift() {
+        for (final Column column : _columns) {
+            if (column == null) continue;
+            if (column.getValue().getShift() > 0
+                    && column.getGroupHierarchy().depth() > 0) return true;
+        }
+        return false;
     }
 
     /** Walks the header region (leaf headers, group cells, vertical merges)
@@ -181,6 +201,16 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
     public void forEachHeaderCell(final HeaderLayoutVisitor visitor) {
         if (!usesHeader()) return;
         final int originRow = _origin.getRow();
+        if (anyNestedShift()) {
+            // Single leaf row: emit every column header (flat + grouped leaves)
+            // on the origin row. Group label rows and vertical merges are skipped;
+            // cascade attributes still apply per-column.
+            for (final Column column : _columns) {
+                if (column == null) continue;
+                visitor.visitColumnHeader(originRow, columnIndexOf(column), column);
+            }
+            return;
+        }
         for (int depth = 0; depth < _headerRowCount; depth++) {
             _visitHeaderRow(originRow + depth, depth, visitor);
         }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
@@ -133,6 +133,11 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
         return SCHEMA_TYPE;
     }
 
+    /**
+     * Iterates the schema's columns in declared order. May yield {@code null}
+     * at sparse gap positions introduced by {@code @DataColumn(shift)} or
+     * {@code @DataColumnGroup(shift)} — callers must null-check each element.
+     */
     @Override
     public Iterator<Column> iterator() {
         return _columns.iterator();
@@ -142,6 +147,11 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
         return findColumn(reference.getColumn());
     }
 
+    /**
+     * Returns the column at the given sheet column index, or {@code null} if
+     * the index falls outside the schema range OR lands on a sparse gap
+     * position introduced by shift.
+     */
     public Column findColumn(final int column) {
         if (_columns.isEmpty()) {
             return null;
@@ -157,6 +167,13 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
         return getColumn(reference.getColumn());
     }
 
+    /**
+     * Returns the column at the given sheet column index. Throws
+     * {@link IndexOutOfBoundsException} when out of range; returns {@code null}
+     * at sparse gap positions introduced by shift. The {@code null}-on-gap
+     * behavior diverges from typical {@code get} semantics — callers that
+     * need a strict non-null contract should prefer explicit index checks.
+     */
     public Column getColumn(final int column) {
         return _columns.get(column - getOriginColumn());
     }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
@@ -181,12 +181,7 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
         return anyNestedShift() ? 1 : _headerRowCount;
     }
 
-    /** Whether any column inside a {@code @DataColumnGroup} carries a positive
-     *  shift — the only case that collapses the multi-row header to a single
-     *  leaf row (the gap would otherwise leave a torn-tooth slot inside a
-     *  group label span). Flat shift and group-level shift leave the header
-     *  layout intact (sparse cells or external blank gaps). */
-    public boolean anyNestedShift() {
+    private boolean anyNestedShift() {
         for (final Column column : _columns) {
             if (column == null) continue;
             if (column.getValue().getShift() > 0

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
@@ -294,7 +294,7 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
         }
         return _columns
                 .stream()
-                .filter(c -> c
+                .filter(c -> c != null && c
                 .getPointer()
                 .startsWith(filter)).collect(Collectors
                 .toList());

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
@@ -133,11 +133,6 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
         return SCHEMA_TYPE;
     }
 
-    /**
-     * Iterates the schema's columns in declared order. May yield {@code null}
-     * at sparse gap positions introduced by {@code @DataColumn(shift)} or
-     * {@code @DataColumnGroup(shift)} — callers must null-check each element.
-     */
     @Override
     public Iterator<Column> iterator() {
         return _columns.iterator();
@@ -147,11 +142,6 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
         return findColumn(reference.getColumn());
     }
 
-    /**
-     * Returns the column at the given sheet column index, or {@code null} if
-     * the index falls outside the schema range OR lands on a sparse gap
-     * position introduced by shift.
-     */
     public Column findColumn(final int column) {
         if (_columns.isEmpty()) {
             return null;
@@ -167,13 +157,6 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
         return getColumn(reference.getColumn());
     }
 
-    /**
-     * Returns the column at the given sheet column index. Throws
-     * {@link IndexOutOfBoundsException} when out of range; returns {@code null}
-     * at sparse gap positions introduced by shift. The {@code null}-on-gap
-     * behavior diverges from typical {@code get} semantics — callers that
-     * need a strict non-null contract should prefer explicit index checks.
-     */
     public Column getColumn(final int column) {
         return _columns.get(column - getOriginColumn());
     }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
@@ -197,9 +197,6 @@ public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
         if (!usesHeader()) return;
         final int originRow = _origin.getRow();
         if (anyNestedShift()) {
-            // Single leaf row: emit every column header (flat + grouped leaves)
-            // on the origin row. Group label rows and vertical merges are skipped;
-            // cascade attributes still apply per-column.
             for (final Column column : _columns) {
                 if (column == null) continue;
                 visitor.visitColumnHeader(originRow, columnIndexOf(column), column);

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/generator/FormatVisitorWrapper.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/generator/FormatVisitorWrapper.java
@@ -108,4 +108,10 @@ public final class FormatVisitorWrapper
             add(column);
         }
     }
+
+    void addShift(final int n) {
+        for (int i = 0; i < n; i++) {
+            _columns.add(null);
+        }
+    }
 }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/generator/FormatVisitorWrapper.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/generator/FormatVisitorWrapper.java
@@ -110,6 +110,7 @@ public final class FormatVisitorWrapper
     }
 
     void addShift(final int n) {
+        if (n <= 0) return;
         for (int i = 0; i < n; i++) {
             _columns.add(null);
         }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/generator/ObjectFormatVisitor.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/generator/ObjectFormatVisitor.java
@@ -122,8 +122,11 @@ final class ObjectFormatVisitor extends JsonObjectFormatVisitor.Base {
             ser.acceptJsonFormatVisitor(visitor, subType);
             for (final Column col : visitor) {
                 if (col == null) {
-                    _wrapper.add(null);
-                    continue;
+                    throw new IllegalStateException(
+                            "Shift inside polymorphic subtype "
+                                    + subType.getRawClass().getSimpleName()
+                                    + " is not supported (polymorphic field at "
+                                    + pointer + "). Place shift outside the polymorphic field.");
                 }
                 if (seen.add(col.getPointer().toString())) {
                     _wrapper.add(col);

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/generator/ObjectFormatVisitor.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/generator/ObjectFormatVisitor.java
@@ -86,9 +86,11 @@ final class ObjectFormatVisitor extends JsonObjectFormatVisitor.Base {
             }
             final String columnName = _resolveColumnName(prop);
             final String[] aliases = _aliases(prop);
+            _wrapper.addShift(columnValue.getShift());
             _wrapper.add(new Column(pointer, columnValue.withName(columnName),
                     _wrapper.getGroupHierarchy(), type, aliases));
         } else {
+            _wrapper.addShift(groupValue.getShift());
             _wrapper.addAll(visitor);
         }
     }
@@ -103,6 +105,7 @@ final class ObjectFormatVisitor extends JsonObjectFormatVisitor.Base {
         // Type discriminator column
         final String discriminator = typeInfo.property();
         final ColumnPointer discPointer = pointer.resolve(discriminator);
+        _wrapper.addShift(columnValue.getShift());
         _wrapper.add(new Column(discPointer,
                 columnValue.withName(discriminator),
                 hierarchy,
@@ -118,6 +121,10 @@ final class ObjectFormatVisitor extends JsonObjectFormatVisitor.Base {
             final JsonSerializer<Object> ser = _provider.findValueSerializer(subType);
             ser.acceptJsonFormatVisitor(visitor, subType);
             for (final Column col : visitor) {
+                if (col == null) {
+                    _wrapper.add(null);
+                    continue;
+                }
                 if (seen.add(col.getPointer().toString())) {
                     _wrapper.add(col);
                 }
@@ -173,7 +180,8 @@ final class ObjectFormatVisitor extends JsonObjectFormatVisitor.Base {
         return new DataColumnGroup.Value(name, ann.comment(), ann.headerStyle(),
                 ann.columnStyle(), ann.columnHeaderStyle(),
                 ann.columnWidth(), ann.autoSizeColumn(),
-                ann.minColumnWidth(), ann.maxColumnWidth(), ann.mergeColumn())
+                ann.minColumnWidth(), ann.maxColumnWidth(), ann.mergeColumn(),
+                ann.shift())
                 .withDefaults(grid);
     }
 

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/SchemaShiftValidator.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/SchemaShiftValidator.java
@@ -1,0 +1,56 @@
+package io.github.scndry.jackson.dataformat.spreadsheet.schema.internal;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
+
+/**
+ * Schema-build-time validation for the {@code shift} attribute on
+ * {@code @DataColumn} and {@code @DataColumnGroup}.
+ *
+ * <p>Rules:
+ * <ul>
+ *   <li>{@code shift < 0} → reject.</li>
+ *   <li>{@code useHeader=true} with any {@code shift > 0} → reject.</li>
+ * </ul>
+ *
+ * <p>Not part of the public API. Classes under
+ * {@code io.github.scndry.jackson.dataformat.spreadsheet.schema.internal}
+ * may change without notice between releases — do not invoke directly
+ * from application code.
+ */
+public final class SchemaShiftValidator {
+
+    private SchemaShiftValidator() {
+    }
+
+    /** Throws {@link IllegalStateException} when the schema violates the shift contract. */
+    public static void validate(final SpreadsheetSchema schema) {
+        boolean anyShift = false;
+        for (final Column column : schema) {
+            if (column == null) continue;
+            final int columnShift = column.getValue().getShift();
+            if (columnShift < 0) {
+                throw new IllegalStateException(
+                        "Column '" + column.getName() + "' has invalid shift "
+                                + columnShift + " (must be >= 0).");
+            }
+            if (columnShift > 0) anyShift = true;
+            for (final DataColumnGroup.Value group : column.getGroupHierarchy()) {
+                final int groupShift = group.getShift();
+                if (groupShift < 0) {
+                    throw new IllegalStateException(
+                            "Column group '" + group.getName() + "' has invalid shift "
+                                    + groupShift + " (must be >= 0).");
+                }
+                if (groupShift > 0) anyShift = true;
+            }
+        }
+        if (anyShift && schema.usesHeader()) {
+            throw new IllegalStateException(
+                    "@DataColumn/@DataColumnGroup(shift) requires useHeader(false). "
+                            + "Shifted columns lack header cells and break the header row. "
+                            + "Either disable headers or remove the shift attributes.");
+        }
+    }
+}

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/SchemaShiftValidator.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/SchemaShiftValidator.java
@@ -1,5 +1,12 @@
 package io.github.scndry.jackson.dataformat.spreadsheet.schema.internal;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.poi.ss.SpreadsheetVersion;
+
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
@@ -8,7 +15,14 @@ import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
  * Schema-build-time validation for the {@code shift} attribute on
  * {@code @DataColumn} and {@code @DataColumnGroup}.
  *
- * <p>Rule: {@code shift < 0} is rejected.
+ * <p>Rules:
+ * <ul>
+ *   <li>{@code shift < 0} is rejected.</li>
+ *   <li>{@code shift > } {@link SpreadsheetVersion#EXCEL2007 EXCEL2007}
+ *       max columns ({@value MAX_SHIFT}) is rejected.</li>
+ * </ul>
+ *
+ * <p>All violations across the schema are collected and reported together.
  *
  * <p>Not part of the public API. Classes under
  * {@code io.github.scndry.jackson.dataformat.spreadsheet.schema.internal}
@@ -17,27 +31,37 @@ import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
  */
 public final class SchemaShiftValidator {
 
+    private static final int MAX_SHIFT = SpreadsheetVersion.EXCEL2007.getMaxColumns();
+
     private SchemaShiftValidator() {
     }
 
-    /** Throws {@link IllegalStateException} when the schema violates the shift contract. */
+    /** Throws {@link IllegalStateException} listing every violation when the
+     *  schema breaks the shift contract. */
     public static void validate(final SpreadsheetSchema schema) {
+        final List<String> violations = new ArrayList<>();
+        final Set<DataColumnGroup.Value> seenGroups = new HashSet<>();
         for (final Column column : schema) {
             if (column == null) continue;
-            final int columnShift = column.getValue().getShift();
-            if (columnShift < 0) {
-                throw new IllegalStateException(
-                        "Column '" + column.getName() + "' has invalid shift "
-                                + columnShift + " (must be >= 0).");
-            }
+            _check(violations, "Column '" + column.getName() + "'", column.getValue().getShift());
             for (final DataColumnGroup.Value group : column.getGroupHierarchy()) {
-                final int groupShift = group.getShift();
-                if (groupShift < 0) {
-                    throw new IllegalStateException(
-                            "Column group '" + group.getName() + "' has invalid shift "
-                                    + groupShift + " (must be >= 0).");
+                if (seenGroups.add(group)) {
+                    _check(violations, "Column group '" + group.getName() + "'", group.getShift());
                 }
             }
+        }
+        if (violations.isEmpty()) return;
+        final StringBuilder sb = new StringBuilder("Shift invariant violation:");
+        for (final String v : violations) sb.append("\n - ").append(v);
+        sb.append("\n\nshift must be in [0, ").append(MAX_SHIFT).append("].");
+        throw new IllegalStateException(sb.toString());
+    }
+
+    private static void _check(final List<String> out, final String subject, final int shift) {
+        if (shift < 0) {
+            out.add(subject + " has invalid shift " + shift + " (must be >= 0)");
+        } else if (shift > MAX_SHIFT) {
+            out.add(subject + " has invalid shift " + shift + " (must be <= " + MAX_SHIFT + ")");
         }
     }
 }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/SchemaShiftValidator.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/SchemaShiftValidator.java
@@ -1,10 +1,5 @@
 package io.github.scndry.jackson.dataformat.spreadsheet.schema.internal;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import org.apache.poi.ss.SpreadsheetVersion;
 
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
@@ -15,7 +10,7 @@ import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
  * Schema-build-time validation for the {@code shift} attribute on
  * {@code @DataColumn} and {@code @DataColumnGroup}: rejects negative
  * values and values exceeding {@link SpreadsheetVersion#EXCEL2007} max
- * columns. All violations are collected and reported together.
+ * columns.
  *
  * <p>Not part of the public API. Classes under
  * {@code io.github.scndry.jackson.dataformat.spreadsheet.schema.internal}
@@ -29,32 +24,25 @@ public final class SchemaShiftValidator {
     private SchemaShiftValidator() {
     }
 
-    /** Throws {@link IllegalStateException} listing every violation when the
-     *  schema breaks the shift contract. */
+    /** Throws {@link IllegalStateException} on the first invalid shift. */
     public static void validate(final SpreadsheetSchema schema) {
-        final List<String> violations = new ArrayList<>();
-        final Set<DataColumnGroup.Value> seenGroups = new HashSet<>();
         for (final Column column : schema) {
             if (column == null) continue;
-            _check(violations, "Column '" + column.getName() + "'", column.getValue().getShift());
+            _check("Column '" + column.getName() + "'", column.getValue().getShift());
             for (final DataColumnGroup.Value group : column.getGroupHierarchy()) {
-                if (seenGroups.add(group)) {
-                    _check(violations, "Column group '" + group.getName() + "'", group.getShift());
-                }
+                _check("Column group '" + group.getName() + "'", group.getShift());
             }
         }
-        if (violations.isEmpty()) return;
-        final StringBuilder sb = new StringBuilder("Shift invariant violation:");
-        for (final String v : violations) sb.append("\n - ").append(v);
-        sb.append("\n\nshift must be in [0, ").append(MAX_SHIFT).append("].");
-        throw new IllegalStateException(sb.toString());
     }
 
-    private static void _check(final List<String> out, final String subject, final int shift) {
+    private static void _check(final String subject, final int shift) {
         if (shift < 0) {
-            out.add(subject + " has invalid shift " + shift + " (must be >= 0)");
-        } else if (shift > MAX_SHIFT) {
-            out.add(subject + " has invalid shift " + shift + " (must be <= " + MAX_SHIFT + ")");
+            throw new IllegalStateException(
+                    subject + " has invalid shift " + shift + " (must be >= 0)");
+        }
+        if (shift > MAX_SHIFT) {
+            throw new IllegalStateException(
+                    subject + " has invalid shift " + shift + " (must be <= " + MAX_SHIFT + ")");
         }
     }
 }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/SchemaShiftValidator.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/SchemaShiftValidator.java
@@ -13,16 +13,9 @@ import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
 
 /**
  * Schema-build-time validation for the {@code shift} attribute on
- * {@code @DataColumn} and {@code @DataColumnGroup}.
- *
- * <p>Rules:
- * <ul>
- *   <li>{@code shift < 0} is rejected.</li>
- *   <li>{@code shift > } {@link SpreadsheetVersion#EXCEL2007 EXCEL2007}
- *       max columns ({@value MAX_SHIFT}) is rejected.</li>
- * </ul>
- *
- * <p>All violations across the schema are collected and reported together.
+ * {@code @DataColumn} and {@code @DataColumnGroup}: rejects negative
+ * values and values exceeding {@link SpreadsheetVersion#EXCEL2007} max
+ * columns. All violations are collected and reported together.
  *
  * <p>Not part of the public API. Classes under
  * {@code io.github.scndry.jackson.dataformat.spreadsheet.schema.internal}

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/SchemaShiftValidator.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/SchemaShiftValidator.java
@@ -8,11 +8,7 @@ import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
  * Schema-build-time validation for the {@code shift} attribute on
  * {@code @DataColumn} and {@code @DataColumnGroup}.
  *
- * <p>Rules:
- * <ul>
- *   <li>{@code shift < 0} → reject.</li>
- *   <li>{@code useHeader=true} with any {@code shift > 0} → reject.</li>
- * </ul>
+ * <p>Rule: {@code shift < 0} is rejected.
  *
  * <p>Not part of the public API. Classes under
  * {@code io.github.scndry.jackson.dataformat.spreadsheet.schema.internal}
@@ -26,7 +22,6 @@ public final class SchemaShiftValidator {
 
     /** Throws {@link IllegalStateException} when the schema violates the shift contract. */
     public static void validate(final SpreadsheetSchema schema) {
-        boolean anyShift = false;
         for (final Column column : schema) {
             if (column == null) continue;
             final int columnShift = column.getValue().getShift();
@@ -35,7 +30,6 @@ public final class SchemaShiftValidator {
                         "Column '" + column.getName() + "' has invalid shift "
                                 + columnShift + " (must be >= 0).");
             }
-            if (columnShift > 0) anyShift = true;
             for (final DataColumnGroup.Value group : column.getGroupHierarchy()) {
                 final int groupShift = group.getShift();
                 if (groupShift < 0) {
@@ -43,14 +37,7 @@ public final class SchemaShiftValidator {
                             "Column group '" + group.getName() + "' has invalid shift "
                                     + groupShift + " (must be >= 0).");
                 }
-                if (groupShift > 0) anyShift = true;
             }
-        }
-        if (anyShift && schema.usesHeader()) {
-            throw new IllegalStateException(
-                    "@DataColumn/@DataColumnGroup(shift) requires useHeader(false). "
-                            + "Shifted columns lack header cells and break the header row. "
-                            + "Either disable headers or remove the shift attributes.");
         }
     }
 }

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/AnnotationValueTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/AnnotationValueTest.java
@@ -72,7 +72,7 @@ class AnnotationValueTest {
 
     @Test
     void dataColumnWithName() {
-        DataColumn.Value val = new DataColumn.Value("original", "", "", "", 0, OptBoolean.DEFAULT, 0, 0, OptBoolean.DEFAULT, false);
+        DataColumn.Value val = new DataColumn.Value("original", "", "", "", 0, OptBoolean.DEFAULT, 0, 0, OptBoolean.DEFAULT, false, 0);
         DataColumn.Value renamed = val.withName("renamed");
         assertThat(renamed.getName()).isEqualTo("renamed");
         assertThat(renamed.getStyle()).isEqualTo(val.getStyle());
@@ -80,7 +80,7 @@ class AnnotationValueTest {
 
     @Test
     void dataColumnWithDefaults() {
-        DataColumn.Value field = new DataColumn.Value("field", "", "fieldStyle", "", 10, OptBoolean.DEFAULT, 0, 0, OptBoolean.DEFAULT, false);
+        DataColumn.Value field = new DataColumn.Value("field", "", "fieldStyle", "", 10, OptBoolean.DEFAULT, 0, 0, OptBoolean.DEFAULT, false, 0);
         DataGrid.Value grid = new DataGrid.Value("gridStyle", "gridHeaderStyle", "",
                 20, OptBoolean.TRUE, 5, 50, OptBoolean.TRUE);
         DataColumn.Value result = field.withDefaults(grid);

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/AttributeResolutionTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/AttributeResolutionTest.java
@@ -41,7 +41,7 @@ class AttributeResolutionTest {
         return new DataColumnGroup.Value(name, "", headerStyle,
                 "", "", DataGrid.DEFAULT_COLUMN_WIDTH, OptBoolean.DEFAULT,
                 DataGrid.DEFAULT_MIN_COLUMN_WIDTH, DataGrid.DEFAULT_MAX_COLUMN_WIDTH,
-                OptBoolean.DEFAULT);
+                OptBoolean.DEFAULT, 0);
     }
 
     private static DataColumnGroup.Value groupWithChildDefaults(
@@ -51,7 +51,7 @@ class AttributeResolutionTest {
                 columnStyle, columnHeaderStyle,
                 DataGrid.DEFAULT_COLUMN_WIDTH, OptBoolean.DEFAULT,
                 DataGrid.DEFAULT_MIN_COLUMN_WIDTH, DataGrid.DEFAULT_MAX_COLUMN_WIDTH,
-                merge);
+                merge, 0);
     }
 
     @Test

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/DataColumnShiftTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/DataColumnShiftTest.java
@@ -211,8 +211,6 @@ class DataColumnShiftTest {
 
     @Test
     void groupShift_withHeader_collapsesToSingleLeafRow() throws Exception {
-        // useHeader=true + nested-group shift: group label row disappears,
-        // every leaf header lands on the origin row, and data starts at row 1.
         final SpreadsheetMapper headerMapper = SpreadsheetMapper.builder().useHeader(true).build();
         File file = tempFile("group-shift-header.xlsx");
 
@@ -224,14 +222,11 @@ class DataColumnShiftTest {
         try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
             Sheet sheet = wb.getSheetAt(0);
             Row header = sheet.getRow(0);
-            // Nested leaves render their pointer path because the leaf @DataColumn
-            // has no explicit name — Column.getName() falls back to pointer.toString().
             assertThat(header.getCell(0).getStringCellValue()).isEqualTo("orderId");
             assertThat(header.getCell(2).getStringCellValue()).isEqualTo("items/[]/product");
             assertThat(header.getCell(3).getStringCellValue()).isEqualTo("items/[]/qty");
             assertThat(header.getCell(5).getStringCellValue()).isEqualTo("items/[]/amount");
             assertThat(header.getCell(6).getStringCellValue()).isEqualTo("total");
-            // "Items" group label must not appear anywhere in the header region.
             for (int r = 0; r <= 1; r++) {
                 Row row = sheet.getRow(r);
                 if (row == null) continue;
@@ -239,15 +234,12 @@ class DataColumnShiftTest {
                     assertThat(cell.toString()).isNotEqualTo("Items");
                 }
             }
-            // Data begins at row 1 (single header row).
             assertThat(sheet.getRow(1).getCell(0).getStringCellValue()).isEqualTo("ORD-1");
         }
     }
 
     @Test
     void flatShift_withColumnReordering_roundTrips() throws Exception {
-        // Gap column has no header text, so column-reordering treats it as
-        // unmatched. Round-trip must still recover the original record.
         final SpreadsheetMapper reorderMapper = SpreadsheetMapper.builder()
                 .useHeader(true)
                 .columnReordering(true)
@@ -265,18 +257,12 @@ class DataColumnShiftTest {
 
     @Test
     void polymorphicShift_onPolymorphicField_isAllowed() {
-        // Shift on the polymorphic field itself precedes the discriminator
-        // column — well-defined (single column-position adjustment, no subtype
-        // ambiguity).
         assertThatCode(() -> mapper.sheetSchemaFor(PolymorphicShiftOnField.class))
                 .doesNotThrowAnyException();
     }
 
     @Test
     void polymorphicShift_insideSubtype_isRejected() {
-        // Shift inside a polymorphic subtype is ill-defined: polymorphic union
-        // is pointer-based dedup, while shift is column-position adjustment —
-        // two different axes that cannot reconcile across subtypes.
         assertThatThrownBy(() -> mapper.sheetSchemaFor(PolymorphicSubtypeShift.class))
                 .isInstanceOf(com.fasterxml.jackson.databind.exc.InvalidDefinitionException.class)
                 .hasMessageContaining("polymorphic subtype")

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/DataColumnShiftTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/DataColumnShiftTest.java
@@ -26,6 +26,7 @@ import io.github.scndry.jackson.dataformat.spreadsheet.SpreadsheetFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Integration tests for {@code @DataColumn(shift)} and
@@ -88,12 +89,27 @@ class DataColumnShiftTest {
     @Data @NoArgsConstructor @AllArgsConstructor
     static class Cash implements Payment {
         @DataColumn String name;
-        @DataColumn(shift = 1) double amount;
+        @DataColumn double amount;
     }
 
     @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
-    static class PolymorphicShift {
+    static class PolymorphicShiftOnField {
         @DataColumn(shift = 1) Payment payment;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class CashWithSubtypeShift implements Payment {
+        @DataColumn String name;
+        @DataColumn(shift = 1) double amount;
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
+    @JsonSubTypes({@JsonSubTypes.Type(value = CashWithSubtypeShift.class, name = "cash")})
+    interface PaymentWithSubtypeShift {}
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class PolymorphicSubtypeShift {
+        PaymentWithSubtypeShift payment;
     }
 
     // -- Round-trip tests --
@@ -194,11 +210,24 @@ class DataColumnShiftTest {
     }
 
     @Test
-    void polymorphicShift_schemaBuilds() {
-        // _polymorphicProperty propagates shift on the discriminator column and
-        // preserves null Column placeholders from subtype visitor — regression guard
-        assertThatCode(() -> mapper.sheetSchemaFor(PolymorphicShift.class))
+    void polymorphicShift_onPolymorphicField_isAllowed() {
+        // Shift on the polymorphic field itself precedes the discriminator
+        // column — well-defined (single column-position adjustment, no subtype
+        // ambiguity).
+        assertThatCode(() -> mapper.sheetSchemaFor(PolymorphicShiftOnField.class))
                 .doesNotThrowAnyException();
+    }
+
+    @Test
+    void polymorphicShift_insideSubtype_isRejected() {
+        // Shift inside a polymorphic subtype is ill-defined: polymorphic union
+        // is pointer-based dedup, while shift is column-position adjustment —
+        // two different axes that cannot reconcile across subtypes.
+        assertThatThrownBy(() -> mapper.sheetSchemaFor(PolymorphicSubtypeShift.class))
+                .isInstanceOf(com.fasterxml.jackson.databind.exc.InvalidDefinitionException.class)
+                .hasMessageContaining("polymorphic subtype")
+                .hasMessageContaining("CashWithSubtypeShift")
+                .hasMessageContaining("Place shift outside the polymorphic field");
     }
 
     // -- Helpers --

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/DataColumnShiftTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/DataColumnShiftTest.java
@@ -210,6 +210,60 @@ class DataColumnShiftTest {
     }
 
     @Test
+    void groupShift_withHeader_collapsesToSingleLeafRow() throws Exception {
+        // useHeader=true + nested-group shift: group label row disappears,
+        // every leaf header lands on the origin row, and data starts at row 1.
+        final SpreadsheetMapper headerMapper = SpreadsheetMapper.builder().useHeader(true).build();
+        File file = tempFile("group-shift-header.xlsx");
+
+        headerMapper.writeValue(file,
+                Arrays.asList(new GroupShift("ORD-1",
+                        Arrays.asList(new Item("Apple", 3, 9.0)), 9.0)),
+                GroupShift.class);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            Row header = sheet.getRow(0);
+            // Nested leaves render their pointer path because the leaf @DataColumn
+            // has no explicit name — Column.getName() falls back to pointer.toString().
+            assertThat(header.getCell(0).getStringCellValue()).isEqualTo("orderId");
+            assertThat(header.getCell(2).getStringCellValue()).isEqualTo("items/[]/product");
+            assertThat(header.getCell(3).getStringCellValue()).isEqualTo("items/[]/qty");
+            assertThat(header.getCell(5).getStringCellValue()).isEqualTo("items/[]/amount");
+            assertThat(header.getCell(6).getStringCellValue()).isEqualTo("total");
+            // "Items" group label must not appear anywhere in the header region.
+            for (int r = 0; r <= 1; r++) {
+                Row row = sheet.getRow(r);
+                if (row == null) continue;
+                for (Cell cell : row) {
+                    assertThat(cell.toString()).isNotEqualTo("Items");
+                }
+            }
+            // Data begins at row 1 (single header row).
+            assertThat(sheet.getRow(1).getCell(0).getStringCellValue()).isEqualTo("ORD-1");
+        }
+    }
+
+    @Test
+    void flatShift_withColumnReordering_roundTrips() throws Exception {
+        // Gap column has no header text, so column-reordering treats it as
+        // unmatched. Round-trip must still recover the original record.
+        final SpreadsheetMapper reorderMapper = SpreadsheetMapper.builder()
+                .useHeader(true)
+                .columnReordering(true)
+                .build();
+        File file = tempFile("flat-shift-reorder.xlsx");
+
+        List<FlatShift> input = Arrays.asList(
+                new FlatShift("Apple", 10, 15.50),
+                new FlatShift("Banana", 20, 8.00));
+        reorderMapper.writeValue(file, input, FlatShift.class);
+        List<FlatShift> output = reorderMapper.readValues(file, FlatShift.class);
+
+        assertThat(output).isEqualTo(input);
+    }
+
+    @Test
     void polymorphicShift_onPolymorphicField_isAllowed() {
         // Shift on the polymorphic field itself precedes the discriminator
         // column — well-defined (single column-position adjustment, no subtype

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/DataColumnShiftTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/DataColumnShiftTest.java
@@ -2,6 +2,7 @@ package io.github.scndry.jackson.dataformat.spreadsheet;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -162,6 +163,27 @@ class DataColumnShiftTest {
     }
 
     @Test
+    void flatShift_withHeader_keepsLayoutAndLeavesGapHeaderBlank() throws Exception {
+        final SpreadsheetMapper headerMapper = SpreadsheetMapper.builder().useHeader(true).build();
+        File file = tempFile("flat-shift-header.xlsx");
+
+        headerMapper.writeValue(file,
+                Arrays.asList(new FlatShift("Apple", 10, 15.50)),
+                FlatShift.class);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            Row header = sheet.getRow(0);
+            assertThat(header.getCell(0).getStringCellValue()).isEqualTo("name");
+            assertThat(header.getCell(1).getStringCellValue()).isEqualTo("qty");
+            Cell gapHeader = header.getCell(2);
+            assertThat(gapHeader == null || gapHeader.toString().isEmpty()).isTrue();
+            assertThat(header.getCell(3).getStringCellValue()).isEqualTo("total");
+            assertThat(sheet.getRow(1).getCell(0).getStringCellValue()).isEqualTo("Apple");
+        }
+    }
+
+    @Test
     void flatShift_poiUserModel_roundTrip() throws Exception {
         SpreadsheetMapper poiMapper = SpreadsheetMapper.builder()
                 .useHeader(false)
@@ -271,9 +293,13 @@ class DataColumnShiftTest {
     }
 
     @Test
-    void polymorphicShift_onPolymorphicField_isAllowed() {
-        assertThatCode(() -> mapper.sheetSchemaFor(PolymorphicShiftOnField.class))
-                .doesNotThrowAnyException();
+    void polymorphicShift_onPolymorphicField_isAllowed() throws Exception {
+        SpreadsheetSchema schema = mapper.sheetSchemaFor(PolymorphicShiftOnField.class);
+        List<Column> columns = new ArrayList<>();
+        for (Column c : schema) columns.add(c);
+        assertThat(columns.get(0)).isNull();
+        assertThat(columns.get(1)).isNotNull();
+        assertThat(columns.get(1).getName()).isEqualTo("kind");
     }
 
     @Test

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/DataColumnShiftTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/DataColumnShiftTest.java
@@ -18,10 +18,13 @@ import org.junit.jupiter.api.io.TempDir;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
 
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
 import io.github.scndry.jackson.dataformat.spreadsheet.SpreadsheetFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -110,6 +113,18 @@ class DataColumnShiftTest {
     @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
     static class PolymorphicSubtypeShift {
         PaymentWithSubtypeShift payment;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class Inner {
+        @DataColumn String city;
+        @DataColumn String zip;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class WithUnwrappedShift {
+        @DataColumn String name;
+        @JsonUnwrapped @DataColumn(shift = 1) Inner inner;
     }
 
     // -- Round-trip tests --
@@ -259,6 +274,19 @@ class DataColumnShiftTest {
     void polymorphicShift_onPolymorphicField_isAllowed() {
         assertThatCode(() -> mapper.sheetSchemaFor(PolymorphicShiftOnField.class))
                 .doesNotThrowAnyException();
+    }
+
+    @Test
+    void unwrapped_shiftOnOuterField_isSilentlyIgnored() throws Exception {
+        SpreadsheetSchema schema = mapper.sheetSchemaFor(WithUnwrappedShift.class);
+        int total = 0;
+        int gaps = 0;
+        for (Column c : schema) {
+            total++;
+            if (c == null) gaps++;
+        }
+        assertThat(total).isEqualTo(3);
+        assertThat(gaps).isZero();
     }
 
     @Test

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/DataColumnShiftTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/DataColumnShiftTest.java
@@ -1,0 +1,209 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+import io.github.scndry.jackson.dataformat.spreadsheet.SpreadsheetFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Integration tests for {@code @DataColumn(shift)} and
+ * {@code @DataColumnGroup(shift)} — verifies blank columns on write,
+ * column skip on read, and round-trip equivalence under
+ * {@code useHeader=false}.
+ */
+class DataColumnShiftTest {
+
+    SpreadsheetMapper mapper;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() {
+        mapper = SpreadsheetMapper.builder().useHeader(false).build();
+    }
+
+    // -- Fixture types --
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class FlatShift {
+        @DataColumn String name;
+        @DataColumn int qty;
+        @DataColumn(shift = 1) double total;  // col 3 (col 2 = blank)
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class Item {
+        @DataColumn String product;
+        @DataColumn int qty;
+        @DataColumn(shift = 1) double amount;  // group col 3 (group col 2 = blank)
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class GroupShift {
+        @DataColumn(anchor = true) String orderId;
+        @DataColumnGroup(value = "Items", shift = 1) List<Item> items;  // col 2 = blank, items col 3-
+        @DataColumn double total;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class ItemShiftFirst {
+        @DataColumn(shift = 2) String product;
+        @DataColumn int qty;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class GroupShiftPlusInnerShift {
+        @DataColumn(anchor = true) String orderId;
+        @DataColumnGroup(value = "Items", shift = 1) List<ItemShiftFirst> items;
+        @DataColumn double total;
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
+    @JsonSubTypes({@JsonSubTypes.Type(value = Cash.class, name = "cash")})
+    interface Payment {}
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class Cash implements Payment {
+        @DataColumn String name;
+        @DataColumn(shift = 1) double amount;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class PolymorphicShift {
+        @DataColumn(shift = 1) Payment payment;
+    }
+
+    // -- Round-trip tests --
+
+    @Test
+    void flatShift_roundTrip() throws Exception {
+        File file = tempFile("flat-shift.xlsx");
+        List<FlatShift> input = Arrays.asList(
+                new FlatShift("Apple", 10, 15.50),
+                new FlatShift("Banana", 20, 8.00));
+
+        mapper.writeValue(file, input, FlatShift.class);
+        List<FlatShift> output = mapper.readValues(file, FlatShift.class);
+
+        assertThat(output).isEqualTo(input);
+    }
+
+    @Test
+    void flatShift_writeBlanksColumn() throws Exception {
+        File file = tempFile("flat-shift-write.xlsx");
+        mapper.writeValue(file,
+                Arrays.asList(new FlatShift("Apple", 10, 15.50)),
+                FlatShift.class);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            Row row = sheet.getRow(0);  // useHeader=false → data starts at row 0
+            assertThat(row.getCell(0).getStringCellValue()).isEqualTo("Apple");
+            assertThat((int) row.getCell(1).getNumericCellValue()).isEqualTo(10);
+            // col 2 = shifted blank
+            Cell blank = row.getCell(2);
+            assertThat(blank == null || blank.toString().isEmpty()).isTrue();
+            assertThat(row.getCell(3).getNumericCellValue()).isEqualTo(15.50);
+        }
+    }
+
+    @Test
+    void flatShift_poiUserModel_roundTrip() throws Exception {
+        SpreadsheetMapper poiMapper = SpreadsheetMapper.builder()
+                .useHeader(false)
+                .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL)
+                .build();
+        File file = tempFile("flat-shift-poi.xlsx");
+        List<FlatShift> input = Arrays.asList(
+                new FlatShift("Apple", 10, 15.50),
+                new FlatShift("Banana", 20, 8.00));
+
+        poiMapper.writeValue(file, input, FlatShift.class);
+        List<FlatShift> output = poiMapper.readValues(file, FlatShift.class);
+
+        assertThat(output).isEqualTo(input);
+    }
+
+    @Test
+    void nestedGroupShift_roundTrip() throws Exception {
+        File file = tempFile("group-shift.xlsx");
+        List<GroupShift> input = Arrays.asList(
+                new GroupShift("ORD-1", Arrays.asList(
+                        new Item("Apple", 3, 9.0),
+                        new Item("Banana", 5, 5.0)), 14.0));
+
+        mapper.writeValue(file, input, GroupShift.class);
+        List<GroupShift> output = mapper.readValues(file, GroupShift.class);
+
+        assertThat(output).isEqualTo(input);
+    }
+
+    @Test
+    void groupShift_plus_innerFirstShift_accumulates() throws Exception {
+        // Group shift (outer space) + inner first field shift (inner space) accumulate.
+        // outer: col 0 orderId, col 1 blank (group shift 1),
+        //        col 2-3 blank (inner shift 2), col 4 product, col 5 qty,
+        //        col 6 total
+        File file = tempFile("group-plus-inner-shift.xlsx");
+        List<GroupShiftPlusInnerShift> input = Arrays.asList(
+                new GroupShiftPlusInnerShift("ORD-1", Arrays.asList(
+                        new ItemShiftFirst("Apple", 3),
+                        new ItemShiftFirst("Banana", 5)), 14.0));
+
+        mapper.writeValue(file, input, GroupShiftPlusInnerShift.class);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            Sheet sheet = wb.getSheetAt(0);
+            Row row0 = sheet.getRow(0);
+            assertThat(row0.getCell(0).getStringCellValue()).isEqualTo("ORD-1");
+            // col 1, 2, 3 = blank (group shift 1 + inner shift 2)
+            for (int c = 1; c <= 3; c++) {
+                Cell blank = row0.getCell(c);
+                assertThat(blank == null || blank.toString().isEmpty()).isTrue();
+            }
+            assertThat(row0.getCell(4).getStringCellValue()).isEqualTo("Apple");
+            assertThat((int) row0.getCell(5).getNumericCellValue()).isEqualTo(3);
+            assertThat(row0.getCell(6).getNumericCellValue()).isEqualTo(14.0);
+        }
+
+        List<GroupShiftPlusInnerShift> output = mapper.readValues(file, GroupShiftPlusInnerShift.class);
+        assertThat(output).isEqualTo(input);
+    }
+
+    @Test
+    void polymorphicShift_schemaBuilds() {
+        // _polymorphicProperty propagates shift on the discriminator column and
+        // preserves null Column placeholders from subtype visitor — regression guard
+        assertThatCode(() -> mapper.sheetSchemaFor(PolymorphicShift.class))
+                .doesNotThrowAnyException();
+    }
+
+    // -- Helpers --
+
+    private File tempFile(String name) {
+        return tempDir.resolve(name).toFile();
+    }
+}

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/SSMLSheetWriterDomEquivalenceTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/SSMLSheetWriterDomEquivalenceTest.java
@@ -356,6 +356,63 @@ class SSMLSheetWriterDomEquivalenceTest {
         XlsxDomAssertions.assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
     }
 
+    // -- @DataColumn(shift) / @DataColumnGroup(shift) ---------------------
+    // Regression guard for null-gap-column handling across writer iteration
+    // paths. The nested-list case triggers mergeScopedColumns with a root
+    // (empty) pointer, exercising every column-iterating path on POI write.
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class FlatShiftEntry {
+        @DataColumn String name;
+        @DataColumn int qty;
+        @DataColumn(shift = 1) double total;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class ShiftItem {
+        @DataColumn String product;
+        @DataColumn int qty;
+        @DataColumn(shift = 1) double amount;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class GroupShiftEntry {
+        @DataColumn(anchor = true) String orderId;
+        @DataColumnGroup(value = "Items", shift = 1) List<ShiftItem> items;
+        @DataColumn double total;
+    }
+
+    @Test
+    void sheetXmlDomEquivalent_flatShift() throws Exception {
+        File ssmlFile = _debugFile("dom-shift-flat-ssml.xlsx");
+        File poiFile = _debugFile("dom-shift-flat-poi.xlsx");
+
+        List<FlatShiftEntry> data = Arrays.asList(
+                new FlatShiftEntry("Apple", 10, 15.50),
+                new FlatShiftEntry("Banana", 20, 8.00));
+
+        new SpreadsheetMapper().writeValue(ssmlFile, data, FlatShiftEntry.class);
+        _poiMapper().writeValue(poiFile, data, FlatShiftEntry.class);
+
+        XlsxDomAssertions.assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
+    }
+
+    @Test
+    void sheetXmlDomEquivalent_groupShift_nestedList() throws Exception {
+        File ssmlFile = _debugFile("dom-shift-group-ssml.xlsx");
+        File poiFile = _debugFile("dom-shift-group-poi.xlsx");
+
+        List<GroupShiftEntry> data = Arrays.asList(
+                new GroupShiftEntry("ORD-1", Arrays.asList(
+                        new ShiftItem("Apple", 3, 9.0),
+                        new ShiftItem("Banana", 5, 5.0)), 14.0));
+
+        new SpreadsheetMapper().writeValue(ssmlFile, data, GroupShiftEntry.class);
+        _poiMapper().writeValue(poiFile, data, GroupShiftEntry.class);
+
+        XlsxDomAssertions.assertPartEqualIgnoringDimension(poiFile, ssmlFile, "/xl/worksheets/sheet1.xml");
+    }
+
     @Test
     void sharedStringsXmlDomEquivalent() throws Exception {
         File ssmlFile = _debugFile("dom-sst-ssml.xlsx");

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/SchemaShiftValidatorTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/SchemaShiftValidatorTest.java
@@ -49,7 +49,7 @@ class SchemaShiftValidatorTest {
     }
 
     @Test
-    void positiveShift_withHeader_doesNotThrow_rendersSingleLeafRow() {
+    void positiveShift_withHeader_doesNotThrow() {
         assertThatCode(() -> new SpreadsheetMapper().sheetSchemaFor(WithShift.class))
                 .doesNotThrowAnyException();
     }
@@ -93,7 +93,7 @@ class SchemaShiftValidatorTest {
     }
 
     @Test
-    void groupShift_withHeader_doesNotThrow_rendersSingleLeafRow() {
+    void groupShift_withHeader_doesNotThrow() {
         assertThatCode(() -> new SpreadsheetMapper().sheetSchemaFor(GroupWithShift.class))
                 .doesNotThrowAnyException();
     }

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/SchemaShiftValidatorTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/SchemaShiftValidatorTest.java
@@ -50,7 +50,6 @@ class SchemaShiftValidatorTest {
 
     @Test
     void positiveShift_withHeader_doesNotThrow_rendersSingleLeafRow() {
-        // Option B: shift collapses the header to a single leaf row.
         assertThatCode(() -> new SpreadsheetMapper().sheetSchemaFor(WithShift.class))
                 .doesNotThrowAnyException();
     }
@@ -95,9 +94,6 @@ class SchemaShiftValidatorTest {
 
     @Test
     void groupShift_withHeader_doesNotThrow_rendersSingleLeafRow() {
-        // Option B: shift inside a @DataColumnGroup collapses the header to a
-        // single leaf row; group label rows are skipped while cascade attributes
-        // continue to apply per-column.
         assertThatCode(() -> new SpreadsheetMapper().sheetSchemaFor(GroupWithShift.class))
                 .doesNotThrowAnyException();
     }

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/SchemaShiftValidatorTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/SchemaShiftValidatorTest.java
@@ -114,4 +114,40 @@ class SchemaShiftValidatorTest {
                 .hasMessageContaining("shift")
                 .hasMessageContaining("must be >= 0");
     }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class MultipleNegativeShifts {
+        @DataColumn("name") String name;
+        @DataColumn(value = "qty", shift = -1) int qty;
+        @DataColumn(value = "total", shift = -2) double total;
+    }
+
+    @Test
+    void multipleViolations_areCollectedAndReportedTogether() {
+        final SpreadsheetMapper mapper = SpreadsheetMapper.builder()
+                .useHeader(false)
+                .build();
+        assertThatThrownBy(() -> mapper.sheetSchemaFor(MultipleNegativeShifts.class))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Shift invariant violation")
+                .hasMessageContaining("'qty'")
+                .hasMessageContaining("'total'");
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class ExcessiveShift {
+        @DataColumn("name") String name;
+        @DataColumn(value = "x", shift = 20000) int x;
+    }
+
+    @Test
+    void excessiveShift_throws() {
+        final SpreadsheetMapper mapper = SpreadsheetMapper.builder()
+                .useHeader(false)
+                .build();
+        assertThatThrownBy(() -> mapper.sheetSchemaFor(ExcessiveShift.class))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("'x'")
+                .hasMessageContaining("must be <= 16384");
+    }
 }

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/SchemaShiftValidatorTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/SchemaShiftValidatorTest.java
@@ -1,0 +1,121 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.junit.jupiter.api.Test;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Schema-build-time validation for the {@code shift} attribute on
+ * {@code @DataColumn} and {@code @DataColumnGroup}. Invariant:
+ * {@code shift >= 0}.
+ */
+class SchemaShiftValidatorTest {
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class NoShift {
+        @DataColumn("name") String name;
+        @DataColumn("qty") int qty;
+    }
+
+    @Test
+    void zeroShift_withHeader_doesNotThrow() {
+        assertThatCode(() -> new SpreadsheetMapper().sheetSchemaFor(NoShift.class))
+                .doesNotThrowAnyException();
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class WithShift {
+        @DataColumn("name") String name;
+        @DataColumn(value = "total", shift = 1) double total;
+    }
+
+    @Test
+    void positiveShift_withoutHeader_doesNotThrow() {
+        final SpreadsheetMapper mapper = SpreadsheetMapper.builder()
+                .useHeader(false)
+                .build();
+        assertThatCode(() -> mapper.sheetSchemaFor(WithShift.class))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void positiveShift_withHeader_doesNotThrow_rendersSingleLeafRow() {
+        // Option B: shift collapses the header to a single leaf row.
+        assertThatCode(() -> new SpreadsheetMapper().sheetSchemaFor(WithShift.class))
+                .doesNotThrowAnyException();
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class NegativeShift {
+        @DataColumn("name") String name;
+        @DataColumn(value = "total", shift = -1) double total;
+    }
+
+    @Test
+    void negativeShift_throws() {
+        final SpreadsheetMapper mapper = SpreadsheetMapper.builder()
+                .useHeader(false)
+                .build();
+        assertThatThrownBy(() -> mapper.sheetSchemaFor(NegativeShift.class))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("shift")
+                .hasMessageContaining("must be >= 0");
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class Inner {
+        @DataColumn("product") String product;
+        @DataColumn("qty") int qty;
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class GroupWithShift {
+        @DataColumn("orderId") int orderId;
+        @DataColumnGroup(value = "Items", shift = 1) List<Inner> items;
+    }
+
+    @Test
+    void groupShift_withoutHeader_doesNotThrow() {
+        final SpreadsheetMapper mapper = SpreadsheetMapper.builder()
+                .useHeader(false)
+                .build();
+        assertThatCode(() -> mapper.sheetSchemaFor(GroupWithShift.class))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void groupShift_withHeader_doesNotThrow_rendersSingleLeafRow() {
+        // Option B: shift inside a @DataColumnGroup collapses the header to a
+        // single leaf row; group label rows are skipped while cascade attributes
+        // continue to apply per-column.
+        assertThatCode(() -> new SpreadsheetMapper().sheetSchemaFor(GroupWithShift.class))
+                .doesNotThrowAnyException();
+    }
+
+    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
+    static class GroupWithNegativeShift {
+        @DataColumn("orderId") int orderId;
+        @DataColumnGroup(value = "Items", shift = -1) List<Inner> items;
+    }
+
+    @Test
+    void groupShift_negative_throws() {
+        final SpreadsheetMapper mapper = SpreadsheetMapper.builder()
+                .useHeader(false)
+                .build();
+        assertThatThrownBy(() -> mapper.sheetSchemaFor(GroupWithNegativeShift.class))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("shift")
+                .hasMessageContaining("must be >= 0");
+    }
+}

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/SchemaShiftValidatorTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/SchemaShiftValidatorTest.java
@@ -116,25 +116,6 @@ class SchemaShiftValidatorTest {
     }
 
     @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
-    static class MultipleNegativeShifts {
-        @DataColumn("name") String name;
-        @DataColumn(value = "qty", shift = -1) int qty;
-        @DataColumn(value = "total", shift = -2) double total;
-    }
-
-    @Test
-    void multipleViolations_areCollectedAndReportedTogether() {
-        final SpreadsheetMapper mapper = SpreadsheetMapper.builder()
-                .useHeader(false)
-                .build();
-        assertThatThrownBy(() -> mapper.sheetSchemaFor(MultipleNegativeShifts.class))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("Shift invariant violation")
-                .hasMessageContaining("'qty'")
-                .hasMessageContaining("'total'");
-    }
-
-    @Data @NoArgsConstructor @AllArgsConstructor @DataGrid
     static class ExcessiveShift {
         @DataColumn("name") String name;
         @DataColumn(value = "x", shift = 20000) int x;


### PR DESCRIPTION
Closes #58.

## Summary

- `@DataColumn(shift = N)` / `@DataColumnGroup(shift = N)` — forward column-position directive (N blank columns before the field/group). Symmetric on read and write; round-trip safe.
- Annotation `Value` types gain `shift` with backward-compatible constructors; the pre-shift constructor is `@Deprecated` for one minor cycle.
- `SchemaShiftValidator` (new, `schema.internal`) rejects `shift < 0` and `shift > Excel max columns` at schema build, fail-fast.
- POI and SSML writers emit null gap columns through their existing iteration paths (`mergeScopedColumns`, `forEachHeaderCell`, `_warnIfAutoSizeUsed`, `_resolveColumnStyleIndices`, `_appendFixedColumns`, `adjustColumnWidth`). Null columns are skipped consistently.
- `RecordTreeBuffer._emitRecord` already (post-1.7.1) handles nested-object pointer paths, so anchor + group + shift round-trip works without further changes.

## Variances from #58 proposal

| #58 | This PR | Reason |
|---|---|---|
| `useHeader=true + shift > 0` → reject at schema build | **Group-nested shift collapses the multi-row header to a single leaf row** (group label rows are skipped; cascade attributes still apply per-column). Flat shift with `useHeader=true` keeps the leaf row and leaves the gap header cell blank | The original proposal listed `useHeader=true` as out-of-scope because shifted columns would "lack header cells and break the row." The collapse approach resolves the conflict for the nested case (rendering a single coherent leaf row) and the flat-with-header case (the gap is a single blank header cell that the leaf row visually accommodates). |
| (not addressed) `@JsonTypeInfo` polymorphic subtype + shift | **Reject at schema build** — `ObjectFormatVisitor._polymorphicProperty` throws when a subtype's visitor emits a gap column. `shift` on the polymorphic field itself (discriminator-prefix shift) is allowed. | Polymorphic union is pointer-based dedup; subtype shift is column-position adjustment. The two axes cannot reconcile across subtypes without an `As.PROPERTY` row-level layout selection (out of scope). Explicit reject avoids silent column-position misalignment. |
| (not addressed) `@JsonUnwrapped` + `@DataColumn(shift)` on the outer field | **Silent ignore** — documented in `DataColumn` class javadoc. | Consistent with the existing `@JsonUnwrapped` + `@DataColumnGroup` silent-ignore behavior. The outer field disappears from the schema, so its attributes (including `shift`) cannot apply. |

## Test plan

- [x] `./gradlew test` — full suite passes.
- [x] `DataColumnShiftTest` — flat shift round-trip (SSML + POI user model), group shift round-trip, group+inner shift accumulation, `useHeader=true` single-leaf collapse with explicit cell assertions, columnReordering+shift round-trip, polymorphic-on-field allowed, polymorphic-inside-subtype rejected, `@JsonUnwrapped`+shift silent ignore.
- [x] `SchemaShiftValidatorTest` — `shift = 0` allowed, positive shift allowed (with/without header), negative shift on column/group throws, excessive shift (`> 16384`) throws.
- [x] `SSMLSheetWriterDomEquivalenceTest` — flat shift and group-shift+nested-list DOM-level parity between SSML and POI write paths.