### PR TITLE
Refactor SpreadsheetSchema to a minimal public interface

### DIFF
--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SchemaGenerator.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SchemaGenerator.java
@@ -24,6 +24,7 @@ import io.github.scndry.jackson.dataformat.spreadsheet.schema.generator.FormatVi
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.grid.GridConfigurer;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.BackWriteProjection;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.SchemaShiftValidator;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.SpreadsheetSchemaImpl;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.style.StylesBuilder;
 
 @Slf4j
@@ -94,7 +95,7 @@ public final class SchemaGenerator {
             throw _invalidSchemaDefinition(type,
                     "has no visible properties — check field visibility or add getters");
         }
-        final SpreadsheetSchema schema = new SpreadsheetSchema(
+        final SpreadsheetSchemaImpl schema = new SpreadsheetSchemaImpl(
                 columns,
                 _generatorSettings._origin,
                 _generatorSettings._features,

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SheetStreamContext.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SheetStreamContext.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.core.JsonStreamContext;
 
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.ColumnPointer;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.SpreadsheetSchemaImpl;
 
 /**
  * {@link JsonStreamContext} extension that tracks the current
@@ -18,15 +19,15 @@ import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
 public abstract class SheetStreamContext extends JsonStreamContext {
 
     protected static final int INITIAL_INDEX = -1;
-    protected final SpreadsheetSchema _schema;
+    protected final SpreadsheetSchemaImpl _schema;
     protected int _size;
 
-    protected SheetStreamContext(final int type, final SpreadsheetSchema schema) {
+    protected SheetStreamContext(final int type, final SpreadsheetSchemaImpl schema) {
         super(type, INITIAL_INDEX);
         _schema = schema;
     }
 
-    public static SheetStreamContext createRootContext(final SpreadsheetSchema schema) {
+    public static SheetStreamContext createRootContext(final SpreadsheetSchemaImpl schema) {
         return new RootContext(schema);
     }
 
@@ -105,7 +106,7 @@ public abstract class SheetStreamContext extends JsonStreamContext {
 
         private int _step = DEFAULT_STEP;
 
-        RootContext(final SpreadsheetSchema schema) {
+        RootContext(final SpreadsheetSchemaImpl schema) {
             super(TYPE_ROOT, schema);
         }
 

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/RecordTreeBuffer.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/RecordTreeBuffer.java
@@ -16,7 +16,7 @@ import com.fasterxml.jackson.core.JsonToken;
 import io.github.scndry.jackson.dataformat.spreadsheet.SheetStreamReadException;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.ColumnPointer;
-import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.SpreadsheetSchemaImpl;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.BackWriteProjection;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.SchemaAnchorInspector;
 
@@ -33,7 +33,7 @@ import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.SchemaAnc
  */
 final class RecordTreeBuffer {
 
-    private final SpreadsheetSchema _schema;
+    private final SpreadsheetSchemaImpl _schema;
     private final List<ColumnPointer> _anchorScopesByDepth;
     private final Set<ColumnPointer> _leafArrayScopes;
     private final Map<ColumnPointer, ColumnPointer> _parentArrayScopeOf;
@@ -49,15 +49,15 @@ final class RecordTreeBuffer {
     private final Map<ColumnPointer, Object> _lastAnchorByScope = new HashMap<>();
     private long _bufferedCells;
 
-    RecordTreeBuffer(final SpreadsheetSchema schema) {
+    RecordTreeBuffer(final SpreadsheetSchemaImpl schema) {
         this(schema, BackWriteProjection.backWriteBufferLimit(), true, false);
     }
 
-    RecordTreeBuffer(final SpreadsheetSchema schema, final long bufferLimitBytes) {
+    RecordTreeBuffer(final SpreadsheetSchemaImpl schema, final long bufferLimitBytes) {
         this(schema, bufferLimitBytes, true, false);
     }
 
-    RecordTreeBuffer(final SpreadsheetSchema schema, final long bufferLimitBytes,
+    RecordTreeBuffer(final SpreadsheetSchemaImpl schema, final long bufferLimitBytes,
                   final boolean blankRowAsNull, final boolean breakOnBlankRow) {
         _schema = schema;
         _anchorScopesByDepth = _collectAnchorScopes(schema);
@@ -72,7 +72,7 @@ final class RecordTreeBuffer {
     }
 
     private static Map<Column, ColumnPointer> _computeImmediateScopeByColumn(
-            final SpreadsheetSchema schema) {
+            final SpreadsheetSchemaImpl schema) {
         final Map<Column, ColumnPointer> result = new HashMap<>();
         for (final Column c : schema) {
             if (c == null) continue;
@@ -82,7 +82,7 @@ final class RecordTreeBuffer {
     }
 
     private static Map<Column, Integer> _computeColumnPositionByColumn(
-            final SpreadsheetSchema schema) {
+            final SpreadsheetSchemaImpl schema) {
         final Map<Column, Integer> result = new HashMap<>();
         int i = 0;
         for (final Column c : schema) {
@@ -93,7 +93,7 @@ final class RecordTreeBuffer {
     }
 
     private static Map<Column, List<String>> _computeRelativeSegmentsByColumn(
-            final SpreadsheetSchema schema) {
+            final SpreadsheetSchemaImpl schema) {
         final Map<Column, List<String>> result = new HashMap<>();
         for (final Column c : schema) {
             if (c == null) continue;
@@ -291,7 +291,7 @@ final class RecordTreeBuffer {
         return null;
     }
 
-    private static List<ColumnPointer> _collectAnchorScopes(final SpreadsheetSchema schema) {
+    private static List<ColumnPointer> _collectAnchorScopes(final SpreadsheetSchemaImpl schema) {
         final List<ColumnPointer> scopes = new ArrayList<>();
         if (SchemaAnchorInspector.findAnchorColumn(schema, ColumnPointer.empty()) != null) {
             scopes.add(ColumnPointer.empty());
@@ -305,7 +305,7 @@ final class RecordTreeBuffer {
         return scopes;
     }
 
-    private static Set<ColumnPointer> _findLeafArrayScopes(final SpreadsheetSchema schema) {
+    private static Set<ColumnPointer> _findLeafArrayScopes(final SpreadsheetSchemaImpl schema) {
         final Set<ColumnPointer> all = SchemaAnchorInspector.allArrayScopes(schema);
         final Set<ColumnPointer> leafs = new LinkedHashSet<>();
         for (final ColumnPointer scope : all) {
@@ -319,7 +319,7 @@ final class RecordTreeBuffer {
     }
 
     private static Map<ColumnPointer, ColumnPointer> _computeParentScopeMap(
-            final SpreadsheetSchema schema) {
+            final SpreadsheetSchemaImpl schema) {
         final Map<ColumnPointer, ColumnPointer> result = new HashMap<>();
         for (final ColumnPointer scope : SchemaAnchorInspector.allArrayScopes(schema)) {
             result.put(scope, _parentArrayScopeOf(scope));

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetParser.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetParser.java
@@ -30,6 +30,7 @@ import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.BackWriteProjection;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.NestedAnchorValidator;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.SchemaAnchorInspector;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.SpreadsheetSchemaImpl;
 
 /**
  * {@link com.fasterxml.jackson.core.JsonParser} implementation
@@ -53,7 +54,7 @@ public final class SheetParser extends ParserMinimalBase {
     private boolean _closed;
     private boolean _ended;
     private ObjectCodec _objectCodec;
-    private SpreadsheetSchema _schema;
+    private SpreadsheetSchemaImpl _schema;
     private SheetStreamContext _parsingContext;
     private RecordTreeBuffer _recordBuffer;
     private RecordTreeBuffer.Emitter _recordEmitter;
@@ -97,7 +98,7 @@ public final class SheetParser extends ParserMinimalBase {
 
     @Override
     public void setSchema(final FormatSchema schema) {
-        _schema = (SpreadsheetSchema) schema;
+        _schema = (SpreadsheetSchemaImpl) schema;
         if (_schema.getHeaderRowCount() > 1 && _schema.reordersColumns()) {
             throw new IllegalStateException(
                     "Column reordering is not supported with multi-row headers"
@@ -169,7 +170,7 @@ public final class SheetParser extends ParserMinimalBase {
                 if (_recordBuffer != null) {
                     _parsingContext.setCurrentName(_nextNames.removeFirst());
                 } else {
-                    final Column column = _schema.getColumn(_referenceColumn);
+                    final Column column = _schema.column(_referenceColumn);
                     final ColumnPointer pointer = _parsingContext.relativePointer(column.getPointer());
                     _parsingContext.setCurrentName(pointer.head().name());
                 }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLSheetWriter.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/SSMLSheetWriter.java
@@ -29,10 +29,10 @@ import io.github.scndry.jackson.dataformat.spreadsheet.poi.POICompat;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.ColumnPointer;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.HeaderLayoutVisitor;
-import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.Styles;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.BackWriteProjection;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.HeaderComments;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.SpreadsheetSchemaImpl;
 import io.github.scndry.jackson.dataformat.spreadsheet.ser.SheetWriter;
 
 /**
@@ -61,7 +61,7 @@ public final class SSMLSheetWriter implements SheetWriter {
     private final ZipOutputStream _zip;
     private final StringBuilder _sb = new StringBuilder(BUFFER_SIZE);
 
-    private SpreadsheetSchema _schema;
+    private SpreadsheetSchemaImpl _schema;
     private CellAddress _reference;
     private SheetDataBuffer _data;
     private int _arrayScopeDepth;
@@ -108,9 +108,9 @@ public final class SSMLSheetWriter implements SheetWriter {
     }
 
     @Override
-    public void setSchema(final SpreadsheetSchema schema) {
+    public void setSchema(final SpreadsheetSchemaImpl schema) {
         _schema = schema;
-        _data = new SheetDataBuffer(schema.getOriginColumn() + schema.columnCount());
+        _data = new SheetDataBuffer(schema.getOriginColumn() + schema.size());
         try {
             _wb = _sheet.getWorkbook();
             _styles = _schema.buildStyles(_wb);

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ss/POISheetWriter.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ss/POISheetWriter.java
@@ -27,9 +27,9 @@ import io.github.scndry.jackson.dataformat.spreadsheet.poi.POICompat;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.ColumnPointer;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.HeaderLayoutVisitor;
-import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.Styles;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.HeaderComments;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.SpreadsheetSchemaImpl;
 import io.github.scndry.jackson.dataformat.spreadsheet.ser.SheetWriter;
 
 /**
@@ -49,7 +49,7 @@ public final class POISheetWriter implements SheetWriter {
 
     private final Sheet _sheet;
     private final OutputStream _out;
-    private SpreadsheetSchema _schema;
+    private SpreadsheetSchemaImpl _schema;
     private CellAddress _reference;
     private Styles _styles;
     private int _lastRow;
@@ -73,7 +73,7 @@ public final class POISheetWriter implements SheetWriter {
     }
 
     @Override
-    public void setSchema(final SpreadsheetSchema schema) {
+    public void setSchema(final SpreadsheetSchemaImpl schema) {
         _schema = schema;
         _styles = _schema.buildStyles(_sheet.getWorkbook());
         HeaderComments.apply(_sheet, _schema);

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/SpreadsheetSchema.java
@@ -1,362 +1,37 @@
 package io.github.scndry.jackson.dataformat.spreadsheet.schema;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import org.apache.poi.ss.usermodel.Sheet;
-import org.apache.poi.ss.usermodel.Workbook;
-import org.apache.poi.ss.util.CellAddress;
 
 import com.fasterxml.jackson.core.FormatSchema;
 
-import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
-import io.github.scndry.jackson.dataformat.spreadsheet.schema.grid.GridConfigurer;
-import io.github.scndry.jackson.dataformat.spreadsheet.schema.style.StylesBuilder;
-
 /**
- * {@link FormatSchema} implementation that defines the column
- * layout for spreadsheet reading and writing. Contains an
- * ordered list of {@link Column} definitions, a cell origin,
- * and style configuration. Do not mutate the builders or
- * columns after construction.
+ * {@link FormatSchema} for spreadsheet reading and writing. Produced by
+ * {@link io.github.scndry.jackson.dataformat.spreadsheet.SpreadsheetMapper#sheetSchemaFor}
+ * and passed back into the mapper's reader / writer chains. Iterates the
+ * ordered {@link Column} layout (sibling-format pattern: see
+ * {@code CsvSchema}).
  *
  * @see Column
  * @see io.github.scndry.jackson.dataformat.spreadsheet.SchemaGenerator
  */
-public final class SpreadsheetSchema implements FormatSchema, Iterable<Column> {
+public interface SpreadsheetSchema extends FormatSchema, Iterable<Column> {
 
-    public static final String SCHEMA_TYPE = "spreadsheet";
+    String SCHEMA_TYPE = "spreadsheet";
 
-    public static final int FEATURE_USE_HEADER = 0x0001;
-    public static final int FEATURE_COLUMN_REORDERING = 0x0002;
+    int FEATURE_USE_HEADER = 0x0001;
+    int FEATURE_COLUMN_REORDERING = 0x0002;
 
-    public static final int DEFAULT_FEATURES = FEATURE_USE_HEADER;
+    int DEFAULT_FEATURES = FEATURE_USE_HEADER;
 
-    private final List<Column> _columns;
-    private final CellAddress _origin;
-    private final int _features;
-    private final StylesBuilder _stylesBuilder;
-    private final GridConfigurer _gridConfigurer;
-    private final int _headerRowCount;
-    // Pre-built lookup tables for resolve / resolveArray on the write path's
-    // per-cell currentPointer chain. Every cell's pointer is a prefix of
-    // some schema column pointer, so all needed (parent, name) and
-    // (parent, []) pairs can be enumerated at schema construction. Avoids
-    // per-cell SegmentPointer / String[] allocation in
-    // SheetStreamContext.ObjectContext/ArrayContext.currentPointer().
-    private final Map<ColumnPointer, Map<String, ColumnPointer>> _resolveTable;
-    private final Map<ColumnPointer, ColumnPointer> _resolveArrayTable;
+    int size();
 
-    public SpreadsheetSchema(
-            final List<Column> columns,
-            final CellAddress origin,
-            final int features,
-            final StylesBuilder stylesBuilder,
-            final GridConfigurer gridConfigurer) {
-        _columns = columns;
-        _origin = origin;
-        _features = features;
-        _stylesBuilder = stylesBuilder;
-        _gridConfigurer = gridConfigurer;
-        _headerRowCount = _computeHeaderRowCount(columns);
-        _resolveTable = new HashMap<>();
-        _resolveArrayTable = new HashMap<>();
-        _buildResolveTables();
-    }
+    Column column(int index);
 
-    private void _buildResolveTables() {
-        for (final Column col : _columns) {
-            if (col == null) continue;
-            ColumnPointer head = ColumnPointer.empty();
-            for (final ColumnPointer seg : col.getPointer()) {
-                ColumnPointer next;
-                if (seg.equals(ColumnPointer.array())) {
-                    next = _resolveArrayTable.get(head);
-                    if (next == null) {
-                        next = head.resolveArray();
-                        _resolveArrayTable.put(head, next);
-                    }
-                } else {
-                    final String name = seg.name();
-                    final Map<String, ColumnPointer> nameMap =
-                            _resolveTable.computeIfAbsent(head, k -> new HashMap<>());
-                    next = nameMap.get(name);
-                    if (next == null) {
-                        next = head.resolve(name);
-                        nameMap.put(name, next);
-                    }
-                }
-                head = next;
-            }
-        }
-    }
+    Column column(String name);
 
-    /**
-     * Internal hot-path cache for per-cell pointer chains; external
-     * callers should use {@link ColumnPointer#resolve(String)}.
-     */
-    public ColumnPointer resolve(final ColumnPointer parent, final String name) {
-        final Map<String, ColumnPointer> nameMap = _resolveTable.get(parent);
-        if (nameMap != null) {
-            final ColumnPointer cached = nameMap.get(name);
-            if (cached != null) return cached;
-        }
-        return parent.resolve(name);
-    }
+    int columnIndex(String name);
 
-    /**
-     * Internal hot-path cache for per-cell pointer chains; external
-     * callers should use {@link ColumnPointer#resolveArray()}.
-     */
-    public ColumnPointer resolveArray(final ColumnPointer parent) {
-        final ColumnPointer cached = _resolveArrayTable.get(parent);
-        if (cached != null) return cached;
-        return parent.resolveArray();
-    }
+    String columnName(int index);
 
-    private static int _computeHeaderRowCount(final List<Column> columns) {
-        int max = 0;
-        for (final Column col : columns) {
-            if (col == null) continue;
-            final int depth = col.getGroupHierarchy().depth();
-            if (depth > max) max = depth;
-        }
-        return max + 1;
-    }
-
-    @Override
-    public String getSchemaType() {
-        return SCHEMA_TYPE;
-    }
-
-    @Override
-    public Iterator<Column> iterator() {
-        return _columns.iterator();
-    }
-
-    public Column findColumn(final CellAddress reference) {
-        return findColumn(reference.getColumn());
-    }
-
-    public Column findColumn(final int column) {
-        if (_columns.isEmpty()) {
-            return null;
-        }
-        final int idx = column - getOriginColumn();
-        if (idx < 0 || idx >= _columns.size()) {
-            return null;
-        }
-        return _columns.get(idx);
-    }
-
-    public Column getColumn(final CellAddress reference) {
-        return getColumn(reference.getColumn());
-    }
-
-    public Column getColumn(final int column) {
-        return _columns.get(column - getOriginColumn());
-    }
-
-    public int getDataRow() {
-        return _origin.getRow() + (usesHeader() ? effectiveHeaderRowCount() : 0);
-    }
-
-    public int getHeaderRowCount() {
-        return effectiveHeaderRowCount();
-    }
-
-    /** Row index of the leaf header row (the row carrying column names).
-     *  Collapses to the origin row when {@link #usesHeader()} is disabled. */
-    public int getLeafHeaderRow() {
-        return _origin.getRow() + (usesHeader() ? effectiveHeaderRowCount() - 1 : 0);
-    }
-
-    /** Effective header rows: shift collapses the layout to a single leaf row
-     *  (group label rows are skipped; cascade attributes still apply per-column). */
-    private int effectiveHeaderRowCount() {
-        return anyNestedShift() ? 1 : _headerRowCount;
-    }
-
-    private boolean anyNestedShift() {
-        for (final Column column : _columns) {
-            if (column == null) continue;
-            if (column.getValue().getShift() > 0
-                    && column.getGroupHierarchy().depth() > 0) return true;
-        }
-        return false;
-    }
-
-    /** Walks the header region (leaf headers, group cells, vertical merges)
-     *  and invokes the visitor for each. Used by writers and the comment
-     *  applicator to share the run-identification algorithm. */
-    public void forEachHeaderCell(final HeaderLayoutVisitor visitor) {
-        if (!usesHeader()) return;
-        final int originRow = _origin.getRow();
-        if (anyNestedShift()) {
-            for (final Column column : _columns) {
-                if (column == null) continue;
-                visitor.visitColumnHeader(originRow, columnIndexOf(column), column);
-            }
-            return;
-        }
-        for (int depth = 0; depth < _headerRowCount; depth++) {
-            _visitHeaderRow(originRow + depth, depth, visitor);
-        }
-        // Vertical merges for shallow-hierarchy (incl. flat) columns.
-        final int leafRow = originRow + _headerRowCount - 1;
-        for (final Column column : _columns) {
-            if (column == null) continue;
-            final int h = column.getGroupHierarchy().depth();
-            if (h >= _headerRowCount - 1) continue;
-            final int colIdx = columnIndexOf(column);
-            final int rowspanStart = originRow + h;
-            if (leafRow > rowspanStart) {
-                visitor.visitVerticalMerge(rowspanStart, leafRow, colIdx);
-            }
-        }
-    }
-
-    private void _visitHeaderRow(final int row, final int depth, final HeaderLayoutVisitor visitor) {
-        int i = 0;
-        while (i < _columns.size()) {
-            final Column col = _columns.get(i);
-            if (col == null) { i++; continue; }
-            final DataColumnGroup.Hierarchy hierarchy = col.getGroupHierarchy();
-            final int h = hierarchy.depth();
-
-            if (h == depth) {
-                // Column hierarchy ends at this depth — leaf header text.
-                visitor.visitColumnHeader(row, columnIndexOf(col), col);
-                i++;
-                continue;
-            }
-            if (h < depth) {
-                // Hierarchy ended above this row — vertical merge covers, skip.
-                i++;
-                continue;
-            }
-
-            // h > depth: group cell at this depth, possibly merged horizontally
-            // across adjacent columns sharing parent path + group name.
-            final DataColumnGroup.Hierarchy parentPath = hierarchy.parentPath(depth);
-            final String groupName = hierarchy.at(depth).getName();
-
-            int j = i + 1;
-            while (j < _columns.size()) {
-                final Column col2 = _columns.get(j);
-                if (col2 == null) break;
-                final DataColumnGroup.Hierarchy h2 = col2.getGroupHierarchy();
-                if (h2.depth() <= depth) break;
-                if (!h2.parentPath(depth).equals(parentPath)) break;
-                if (!h2.at(depth).getName().equals(groupName)) break;
-                j++;
-            }
-
-            final int firstColIdx = columnIndexOf(col);
-            final int lastColIdx = columnIndexOf(_columns.get(j - 1));
-            visitor.visitGroupCell(row, firstColIdx, lastColIdx, hierarchy.at(depth));
-            i = j;
-        }
-    }
-
-    public boolean usesHeader() {
-        return (_features & FEATURE_USE_HEADER) != 0;
-    }
-
-    public boolean reordersColumns() {
-        return (_features & FEATURE_COLUMN_REORDERING) != 0;
-    }
-
-    public SpreadsheetSchema reorderColumns(final List<String> headers) {
-        final List<Column> reordered = new ArrayList<>(headers.size());
-        for (final String header : headers) {
-            Column matched = null;
-            if (header != null) {
-                for (final Column col : _columns) {
-                    if (col != null && col.matchesName(header)) {
-                        matched = col;
-                        break;
-                    }
-                }
-            }
-            reordered.add(matched);
-        }
-        return new SpreadsheetSchema(reordered, _origin, _features, _stylesBuilder, _gridConfigurer);
-    }
-
-    public int getOriginColumn() {
-        return _origin.getColumn();
-    }
-
-    public int columnIndexOf(final ColumnPointer pointer) {
-        for (int i = 0; i < _columns.size(); i++) {
-            final Column col = _columns.get(i);
-            if (col != null && col.matches(pointer)) {
-                return i + getOriginColumn();
-            }
-        }
-        return -1;
-    }
-
-    public int columnIndexOf(final Column column) {
-        return columnIndexOf(column.getPointer());
-    }
-
-    public int getOriginRow() {
-        return _origin.getRow();
-    }
-
-    public List<Column> getColumns(final ColumnPointer filter) {
-        if (filter.isEmpty()) {
-            return _columns;
-        }
-        return _columns
-                .stream()
-                .filter(c -> c != null && c
-                .getPointer()
-                .startsWith(filter)).collect(Collectors
-                .toList());
-    }
-
-    public Styles buildStyles(final Workbook workbook) {
-        return _stylesBuilder.build(workbook);
-    }
-
-    public void configureSheet(final Sheet sheet, final Styles styles, final int lastRow) {
-        _gridConfigurer.apply(sheet, styles, this, lastRow);
-    }
-
-    public int columnIndexByName(final String name) {
-        for (int i = 0; i < _columns.size(); i++) {
-            final Column col = _columns.get(i);
-            if (col != null && col.matchesName(name)) {
-                return i + getOriginColumn();
-            }
-        }
-        return -1;
-    }
-
-    public int columnCount() {
-        return _columns.size();
-    }
-
-    public List<String> columnNames() {
-        final List<String> names = new ArrayList<>();
-        for (final Column col : _columns) {
-            if (col != null) names.add(col.getName());
-        }
-        return names;
-    }
-
-    public boolean isInRowBounds(final int row) {
-        return getDataRow() <= row;
-    }
-
-    public boolean isInColumnBounds(final int col) {
-        return getOriginColumn() <= col && col < getOriginColumn() + _columns.size();
-    }
+    List<String> columnNames();
 }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/grid/GridConfigurer.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/grid/GridConfigurer.java
@@ -13,8 +13,8 @@ import org.apache.poi.xssf.usermodel.XSSFCellStyle;
 import org.apache.poi.xssf.usermodel.XSSFFont;
 
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.Incubating;
-import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.Styles;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.SpreadsheetSchemaImpl;
 
 /**
  * Configurer for sheet-level features: freeze pane, auto filter, and conditional formatting.
@@ -90,7 +90,7 @@ public final class GridConfigurer {
     }
 
     public void apply(final Sheet sheet, final Styles styles,
-            final SpreadsheetSchema schema, final int lastRow) {
+            final SpreadsheetSchemaImpl schema, final int lastRow) {
         _applyFreezePane(sheet);
         _applyAutoFilter(sheet, schema, lastRow);
         _applyConditionalFormattings(sheet, styles, schema, lastRow);
@@ -104,10 +104,10 @@ public final class GridConfigurer {
         }
     }
 
-    private void _applyAutoFilter(final Sheet sheet, final SpreadsheetSchema schema, final int lastRow) {
-        if (!_autoFilter || schema.columnCount() == 0) return;
+    private void _applyAutoFilter(final Sheet sheet, final SpreadsheetSchemaImpl schema, final int lastRow) {
+        if (!_autoFilter || schema.size() == 0) return;
         final int firstCol = schema.getOriginColumn();
-        final int lastCol = firstCol + schema.columnCount() - 1;
+        final int lastCol = firstCol + schema.size() - 1;
         final int firstRow = schema.getLeafHeaderRow();
         final int endRow = lastRow < 0
                 ? sheet.getWorkbook().getSpreadsheetVersion().getMaxRows() - 1
@@ -116,7 +116,7 @@ public final class GridConfigurer {
     }
 
     private void _applyConditionalFormattings(final Sheet sheet, final Styles styles,
-            final SpreadsheetSchema schema, final int lastRow) {
+            final SpreadsheetSchemaImpl schema, final int lastRow) {
         if (_columnRules.isEmpty()) return;
         final Workbook wb = sheet.getWorkbook();
         final int dataRow = schema.getDataRow();
@@ -125,7 +125,7 @@ public final class GridConfigurer {
         final SheetConditionalFormatting scf = sheet.getSheetConditionalFormatting();
 
         for (final ColumnRule cr : _columnRules) {
-            final int colIndex = schema.columnIndexByName(cr.column);
+            final int colIndex = schema.columnIndex(cr.column);
             if (colIndex < 0) {
                 throw new IllegalArgumentException("Column '" + cr.column
                         + "' not found in schema. Available columns: " + schema.columnNames());
@@ -139,7 +139,7 @@ public final class GridConfigurer {
     private static ConditionalFormattingRule _createPoiRule(
             final SheetConditionalFormatting scf,
             final ConditionalFormatRule rule,
-            final SpreadsheetSchema schema,
+            final SpreadsheetSchemaImpl schema,
             final Workbook wb,
             final Styles styles) {
         if (rule instanceof CellIsRule) {
@@ -198,14 +198,14 @@ public final class GridConfigurer {
         ((ExtendedColor) colors[2]).setARGBHex("FF63BE7B");
     }
 
-    private static String _resolveOperand(final Object operand, final SpreadsheetSchema schema) {
+    private static String _resolveOperand(final Object operand, final SpreadsheetSchemaImpl schema) {
         if (operand instanceof Formula) {
             final Formula f = (Formula) operand;
             switch (f.kind()) {
                 case OF:
                     return f.value();
                 case COLUMN:
-                    final int col = schema.columnIndexByName(f.value());
+                    final int col = schema.columnIndex(f.value());
                     if (col < 0) {
                         throw new IllegalArgumentException("Formula column '" + f.value()
                                 + "' not found in schema. Available columns: " + schema.columnNames());

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/BackWriteProjection.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/BackWriteProjection.java
@@ -13,7 +13,6 @@ import lombok.extern.slf4j.Slf4j;
 
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.ColumnPointer;
-import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
 
 /**
  * Internal helpers for the SSML back-write scenario — per-cell heap
@@ -43,12 +42,12 @@ public final class BackWriteProjection {
      *  Single source of truth shared with {@code SheetDataBuffer.byteSize()}. */
     public static final int ROW_MEMORY_BYTES = 8;
 
-    /** Cache for {@link #requiresBackWriteScope(SpreadsheetSchema)} keyed on
+    /** Cache for {@link #requiresBackWriteScope(SpreadsheetSchemaImpl)} keyed on
      *  schema identity. WeakHashMap so schemas reclaimed by GC drop their
      *  entry — typical applications hold a single schema for their lifetime,
      *  edge-case ClassLoader reload / dynamically generated schemas do not
      *  leak. */
-    private static final Map<SpreadsheetSchema, Boolean> SCOPE_CACHE =
+    private static final Map<SpreadsheetSchemaImpl, Boolean> SCOPE_CACHE =
             Collections.synchronizedMap(new WeakHashMap<>());
 
     private BackWriteProjection() {
@@ -58,7 +57,7 @@ public final class BackWriteProjection {
      *  ({@link #CELL_MEMORY_BYTES}) plus the row directory entry
      *  ({@link #ROW_MEMORY_BYTES}). */
     public static long innerRowMaxBytes(
-            final SpreadsheetSchema schema, final ColumnPointer arrayPointer) {
+            final SpreadsheetSchemaImpl schema, final ColumnPointer arrayPointer) {
         final List<Column> inners = schema.getColumns(arrayPointer);
         return (long) ROW_MEMORY_BYTES + (long) inners.size() * CELL_MEMORY_BYTES;
     }
@@ -66,7 +65,7 @@ public final class BackWriteProjection {
     /** Projected back-write buffer max for a nested list of
      *  {@code listSize} elements rooted at {@code arrayPointer}. */
     public static long project(
-            final SpreadsheetSchema schema, final ColumnPointer arrayPointer, final int listSize) {
+            final SpreadsheetSchemaImpl schema, final ColumnPointer arrayPointer, final int listSize) {
         if (listSize <= 0) return 0;
         return (long) listSize * innerRowMaxBytes(schema, arrayPointer);
     }
@@ -106,7 +105,7 @@ public final class BackWriteProjection {
     /** Returns true when any record scope (root or nested) has an
      *  outer field of that scope appearing after a child array of the
      *  same scope — the trigger for SSML back-write at that scope. */
-    public static boolean hasOuterFieldAfterList(final SpreadsheetSchema schema) {
+    public static boolean hasOuterFieldAfterList(final SpreadsheetSchemaImpl schema) {
         final Set<ColumnPointer> scopes = new LinkedHashSet<>();
         scopes.add(ColumnPointer.empty());
         for (final Column c : schema) {
@@ -124,7 +123,7 @@ public final class BackWriteProjection {
     }
 
     private static boolean _outerAfterListAt(
-            final SpreadsheetSchema schema, final ColumnPointer scope) {
+            final SpreadsheetSchemaImpl schema, final ColumnPointer scope) {
         boolean seenChildArray = false;
         for (final Column c : schema) {
             if (c == null) continue;
@@ -153,7 +152,7 @@ public final class BackWriteProjection {
      *  one immediate child array — sibling lists share the parent row,
      *  so the second list must back-write into rows already produced by
      *  the first list. */
-    public static boolean hasMultipleSiblingLists(final SpreadsheetSchema schema) {
+    public static boolean hasMultipleSiblingLists(final SpreadsheetSchemaImpl schema) {
         final Map<ColumnPointer, Set<ColumnPointer>> childArraysByParent = new HashMap<>();
         for (final Column c : schema) {
             if (c == null) continue;
@@ -173,11 +172,11 @@ public final class BackWriteProjection {
         return false;
     }
 
-    /** Cached form of {@link #hasOuterFieldAfterList(SpreadsheetSchema)} or
-     *  {@link #hasMultipleSiblingLists(SpreadsheetSchema)}. Writers call this
+    /** Cached form of {@link #hasOuterFieldAfterList(SpreadsheetSchemaImpl)} or
+     *  {@link #hasMultipleSiblingLists(SpreadsheetSchemaImpl)}. Writers call this
      *  once per nested array to gate flush suspension — the cache avoids
      *  recomputing the result across every record. */
-    public static boolean requiresBackWriteScope(final SpreadsheetSchema schema) {
+    public static boolean requiresBackWriteScope(final SpreadsheetSchemaImpl schema) {
         final Boolean cached = SCOPE_CACHE.get(schema);
         if (cached != null) return cached;
         final boolean v = hasOuterFieldAfterList(schema) || hasMultipleSiblingLists(schema);
@@ -187,7 +186,7 @@ public final class BackWriteProjection {
 
     /** Logs a warn at schema build time when {@link #hasOuterFieldAfterList}
      *  returns true. Call once after schema construction. */
-    public static void warnIfScenario(final SpreadsheetSchema schema) {
+    public static void warnIfScenario(final SpreadsheetSchemaImpl schema) {
         if (!hasOuterFieldAfterList(schema)) return;
         log.warn(
                 "Schema has an outer field declared after a List<T> field —"

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/HeaderComments.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/HeaderComments.java
@@ -24,7 +24,7 @@ public final class HeaderComments {
 
     private HeaderComments() {}
 
-    public static void apply(final Sheet sheet, final SpreadsheetSchema schema) {
+    public static void apply(final Sheet sheet, final SpreadsheetSchemaImpl schema) {
         if (!schema.usesHeader()) return;
         final CreationHelper factory = sheet.getWorkbook().getCreationHelper();
         schema.forEachHeaderCell(new HeaderLayoutVisitor() {

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/NestedAnchorValidator.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/NestedAnchorValidator.java
@@ -9,7 +9,6 @@ import java.util.Set;
 
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.ColumnPointer;
-import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
 
 /**
  * Read-time validation for the depth-aware nested-list contract:
@@ -29,7 +28,7 @@ public final class NestedAnchorValidator {
     /** Throws {@link IllegalStateException} when the schema violates the
      *  anchor invariant — exactly one anchor per nested-list-bearing
      *  record level, no anchors elsewhere. */
-    public static void validate(final SpreadsheetSchema schema) {
+    public static void validate(final SpreadsheetSchemaImpl schema) {
         final Set<ColumnPointer> expected = _listBearingScopes(schema);
         final Map<ColumnPointer, List<Column>> anchorsByScope = _anchorsByScope(schema);
 
@@ -47,7 +46,7 @@ public final class NestedAnchorValidator {
         throw new IllegalStateException(_buildMessage(missing, extra, duplicate));
     }
 
-    private static Set<ColumnPointer> _listBearingScopes(final SpreadsheetSchema schema) {
+    private static Set<ColumnPointer> _listBearingScopes(final SpreadsheetSchemaImpl schema) {
         final Set<ColumnPointer> scopes = new LinkedHashSet<>();
         for (final Column c : schema) {
             if (c == null) continue;
@@ -64,7 +63,7 @@ public final class NestedAnchorValidator {
         return scopes;
     }
 
-    private static Map<ColumnPointer, List<Column>> _anchorsByScope(final SpreadsheetSchema schema) {
+    private static Map<ColumnPointer, List<Column>> _anchorsByScope(final SpreadsheetSchemaImpl schema) {
         final Map<ColumnPointer, List<Column>> result = new LinkedHashMap<>();
         for (final Column c : schema) {
             if (c == null || !c.isAnchor()) continue;

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/SpreadsheetSchemaImpl.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/internal/SpreadsheetSchemaImpl.java
@@ -1,0 +1,358 @@
+package io.github.scndry.jackson.dataformat.spreadsheet.schema.internal;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.util.CellAddress;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumnGroup;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.ColumnPointer;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.HeaderLayoutVisitor;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.Styles;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.grid.GridConfigurer;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.style.StylesBuilder;
+
+/**
+ * Library-internal implementation of {@link SpreadsheetSchema}. Not part of
+ * the public API; callers outside this library must not depend on it.
+ */
+public final class SpreadsheetSchemaImpl implements SpreadsheetSchema {
+
+    private final List<Column> _columns;
+    private final CellAddress _origin;
+    private final int _features;
+    private final StylesBuilder _stylesBuilder;
+    private final GridConfigurer _gridConfigurer;
+    private final int _headerRowCount;
+    // Pre-built lookup tables for resolve / resolveArray on the write path's
+    // per-cell currentPointer chain. Every cell's pointer is a prefix of
+    // some schema column pointer, so all needed (parent, name) and
+    // (parent, []) pairs can be enumerated at schema construction. Avoids
+    // per-cell SegmentPointer / String[] allocation in
+    // SheetStreamContext.ObjectContext/ArrayContext.currentPointer().
+    private final Map<ColumnPointer, Map<String, ColumnPointer>> _resolveTable;
+    private final Map<ColumnPointer, ColumnPointer> _resolveArrayTable;
+
+    public SpreadsheetSchemaImpl(
+            final List<Column> columns,
+            final CellAddress origin,
+            final int features,
+            final StylesBuilder stylesBuilder,
+            final GridConfigurer gridConfigurer) {
+        _columns = columns;
+        _origin = origin;
+        _features = features;
+        _stylesBuilder = stylesBuilder;
+        _gridConfigurer = gridConfigurer;
+        _headerRowCount = _computeHeaderRowCount(columns);
+        _resolveTable = new HashMap<>();
+        _resolveArrayTable = new HashMap<>();
+        _buildResolveTables();
+    }
+
+    private void _buildResolveTables() {
+        for (final Column col : _columns) {
+            if (col == null) continue;
+            ColumnPointer head = ColumnPointer.empty();
+            for (final ColumnPointer seg : col.getPointer()) {
+                ColumnPointer next;
+                if (seg.equals(ColumnPointer.array())) {
+                    next = _resolveArrayTable.get(head);
+                    if (next == null) {
+                        next = head.resolveArray();
+                        _resolveArrayTable.put(head, next);
+                    }
+                } else {
+                    final String name = seg.name();
+                    final Map<String, ColumnPointer> nameMap =
+                            _resolveTable.computeIfAbsent(head, k -> new HashMap<>());
+                    next = nameMap.get(name);
+                    if (next == null) {
+                        next = head.resolve(name);
+                        nameMap.put(name, next);
+                    }
+                }
+                head = next;
+            }
+        }
+    }
+
+    public ColumnPointer resolve(final ColumnPointer parent, final String name) {
+        final Map<String, ColumnPointer> nameMap = _resolveTable.get(parent);
+        if (nameMap != null) {
+            final ColumnPointer cached = nameMap.get(name);
+            if (cached != null) return cached;
+        }
+        return parent.resolve(name);
+    }
+
+    public ColumnPointer resolveArray(final ColumnPointer parent) {
+        final ColumnPointer cached = _resolveArrayTable.get(parent);
+        if (cached != null) return cached;
+        return parent.resolveArray();
+    }
+
+    private static int _computeHeaderRowCount(final List<Column> columns) {
+        int max = 0;
+        for (final Column col : columns) {
+            if (col == null) continue;
+            final int depth = col.getGroupHierarchy().depth();
+            if (depth > max) max = depth;
+        }
+        return max + 1;
+    }
+
+    @Override
+    public String getSchemaType() {
+        return SCHEMA_TYPE;
+    }
+
+    @Override
+    public Iterator<Column> iterator() {
+        return _columns.iterator();
+    }
+
+    public Column findColumn(final CellAddress reference) {
+        return findColumn(reference.getColumn());
+    }
+
+    public Column findColumn(final int column) {
+        if (_columns.isEmpty()) {
+            return null;
+        }
+        final int idx = column - getOriginColumn();
+        if (idx < 0 || idx >= _columns.size()) {
+            return null;
+        }
+        return _columns.get(idx);
+    }
+
+    @Override
+    public Column column(final int index) {
+        return _columns.get(index - getOriginColumn());
+    }
+
+    public Column column(final CellAddress reference) {
+        return column(reference.getColumn());
+    }
+
+    @Override
+    public Column column(final String name) {
+        for (final Column col : _columns) {
+            if (col != null && col.matchesName(name)) return col;
+        }
+        return null;
+    }
+
+    @Override
+    public String columnName(final int index) {
+        final Column col = column(index);
+        return col == null ? null : col.getName();
+    }
+
+    public int getDataRow() {
+        return _origin.getRow() + (usesHeader() ? effectiveHeaderRowCount() : 0);
+    }
+
+    public int getHeaderRowCount() {
+        return effectiveHeaderRowCount();
+    }
+
+    /** Row index of the leaf header row (the row carrying column names).
+     *  Collapses to the origin row when {@link #usesHeader()} is disabled. */
+    public int getLeafHeaderRow() {
+        return _origin.getRow() + (usesHeader() ? effectiveHeaderRowCount() - 1 : 0);
+    }
+
+    /** Effective header rows: shift collapses the layout to a single leaf row
+     *  (group label rows are skipped; cascade attributes still apply per-column). */
+    private int effectiveHeaderRowCount() {
+        return anyNestedShift() ? 1 : _headerRowCount;
+    }
+
+    private boolean anyNestedShift() {
+        for (final Column column : _columns) {
+            if (column == null) continue;
+            if (column.getValue().getShift() > 0
+                    && column.getGroupHierarchy().depth() > 0) return true;
+        }
+        return false;
+    }
+
+    /** Walks the header region (leaf headers, group cells, vertical merges)
+     *  and invokes the visitor for each. Used by writers and the comment
+     *  applicator to share the run-identification algorithm. */
+    public void forEachHeaderCell(final HeaderLayoutVisitor visitor) {
+        if (!usesHeader()) return;
+        final int originRow = _origin.getRow();
+        if (anyNestedShift()) {
+            for (final Column column : _columns) {
+                if (column == null) continue;
+                visitor.visitColumnHeader(originRow, columnIndexOf(column), column);
+            }
+            return;
+        }
+        for (int depth = 0; depth < _headerRowCount; depth++) {
+            _visitHeaderRow(originRow + depth, depth, visitor);
+        }
+        // Vertical merges for shallow-hierarchy (incl. flat) columns.
+        final int leafRow = originRow + _headerRowCount - 1;
+        for (final Column column : _columns) {
+            if (column == null) continue;
+            final int h = column.getGroupHierarchy().depth();
+            if (h >= _headerRowCount - 1) continue;
+            final int colIdx = columnIndexOf(column);
+            final int rowspanStart = originRow + h;
+            if (leafRow > rowspanStart) {
+                visitor.visitVerticalMerge(rowspanStart, leafRow, colIdx);
+            }
+        }
+    }
+
+    private void _visitHeaderRow(final int row, final int depth, final HeaderLayoutVisitor visitor) {
+        int i = 0;
+        while (i < _columns.size()) {
+            final Column col = _columns.get(i);
+            if (col == null) { i++; continue; }
+            final DataColumnGroup.Hierarchy hierarchy = col.getGroupHierarchy();
+            final int h = hierarchy.depth();
+
+            if (h == depth) {
+                // Column hierarchy ends at this depth — leaf header text.
+                visitor.visitColumnHeader(row, columnIndexOf(col), col);
+                i++;
+                continue;
+            }
+            if (h < depth) {
+                // Hierarchy ended above this row — vertical merge covers, skip.
+                i++;
+                continue;
+            }
+
+            // h > depth: group cell at this depth, possibly merged horizontally
+            // across adjacent columns sharing parent path + group name.
+            final DataColumnGroup.Hierarchy parentPath = hierarchy.parentPath(depth);
+            final String groupName = hierarchy.at(depth).getName();
+
+            int j = i + 1;
+            while (j < _columns.size()) {
+                final Column col2 = _columns.get(j);
+                if (col2 == null) break;
+                final DataColumnGroup.Hierarchy h2 = col2.getGroupHierarchy();
+                if (h2.depth() <= depth) break;
+                if (!h2.parentPath(depth).equals(parentPath)) break;
+                if (!h2.at(depth).getName().equals(groupName)) break;
+                j++;
+            }
+
+            final int firstColIdx = columnIndexOf(col);
+            final int lastColIdx = columnIndexOf(_columns.get(j - 1));
+            visitor.visitGroupCell(row, firstColIdx, lastColIdx, hierarchy.at(depth));
+            i = j;
+        }
+    }
+
+    public boolean usesHeader() {
+        return (_features & FEATURE_USE_HEADER) != 0;
+    }
+
+    public boolean reordersColumns() {
+        return (_features & FEATURE_COLUMN_REORDERING) != 0;
+    }
+
+    public SpreadsheetSchemaImpl reorderColumns(final List<String> headers) {
+        final List<Column> reordered = new ArrayList<>(headers.size());
+        for (final String header : headers) {
+            Column matched = null;
+            if (header != null) {
+                for (final Column col : _columns) {
+                    if (col != null && col.matchesName(header)) {
+                        matched = col;
+                        break;
+                    }
+                }
+            }
+            reordered.add(matched);
+        }
+        return new SpreadsheetSchemaImpl(reordered, _origin, _features, _stylesBuilder, _gridConfigurer);
+    }
+
+    public int getOriginColumn() {
+        return _origin.getColumn();
+    }
+
+    public int columnIndexOf(final ColumnPointer pointer) {
+        for (int i = 0; i < _columns.size(); i++) {
+            final Column col = _columns.get(i);
+            if (col != null && col.matches(pointer)) {
+                return i + getOriginColumn();
+            }
+        }
+        return -1;
+    }
+
+    public int columnIndexOf(final Column column) {
+        return columnIndexOf(column.getPointer());
+    }
+
+    public List<Column> getColumns(final ColumnPointer filter) {
+        if (filter.isEmpty()) {
+            return _columns;
+        }
+        return _columns
+                .stream()
+                .filter(c -> c != null && c
+                .getPointer()
+                .startsWith(filter)).collect(Collectors
+                .toList());
+    }
+
+    public Styles buildStyles(final Workbook workbook) {
+        return _stylesBuilder.build(workbook);
+    }
+
+    public void configureSheet(final Sheet sheet, final Styles styles, final int lastRow) {
+        _gridConfigurer.apply(sheet, styles, this, lastRow);
+    }
+
+    @Override
+    public int columnIndex(final String name) {
+        for (int i = 0; i < _columns.size(); i++) {
+            final Column col = _columns.get(i);
+            if (col != null && col.matchesName(name)) {
+                return i + getOriginColumn();
+            }
+        }
+        return -1;
+    }
+
+    @Override
+    public int size() {
+        return _columns.size();
+    }
+
+    @Override
+    public List<String> columnNames() {
+        final List<String> names = new ArrayList<>();
+        for (final Column col : _columns) {
+            if (col != null) names.add(col.getName());
+        }
+        return names;
+    }
+
+    public boolean isInRowBounds(final int row) {
+        return getDataRow() <= row;
+    }
+
+    public boolean isInColumnBounds(final int col) {
+        return getOriginColumn() <= col && col < getOriginColumn() + _columns.size();
+    }
+}

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/ser/SheetGenerator.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/ser/SheetGenerator.java
@@ -16,6 +16,7 @@ import io.github.scndry.jackson.dataformat.spreadsheet.SheetStreamWriteException
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.ColumnPointer;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.BackWriteProjection;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.SpreadsheetSchemaImpl;
 
 /**
  * {@link com.fasterxml.jackson.core.JsonGenerator} implementation
@@ -40,7 +41,7 @@ public final class SheetGenerator extends GeneratorBase {
 
     private final IOContext _ioContext;
     private final SheetWriter _writer;
-    private SpreadsheetSchema _schema;
+    private SpreadsheetSchemaImpl _schema;
     private SheetStreamContext _outputContext;
 
     public SheetGenerator(
@@ -71,7 +72,7 @@ public final class SheetGenerator extends GeneratorBase {
     @Override
     public void setSchema(final FormatSchema schema) {
         if (_schema != null) return;
-        _schema = (SpreadsheetSchema) schema;
+        _schema = (SpreadsheetSchemaImpl) schema;
         _writer.setSchema(_schema);
         if (_schema.usesHeader()) {
             _writer.writeHeaders();

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/ser/SheetWriter.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/ser/SheetWriter.java
@@ -7,6 +7,7 @@ import org.apache.poi.ss.util.CellAddress;
 
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.ColumnPointer;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.SpreadsheetSchemaImpl;
 
 /**
  * Low-level interface for writing values into spreadsheet cells.
@@ -20,7 +21,7 @@ public interface SheetWriter extends AutoCloseable {
 
     SpreadsheetVersion getSpreadsheetVersion();
 
-    void setSchema(SpreadsheetSchema schema);
+    void setSchema(SpreadsheetSchemaImpl schema);
 
     void setReference(CellAddress reference);
 

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/AnnotationValueTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/AnnotationValueTest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.OptBoolean;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.ColumnPointer;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.SpreadsheetSchemaImpl;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -23,7 +24,7 @@ class AnnotationValueTest {
             @DataColumn(value = "Qty", width = 20) public int qty;
         }
 
-        SpreadsheetSchema schema = mapper.sheetSchemaFor(Row.class);
+        SpreadsheetSchemaImpl schema = (SpreadsheetSchemaImpl) mapper.sheetSchemaFor(Row.class);
         List<Column> columns = schema.getColumns(ColumnPointer.empty());
         assertThat(columns).hasSize(2);
         assertThat(columns.get(0).getName()).isEqualTo("Name");
@@ -38,7 +39,7 @@ class AnnotationValueTest {
             @DataColumn("B") public int b;
         }
 
-        SpreadsheetSchema schema = mapper.sheetSchemaFor(Row.class);
+        SpreadsheetSchemaImpl schema = (SpreadsheetSchemaImpl) mapper.sheetSchemaFor(Row.class);
         for (Column col : schema.getColumns(ColumnPointer.empty())) {
             assertThat(col.isMerge()).isTrue();
         }
@@ -52,7 +53,7 @@ class AnnotationValueTest {
             @DataColumn("B") public int b;
         }
 
-        SpreadsheetSchema schema = mapper.sheetSchemaFor(Row.class);
+        SpreadsheetSchemaImpl schema = (SpreadsheetSchemaImpl) mapper.sheetSchemaFor(Row.class);
         assertThat(schema.getColumns(ColumnPointer.empty()).get(0).isMerge()).isFalse();
         assertThat(schema.getColumns(ColumnPointer.empty()).get(1).isMerge()).isTrue();
     }
@@ -65,7 +66,7 @@ class AnnotationValueTest {
             @DataColumn("B") public int b;
         }
 
-        SpreadsheetSchema schema = mapper.sheetSchemaFor(Row.class);
+        SpreadsheetSchemaImpl schema = (SpreadsheetSchemaImpl) mapper.sheetSchemaFor(Row.class);
         assertThat(schema.getColumns(ColumnPointer.empty()).get(0).getValue().isAutoSize()).isFalse();
         assertThat(schema.getColumns(ColumnPointer.empty()).get(1).getValue().isAutoSize()).isTrue();
     }

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/BackWriteProjectionTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/BackWriteProjectionTest.java
@@ -17,8 +17,8 @@ import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.ColumnPointer;
-import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.BackWriteProjection;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.SpreadsheetSchemaImpl;
 
 import static io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.BackWriteProjection.CELL_MEMORY_BYTES;
 import static io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.BackWriteProjection.ROW_MEMORY_BYTES;
@@ -53,7 +53,7 @@ class BackWriteProjectionTest {
 
     @Test
     void project_oneRow_equalsInnerRowMaxBytes() throws Exception {
-        final SpreadsheetSchema schema = _schemaFor(Outer.class);
+        final SpreadsheetSchemaImpl schema = _schemaFor(Outer.class);
         final ColumnPointer arrayPointer = _findInnerArrayPointer(schema);
 
         // Inner has 1 column → cellMemory 20 + rowMemory 8 = 28 bytes.
@@ -63,7 +63,7 @@ class BackWriteProjectionTest {
 
     @Test
     void project_scalesLinearlyWithListSize() throws Exception {
-        final SpreadsheetSchema schema = _schemaFor(Outer.class);
+        final SpreadsheetSchemaImpl schema = _schemaFor(Outer.class);
         final ColumnPointer arrayPointer = _findInnerArrayPointer(schema);
 
         final long perRow = BackWriteProjection.project(schema, arrayPointer, 1);
@@ -75,7 +75,7 @@ class BackWriteProjectionTest {
 
     @Test
     void project_zeroOrNegativeSize_returnsZero() throws Exception {
-        final SpreadsheetSchema schema = _schemaFor(Outer.class);
+        final SpreadsheetSchemaImpl schema = _schemaFor(Outer.class);
         final ColumnPointer arrayPointer = _findInnerArrayPointer(schema);
 
         assertThat(BackWriteProjection.project(schema, arrayPointer, 0)).isZero();
@@ -108,7 +108,7 @@ class BackWriteProjectionTest {
 
     @Test
     void requiresBackWriteScope_outerAfterListReturnsTrue() throws Exception {
-        final SpreadsheetSchema schema = _schemaFor(Outer.class);
+        final SpreadsheetSchemaImpl schema = _schemaFor(Outer.class);
         assertThat(BackWriteProjection.requiresBackWriteScope(schema)).isTrue();
     }
 
@@ -121,7 +121,7 @@ class BackWriteProjectionTest {
 
     @Test
     void requiresBackWriteScope_outerFirstReturnsFalse() throws Exception {
-        final SpreadsheetSchema schema = _schemaFor(OuterFirst.class);
+        final SpreadsheetSchemaImpl schema = _schemaFor(OuterFirst.class);
         assertThat(BackWriteProjection.requiresBackWriteScope(schema)).isFalse();
     }
 
@@ -143,7 +143,7 @@ class BackWriteProjectionTest {
 
     @Test
     void requiresBackWriteScope_nestedScopeOuterAfterListReturnsTrue() throws Exception {
-        final SpreadsheetSchema schema = _schemaFor(NestedOuterAfterList.class);
+        final SpreadsheetSchemaImpl schema = _schemaFor(NestedOuterAfterList.class);
         assertThat(BackWriteProjection.requiresBackWriteScope(schema)).isTrue();
     }
 
@@ -164,7 +164,7 @@ class BackWriteProjectionTest {
 
     @Test
     void requiresBackWriteScope_nestedScopeOuterFirstReturnsFalse() throws Exception {
-        final SpreadsheetSchema schema = _schemaFor(NestedOuterFirst.class);
+        final SpreadsheetSchemaImpl schema = _schemaFor(NestedOuterFirst.class);
         assertThat(BackWriteProjection.requiresBackWriteScope(schema)).isFalse();
     }
 
@@ -184,7 +184,7 @@ class BackWriteProjectionTest {
 
     @Test
     void requiresBackWriteScope_rootMultiSiblingReturnsTrue() throws Exception {
-        final SpreadsheetSchema schema = _schemaFor(RootSiblingLists.class);
+        final SpreadsheetSchemaImpl schema = _schemaFor(RootSiblingLists.class);
         assertThat(BackWriteProjection.requiresBackWriteScope(schema)).isTrue();
     }
 
@@ -206,7 +206,7 @@ class BackWriteProjectionTest {
 
     @Test
     void requiresBackWriteScope_nestedScopeMultiSiblingReturnsTrue() throws Exception {
-        final SpreadsheetSchema schema = _schemaFor(NestedMultiSiblingTop.class);
+        final SpreadsheetSchemaImpl schema = _schemaFor(NestedMultiSiblingTop.class);
         assertThat(BackWriteProjection.requiresBackWriteScope(schema)).isTrue();
     }
 
@@ -223,7 +223,7 @@ class BackWriteProjectionTest {
         // verify the message contract — operator size, the projected and
         // limit byte figures, and the three mitigation options.
         final SpreadsheetMapper mapper = new SpreadsheetMapper();
-        final SpreadsheetSchema schema = mapper.sheetSchemaFor(Outer.class);
+        final SpreadsheetSchemaImpl schema = (SpreadsheetSchemaImpl) mapper.sheetSchemaFor(Outer.class);
         final ColumnPointer arrayPointer = _findInnerArrayPointer(schema);
         final long perRow = BackWriteProjection.project(schema, arrayPointer, 1);
         final long limit = BackWriteProjection.backWriteBufferLimit();
@@ -249,14 +249,14 @@ class BackWriteProjectionTest {
     // Helpers
     // ----------------------------------------------------------------
 
-    private static SpreadsheetSchema _schemaFor(final Class<?> type) throws Exception {
-        return new SpreadsheetMapper().sheetSchemaFor(type);
+    private static SpreadsheetSchemaImpl _schemaFor(final Class<?> type) throws Exception {
+        return (SpreadsheetSchemaImpl) new SpreadsheetMapper().sheetSchemaFor(type);
     }
 
     /** Finds the array pointer ({@code items/[]}) for an inner column —
      *  the same pointer the writer hands to {@code project()} at
      *  {@code writeStartArray}. */
-    private static ColumnPointer _findInnerArrayPointer(final SpreadsheetSchema schema) {
+    private static ColumnPointer _findInnerArrayPointer(final SpreadsheetSchemaImpl schema) {
         for (final Column c : schema) {
             if (c == null) continue;
             final ColumnPointer p = c.getPointer();

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedAnchorValidatorTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/NestedAnchorValidatorTest.java
@@ -9,8 +9,8 @@ import org.junit.jupiter.api.Test;
 
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
-import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.NestedAnchorValidator;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.SpreadsheetSchemaImpl;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -36,7 +36,7 @@ class NestedAnchorValidatorTest {
 
     @Test
     void valid_anchorAtListBearingScope_doesNotThrow() throws Exception {
-        final SpreadsheetSchema schema = _schemaFor(Valid.class);
+        final SpreadsheetSchemaImpl schema = _schemaFor(Valid.class);
         assertThatCode(() -> NestedAnchorValidator.validate(schema)).doesNotThrowAnyException();
     }
 
@@ -54,7 +54,7 @@ class NestedAnchorValidatorTest {
 
     @Test
     void missing_anchorAtNestedScope_throws() throws Exception {
-        final SpreadsheetSchema schema = _schemaFor(MissingAtNested.class);
+        final SpreadsheetSchemaImpl schema = _schemaFor(MissingAtNested.class);
         assertThatThrownBy(() -> NestedAnchorValidator.validate(schema))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Missing anchor")
@@ -75,7 +75,7 @@ class NestedAnchorValidatorTest {
 
     @Test
     void missing_anchorAtRootScope_throws() throws Exception {
-        final SpreadsheetSchema schema = _schemaFor(MissingAtRoot.class);
+        final SpreadsheetSchemaImpl schema = _schemaFor(MissingAtRoot.class);
         assertThatThrownBy(() -> NestedAnchorValidator.validate(schema))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Missing anchor")
@@ -90,7 +90,7 @@ class NestedAnchorValidatorTest {
 
     @Test
     void missing_noAnchorAnywhereWithNestedList_throws() throws Exception {
-        final SpreadsheetSchema schema = _schemaFor(MissingAll.class);
+        final SpreadsheetSchemaImpl schema = _schemaFor(MissingAll.class);
         assertThatThrownBy(() -> NestedAnchorValidator.validate(schema))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Missing anchor")
@@ -111,7 +111,7 @@ class NestedAnchorValidatorTest {
 
     @Test
     void extra_anchorAtInnermostScope_throws() throws Exception {
-        final SpreadsheetSchema schema = _schemaFor(ExtraAtInnermost.class);
+        final SpreadsheetSchemaImpl schema = _schemaFor(ExtraAtInnermost.class);
         assertThatThrownBy(() -> NestedAnchorValidator.validate(schema))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Extra anchor")
@@ -126,7 +126,7 @@ class NestedAnchorValidatorTest {
 
     @Test
     void extra_anchorOnFlatSchema_throws() throws Exception {
-        final SpreadsheetSchema schema = _schemaFor(ExtraOnFlat.class);
+        final SpreadsheetSchemaImpl schema = _schemaFor(ExtraOnFlat.class);
         assertThatThrownBy(() -> NestedAnchorValidator.validate(schema))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Extra anchor")
@@ -142,7 +142,7 @@ class NestedAnchorValidatorTest {
 
     @Test
     void duplicate_anchorAtSameScope_throws() throws Exception {
-        final SpreadsheetSchema schema = _schemaFor(DuplicateAtRoot.class);
+        final SpreadsheetSchemaImpl schema = _schemaFor(DuplicateAtRoot.class);
         assertThatThrownBy(() -> NestedAnchorValidator.validate(schema))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Multiple anchors")
@@ -150,7 +150,7 @@ class NestedAnchorValidatorTest {
                 .hasMessageContaining("name");
     }
 
-    private static SpreadsheetSchema _schemaFor(final Class<?> type) throws Exception {
-        return new SpreadsheetMapper().sheetSchemaFor(type);
+    private static SpreadsheetSchemaImpl _schemaFor(final Class<?> type) throws Exception {
+        return (SpreadsheetSchemaImpl) new SpreadsheetMapper().sheetSchemaFor(type);
     }
 }

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/UnitTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/UnitTest.java
@@ -2,6 +2,7 @@ package io.github.scndry.jackson.dataformat.spreadsheet;
 
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.SpreadsheetSchemaImpl;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -42,7 +43,7 @@ class UnitTest {
 
         @Test
         void dataRowWithHeader() throws Exception {
-            SpreadsheetSchema schema = mapper.sheetSchemaFor(Simple.class);
+            SpreadsheetSchemaImpl schema = (SpreadsheetSchemaImpl) mapper.sheetSchemaFor(Simple.class);
             assertThat(schema.usesHeader()).isTrue();
             assertThat(schema.getDataRow()).isEqualTo(1);
         }
@@ -50,7 +51,7 @@ class UnitTest {
         @Test
         void dataRowWithoutHeader() throws Exception {
             SpreadsheetMapper noHeader = mapper.rebuild().useHeader(false).build();
-            SpreadsheetSchema schema = noHeader.sheetSchemaFor(Simple.class);
+            SpreadsheetSchemaImpl schema = (SpreadsheetSchemaImpl) noHeader.sheetSchemaFor(Simple.class);
             assertThat(schema.usesHeader()).isFalse();
             assertThat(schema.getDataRow()).isEqualTo(0);
         }

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/RecordTreeBufferLimitTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/RecordTreeBufferLimitTest.java
@@ -14,7 +14,7 @@ import io.github.scndry.jackson.dataformat.spreadsheet.SpreadsheetMapper;
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
 import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.Column;
-import io.github.scndry.jackson.dataformat.spreadsheet.schema.SpreadsheetSchema;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.SpreadsheetSchemaImpl;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -56,7 +56,7 @@ class RecordTreeBufferLimitTest {
 
     private static ThrowingRunnable _runNRows(final long bufferLimitBytes, final int innerRows)
             throws Exception {
-        final SpreadsheetSchema schema = new SpreadsheetMapper().sheetSchemaFor(Outer.class);
+        final SpreadsheetSchemaImpl schema = (SpreadsheetSchemaImpl) new SpreadsheetMapper().sheetSchemaFor(Outer.class);
         final Column idCol = _findColumn(schema, "id");
         final Column xCol = _findColumn(schema, "x");
         final Column yCol = _findColumn(schema, "y");
@@ -82,7 +82,7 @@ class RecordTreeBufferLimitTest {
         };
     }
 
-    private static Column _findColumn(final SpreadsheetSchema schema, final String name) {
+    private static Column _findColumn(final SpreadsheetSchemaImpl schema, final String name) {
         for (final Column c : schema) {
             if (c != null && name.equals(c.getName())) return c;
         }


### PR DESCRIPTION
## Summary

- `SpreadsheetSchema` becomes an interface exposing constants, `FormatSchema`, `Iterable<Column>`, and five CSV-style query methods (`size`, `column(int)`, `column(String)`, `columnIndex(String)`, `columnName(int)`, `columnNames()`).
- Constructor, fields, and all internal methods (`resolve`, `findColumn`, `getDataRow`, `getOriginColumn`, `forEachHeaderCell`, `buildStyles`, `configureSheet`, `getLeafHeaderRow`, `getHeaderRowCount`, `columnIndexOf`, `getColumns(ColumnPointer)`, `isInRowBounds`, `isInColumnBounds`, `reorderColumns`, `usesHeader`, `reordersColumns`, etc.) move to `SpreadsheetSchemaImpl` in `schema.internal`.
- Library callers cast the incoming `FormatSchema` to `SpreadsheetSchemaImpl`; internal renames align method names with the interface (`columnCount`→`size`, `getColumn(int)`→`column(int)`, `columnIndexByName`→`columnIndex`).
- Unused `getOriginRow` accessor removed.

## Breaking change (1.8.0)

- `SpreadsheetSchema` is now an `interface`; the public constructor is removed. User code calling `new SpreadsheetSchema(...)` directly will not compile.
- Internal dispatch methods are no longer on `SpreadsheetSchema`. Third-party callers that invoked them (none in this repo or in the examples repo) must cast to `SpreadsheetSchemaImpl` from `schema.internal`.
- The five exposed query methods follow the `CsvSchema` naming convention; sibling-format users will recognise the surface.

## Design context

The minimal surface reflects observed usage: users iterate or query the schema for display/debug, never for parser-internal dispatch. `origin`, style builder, grid configurer, and the `useHeader`/`reordersColumns` flags are user-supplied builder config and are not re-exposed on the schema instance. Library callers that need internal dispatch use `SpreadsheetSchemaImpl` directly.

## Test plan

- [x] `./gradlew compileJava compileTestJava` passes
- [x] `./gradlew test` passes (all suites green)