### PR TITLE
Add OOXML (XLSX) password protection

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -137,6 +137,7 @@ The library draws a deliberate line. These are outside its scope entirely:
 | **Charts, pivot tables, macros** | Outside data binding scope — these are document features, not data features |
 | **Cell-level random access** | Contradicts the streaming model that enables performance |
 | **Validation rules** | Business logic belongs in the application, not the format layer |
+| **Sheet- and workbook-level protection** | Tamper hash on readable content, not encryption — different mechanism; POI handles it |
 
 Sheet selection is a different case — the library provides `SheetInput` and `SheetOutput` for it, but the decision is explicit, not defaulted. The default (first sheet) works without any wrapper; naming or indexing a sheet is an opt-in choice.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -137,7 +137,6 @@ The library draws a deliberate line. These are outside its scope entirely:
 | **Charts, pivot tables, macros** | Outside data binding scope — these are document features, not data features |
 | **Cell-level random access** | Contradicts the streaming model that enables performance |
 | **Validation rules** | Business logic belongs in the application, not the format layer |
-| **Sheet- and workbook-level protection** | Tamper hash on readable content, not encryption — different mechanism; POI handles it |
 
 Sheet selection is a different case — the library provides `SheetInput` and `SheetOutput` for it, but the decision is explicit, not defaulted. The default (first sheet) works without any wrapper; naming or indexing a sheet is an opt-in choice.
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -988,7 +988,7 @@ SheetOutput.target(file).withPassword("secret", EncryptionSpec.legacy())
 
 `EncryptionSpec.custom()` opens a builder for arbitrary combinations.
 
-Sheet-level and workbook-level protection are out of scope — use POI directly.
+Scope covers the output XLSX file only. For at-rest protection of the file-backed shared-strings temp store, see [Low-Memory Mode](#low-memory-mode-for-large-files). Sheet-level and workbook-level protection are out of scope — use POI directly.
 
 ## Low-Memory Mode for Large Files
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -957,6 +957,39 @@ SpreadsheetMapper mapper = SpreadsheetMapper.builder()
 List<Row> rows = mapper.readValues(inputStream, Row.class);
 ```
 
+### Password Protection
+
+OOXML files can be encrypted with a password. The same `withPassword` applies to both directions.
+
+```java
+// Write
+mapper.writeValue(
+    SheetOutput.target(file).withPassword("secret"),
+    products, Product.class);
+
+// Read
+List<Product> list = mapper.readValues(
+    SheetInput.source(file).withPassword("secret"),
+    Product.class);
+```
+
+The default is `EncryptionSpec.strong()` (AES-256 + SHA-512). Pass an explicit spec for a different trade-off:
+
+```java
+SheetOutput.target(file).withPassword("secret", EncryptionSpec.legacy())
+```
+
+| Preset | Cipher | Hash | Mode | Notes |
+|--------|--------|------|------|-------|
+| `strong()` | AES-256 | SHA-512 | Agile (Excel 2013+) | Default. Opens in Excel, Numbers, LibreOffice. |
+| `balanced()` | AES-128 | SHA-512 | Agile (Excel 2013+) | LibreOffice rejects this combination. |
+| `legacy()` | AES-128 | SHA-1 | Standard (Excel 2007/2010) | For older Excel that rejects agile. |
+| `fast()` | AES-128 | SHA-256 | Agile (Excel 2013+) | Lighter hash than `balanced()`. |
+
+`EncryptionSpec.custom()` opens a builder for arbitrary combinations.
+
+Sheet-level and workbook-level protection are out of scope — use POI directly.
+
 ## Low-Memory Mode for Large Files
 
 For extremely large XLSX files that cause `OutOfMemoryError`:
@@ -976,7 +1009,7 @@ SpreadsheetMapper mapper = SpreadsheetMapper.builder()
     .build();
 ```
 
-This protects the temp file only — the output XLSX is not encrypted. Workbook-level password protection (encrypted XLSX) is out of scope; use POI directly for that.
+This protects the temp file only — the output XLSX is not encrypted. For full-file XLSX encryption, see [Password Protection](#password-protection).
 
 Requires `com.h2database:h2` on the classpath:
 

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/EncryptionSpec.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/EncryptionSpec.java
@@ -8,13 +8,9 @@ import org.apache.poi.poifs.crypt.HashAlgorithm;
 
 /**
  * Encryption strength preset for password-protected OOXML output, used with
- * {@code SheetOutput.withEncryption}. {@link #strong()} is the default when
- * a password is set without an explicit spec.
- *
- * <p>The four presets cover the practical strength / compatibility / speed
- * axis without exposing POI's cipher / hash / mode enums. {@link #custom()}
- * opens a builder for finer control while keeping POI types behind the
- * abstraction.
+ * {@code SheetOutput.withPassword(password, spec)}. {@link #strong()} is the
+ * default when a password is set without an explicit spec; {@link #custom()}
+ * opens a builder for finer control.
  */
 public final class EncryptionSpec {
 
@@ -94,11 +90,7 @@ public final class EncryptionSpec {
     public Hash getHash() { return hash; }
     public int getKeyBits() { return keyBits; }
 
-    /**
-     * AES uses a fixed 16-byte block at every key size; this is the value POI
-     * expects in {@link EncryptionInfo}'s {@code blockSize} slot regardless of
-     * key length.
-     */
+    // AES uses a fixed 16-byte block at every key size; POI expects this in EncryptionInfo#blockSize.
     private static final int AES_BLOCK_SIZE_BYTES = 16;
 
     EncryptionInfo toEncryptionInfo() {

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/EncryptionSpec.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/EncryptionSpec.java
@@ -96,7 +96,8 @@ public final class EncryptionSpec {
     // AES uses a fixed 16-byte block at every key size; POI expects this in EncryptionInfo#blockSize.
     private static final int AES_BLOCK_SIZE_BYTES = 16;
 
-    EncryptionInfo toEncryptionInfo() {
+    /** Internal — used by the write path to build the POI {@link EncryptionInfo}. */
+    public EncryptionInfo toEncryptionInfo() {
         // POI: standard encryption supports only ECB; agile uses CBC.
         final ChainingMode chaining = compatibility == Compatibility.EXCEL_2007_2010
                 ? ChainingMode.ecb : ChainingMode.cbc;

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/EncryptionSpec.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/EncryptionSpec.java
@@ -71,7 +71,7 @@ public final class EncryptionSpec {
         return new EncryptionSpec(Compatibility.EXCEL_2013_PLUS, Cipher.AES_256, Hash.SHA_512, 256);
     }
 
-    /** AES-128 + SHA-512 (Excel 2013+). Roughly half the key-schedule cost of {@link #strong()}. */
+    /** AES-128 + SHA-512 (Excel 2013+). LibreOffice rejects this combination — use {@link #strong()} or {@link #legacy()} for LibreOffice compatibility. */
     public static EncryptionSpec balanced() {
         return new EncryptionSpec(Compatibility.EXCEL_2013_PLUS, Cipher.AES_128, Hash.SHA_512, 128);
     }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/EncryptionSpec.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/EncryptionSpec.java
@@ -1,0 +1,163 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import org.apache.poi.poifs.crypt.ChainingMode;
+import org.apache.poi.poifs.crypt.CipherAlgorithm;
+import org.apache.poi.poifs.crypt.EncryptionInfo;
+import org.apache.poi.poifs.crypt.EncryptionMode;
+import org.apache.poi.poifs.crypt.HashAlgorithm;
+
+/**
+ * Encryption strength preset for password-protected OOXML output, used with
+ * {@code SheetOutput.withEncryption}. {@link #strong()} is the default when
+ * a password is set without an explicit spec.
+ *
+ * <p>The four presets cover the practical strength / compatibility / speed
+ * axis without exposing POI's cipher / hash / mode enums. {@link #custom()}
+ * opens a builder for finer control while keeping POI types behind the
+ * abstraction.
+ */
+public final class EncryptionSpec {
+
+    /** Underlying cipher family. */
+    public enum Cipher {
+        AES_128(CipherAlgorithm.aes128),
+        AES_192(CipherAlgorithm.aes192),
+        AES_256(CipherAlgorithm.aes256);
+
+        final CipherAlgorithm poi;
+
+        Cipher(final CipherAlgorithm poi) { this.poi = poi; }
+    }
+
+    /** Hash used for the password-derivation key and integrity check. */
+    public enum Hash {
+        SHA_1(HashAlgorithm.sha1),
+        SHA_256(HashAlgorithm.sha256),
+        SHA_384(HashAlgorithm.sha384),
+        SHA_512(HashAlgorithm.sha512);
+
+        final HashAlgorithm poi;
+
+        Hash(final HashAlgorithm poi) { this.poi = poi; }
+    }
+
+    /** Excel-version compatibility envelope. */
+    public enum Compatibility {
+        /** Agile encryption — Excel 2013 and newer. */
+        EXCEL_2013_PLUS(EncryptionMode.agile),
+        /** Standard encryption — Excel 2007/2010. */
+        EXCEL_2007_2010(EncryptionMode.standard);
+
+        final EncryptionMode poi;
+
+        Compatibility(final EncryptionMode poi) { this.poi = poi; }
+    }
+
+    private final Compatibility compatibility;
+    private final Cipher cipher;
+    private final Hash hash;
+    private final int keyBits;
+
+    private EncryptionSpec(final Compatibility compatibility, final Cipher cipher,
+                           final Hash hash, final int keyBits) {
+        this.compatibility = compatibility;
+        this.cipher = cipher;
+        this.hash = hash;
+        this.keyBits = keyBits;
+    }
+
+    /** AES-256 + SHA-512 (Excel 2013+). Default. */
+    public static EncryptionSpec strong() {
+        return new EncryptionSpec(Compatibility.EXCEL_2013_PLUS, Cipher.AES_256, Hash.SHA_512, 256);
+    }
+
+    /** AES-128 + SHA-512 (Excel 2013+). Roughly half the key-schedule cost of {@link #strong()}. */
+    public static EncryptionSpec balanced() {
+        return new EncryptionSpec(Compatibility.EXCEL_2013_PLUS, Cipher.AES_128, Hash.SHA_512, 128);
+    }
+
+    /** AES-128 + SHA-1 (Excel 2007/2010). Opens in older Excel installs that reject agile mode. */
+    public static EncryptionSpec legacy() {
+        return new EncryptionSpec(Compatibility.EXCEL_2007_2010, Cipher.AES_128, Hash.SHA_1, 128);
+    }
+
+    /** AES-128 + SHA-256 (Excel 2013+). Lighter hash than {@link #balanced()}. */
+    public static EncryptionSpec fast() {
+        return new EncryptionSpec(Compatibility.EXCEL_2013_PLUS, Cipher.AES_128, Hash.SHA_256, 128);
+    }
+
+    /** Builder for custom combinations. Invalid combinations raise at {@link Builder#build()}. */
+    public static Builder custom() { return new Builder(); }
+
+    public Compatibility getCompatibility() { return compatibility; }
+    public Cipher getCipher() { return cipher; }
+    public Hash getHash() { return hash; }
+    public int getKeyBits() { return keyBits; }
+
+    /**
+     * AES uses a fixed 16-byte block at every key size; this is the value POI
+     * expects in {@link EncryptionInfo}'s {@code blockSize} slot regardless of
+     * key length.
+     */
+    private static final int AES_BLOCK_SIZE_BYTES = 16;
+
+    EncryptionInfo toPoiEncryptionInfo() {
+        // POI: standard encryption supports only ECB; agile uses CBC.
+        final ChainingMode chaining = compatibility == Compatibility.EXCEL_2007_2010
+                ? ChainingMode.ecb : ChainingMode.cbc;
+        return new EncryptionInfo(compatibility.poi, cipher.poi, hash.poi,
+                keyBits, AES_BLOCK_SIZE_BYTES, chaining);
+    }
+
+    @Override
+    public String toString() {
+        return "EncryptionSpec(" + compatibility + ", " + cipher + ", " + hash
+                + ", " + keyBits + " bits)";
+    }
+
+    public static final class Builder {
+        private Compatibility compatibility = Compatibility.EXCEL_2013_PLUS;
+        private Cipher cipher = Cipher.AES_256;
+        private Hash hash = Hash.SHA_512;
+        private int keyBits = 256;
+        private boolean keyBitsSet;
+
+        private Builder() {}
+
+        public Builder compatibility(final Compatibility c) {
+            this.compatibility = c;
+            return this;
+        }
+
+        public Builder cipher(final Cipher c) {
+            this.cipher = c;
+            if (!keyBitsSet) {
+                this.keyBits = (c == Cipher.AES_256 ? 256 : c == Cipher.AES_192 ? 192 : 128);
+            }
+            return this;
+        }
+
+        public Builder hash(final Hash h) {
+            this.hash = h;
+            return this;
+        }
+
+        public Builder keyBits(final int bits) {
+            if (bits != 128 && bits != 192 && bits != 256) {
+                throw new IllegalArgumentException(
+                        "keyBits must be 128, 192, or 256 (was " + bits + ")");
+            }
+            this.keyBits = bits;
+            this.keyBitsSet = true;
+            return this;
+        }
+
+        public EncryptionSpec build() {
+            if (compatibility == Compatibility.EXCEL_2007_2010 && cipher == Cipher.AES_256) {
+                throw new IllegalArgumentException(
+                        "EXCEL_2007_2010 (standard mode) does not support AES-256");
+            }
+            return new EncryptionSpec(compatibility, cipher, hash, keyBits);
+        }
+    }
+}

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/EncryptionSpec.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/EncryptionSpec.java
@@ -101,7 +101,7 @@ public final class EncryptionSpec {
      */
     private static final int AES_BLOCK_SIZE_BYTES = 16;
 
-    EncryptionInfo toPoiEncryptionInfo() {
+    EncryptionInfo toEncryptionInfo() {
         // POI: standard encryption supports only ECB; agile uses CBC.
         final ChainingMode chaining = compatibility == Compatibility.EXCEL_2007_2010
                 ? ChainingMode.ecb : ChainingMode.cbc;

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/EncryptionSpec.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/EncryptionSpec.java
@@ -6,12 +6,15 @@ import org.apache.poi.poifs.crypt.EncryptionInfo;
 import org.apache.poi.poifs.crypt.EncryptionMode;
 import org.apache.poi.poifs.crypt.HashAlgorithm;
 
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.Incubating;
+
 /**
  * Encryption strength preset for password-protected OOXML output, used with
  * {@code SheetOutput.withPassword(password, spec)}. {@link #strong()} is the
  * default when a password is set without an explicit spec; {@link #custom()}
  * opens a builder for finer control.
  */
+@Incubating
 public final class EncryptionSpec {
 
     /** Underlying cipher family. */

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SpreadsheetFactory.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SpreadsheetFactory.java
@@ -7,17 +7,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 
-import java.security.GeneralSecurityException;
-
-import org.apache.poi.EncryptedDocumentException;
-import org.apache.poi.openxml4j.opc.OPCPackage;
 import org.apache.poi.openxml4j.opc.PackagePart;
-import org.apache.poi.poifs.crypt.Decryptor;
-import org.apache.poi.poifs.crypt.EncryptionInfo;
-import org.apache.poi.poifs.crypt.Encryptor;
-import org.apache.poi.poifs.crypt.temp.EncryptedTempData;
 import org.apache.poi.poifs.filesystem.FileMagic;
-import org.apache.poi.poifs.filesystem.POIFSFileSystem;
+import org.apache.poi.ss.SpreadsheetVersion;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
@@ -33,6 +25,7 @@ import io.github.scndry.jackson.dataformat.spreadsheet.deser.SheetInput;
 import io.github.scndry.jackson.dataformat.spreadsheet.deser.SheetParser;
 import io.github.scndry.jackson.dataformat.spreadsheet.deser.SheetReader;
 import io.github.scndry.jackson.dataformat.spreadsheet.poi.POICompat;
+import io.github.scndry.jackson.dataformat.spreadsheet.poi.ooxml.OoxmlEncryption;
 import io.github.scndry.jackson.dataformat.spreadsheet.poi.ooxml.PackageUtil;
 import io.github.scndry.jackson.dataformat.spreadsheet.poi.ooxml.SSMLSheetReader;
 import io.github.scndry.jackson.dataformat.spreadsheet.poi.ooxml.SSMLSheetWriter;
@@ -179,7 +172,7 @@ public final class SpreadsheetFactory extends JsonFactory {
     public SheetParser createParser(final SheetInput<?> src) throws IOException {
         SheetInput<?> source = src;
         if (src.getPassword() != null) {
-            source = _decryptToSheetInput(src);
+            source = OoxmlEncryption.decrypt(src);
         }
         source = _preferRawAsFile(source);
         final boolean resourceManaged = src != source;
@@ -217,10 +210,23 @@ public final class SpreadsheetFactory extends JsonFactory {
     }
 
     public SheetGenerator createGenerator(final SheetOutput<?> out) throws IOException {
+        final Workbook workbook = _workbookProvider.create();
+        if (out.getPassword() != null
+                && workbook.getSpreadsheetVersion() != SpreadsheetVersion.EXCEL2007) {
+            try {
+                workbook.close();
+            } catch (IOException e) {
+                if (log.isWarnEnabled()) {
+                    log.warn("Failed to close workbook after password guard rejection: {}", e.getMessage());
+                }
+            }
+            throw new IllegalArgumentException(
+                    "Password protection is supported for OOXML (XLSX) targets only");
+        }
         final SheetOutput<OutputStream> output = _rawAsOutputStream(out);
         final boolean resourceManaged = out != output;
         final IOContext ctxt = _createContext(_createContentReference(output), resourceManaged);
-        return _createGenerator(_createSheetWriter(output), ctxt);
+        return _createGenerator(_createSheetWriter(workbook, output), ctxt);
     }
 
     @Override
@@ -347,104 +353,6 @@ public final class SpreadsheetFactory extends JsonFactory {
                 ? SheetInput.source(file, src.getName()) : SheetInput.source(file, src.getIndex());
     }
 
-    /**
-     * Decrypts an encrypted OOXML source to an owner-only temp file and
-     * returns a fresh {@link SheetInput} referencing it. The temp is cleaned
-     * when the resulting {@link SheetParser} closes.
-     */
-    @SuppressWarnings("unchecked")
-    private SheetInput<?> _decryptToSheetInput(final SheetInput<?> src) throws IOException {
-        // Spool InputStream to disk to bound heap usage.
-        final File encryptedFile;
-        final boolean spooledFromStream;
-        if (src.isFile()) {
-            encryptedFile = ((SheetInput<File>) src).getRaw();
-            spooledFromStream = false;
-        } else {
-            encryptedFile = _spoolToSecureTempFile(
-                    ((SheetInput<InputStream>) src).getRaw(),
-                    "jackson-spreadsheet-encrypted-");
-            spooledFromStream = true;
-        }
-
-        File decrypted = null;
-        try (POIFSFileSystem fs = _openEncryptedPOIFS(encryptedFile, src)) {
-            final EncryptionInfo info;
-            try {
-                info = new EncryptionInfo(fs);
-            } catch (IOException e) {
-                throw new EncryptedDocumentException(
-                        "Source is not an encrypted OOXML document (password was supplied"
-                                + " but no EncryptionInfo entry found): " + src);
-            }
-            final Decryptor d = Decryptor.getInstance(info);
-            try {
-                if (!d.verifyPassword(src.getPassword())) {
-                    throw new EncryptedDocumentException(
-                            "Invalid password for encrypted spreadsheet source: " + src);
-                }
-            } catch (GeneralSecurityException e) {
-                throw new IOException("Failed to verify password for " + src, e);
-            }
-            decrypted = POICompat.createSecureTempFile(
-                    "jackson-spreadsheet-decrypted-", ".xlsx").toFile();
-            try (InputStream plain = d.getDataStream(fs);
-                 FileOutputStream out = new FileOutputStream(decrypted)) {
-                final byte[] buf = new byte[8192];
-                int n;
-                while ((n = plain.read(buf)) != -1) {
-                    out.write(buf, 0, n);
-                }
-            } catch (GeneralSecurityException e) {
-                throw new IOException("Failed to read decrypted data stream for " + src, e);
-            }
-        } catch (IOException | RuntimeException e) {
-            if (decrypted != null) {
-                try { POICompat.releaseTempFile(decrypted.toPath()); }
-                catch (IOException cleanup) { e.addSuppressed(cleanup); }
-            }
-            throw e;
-        } finally {
-            if (spooledFromStream) {
-                try { POICompat.releaseTempFile(encryptedFile.toPath()); }
-                catch (IOException ignore) { /* best effort */ }
-            }
-        }
-        if (log.isDebugEnabled()) {
-            log.debug("Decrypted encrypted source to temp file: {}", decrypted);
-        }
-        return src.isNamed()
-                ? SheetInput.source(decrypted, src.getName())
-                : SheetInput.source(decrypted, src.getIndex());
-    }
-
-    private POIFSFileSystem _openEncryptedPOIFS(final File encryptedFile, final SheetInput<?> src)
-            throws IOException {
-        try {
-            return new POIFSFileSystem(encryptedFile, true);
-        } catch (org.apache.poi.poifs.filesystem.OfficeXmlFileException e) {
-            // Plain OOXML (zip) reaches here as OfficeXmlFileException — POIFSFileSystem only opens OLE2.
-            throw new EncryptedDocumentException(
-                    "Source is not an encrypted OOXML document (password was supplied"
-                            + " but the file is a plain OOXML package): " + src);
-        }
-    }
-
-    private File _spoolToSecureTempFile(final InputStream in, final String prefix) throws IOException {
-        final File temp = POICompat.createSecureTempFile(prefix, ".tmp").toFile();
-        try (FileOutputStream out = new FileOutputStream(temp)) {
-            final byte[] buf = new byte[8192];
-            int n;
-            while ((n = in.read(buf)) != -1) {
-                out.write(buf, 0, n);
-            }
-        } catch (IOException e) {
-            try { POICompat.releaseTempFile(temp.toPath()); }
-            catch (IOException cleanup) { e.addSuppressed(cleanup); }
-            throw e;
-        }
-        return temp;
-    }
 
     /*
     /**********************************************************
@@ -457,8 +365,7 @@ public final class SpreadsheetFactory extends JsonFactory {
     }
 
     @SuppressWarnings("resource")
-    private SheetWriter _createSheetWriter(final SheetOutput<OutputStream> out) throws IOException {
-        final Workbook workbook = _workbookProvider.create();
+    private SheetWriter _createSheetWriter(final Workbook workbook, final SheetOutput<OutputStream> out) throws IOException {
         final Sheet sheet = out.isNamed()
                 ? workbook.createSheet(out.getName()) : workbook.createSheet();
         final boolean useUserModel = _shouldUsePOIUserModel(sheet);
@@ -497,113 +404,11 @@ public final class SpreadsheetFactory extends JsonFactory {
     private SheetOutput<OutputStream> _rawAsOutputStream(
             final SheetOutput<?> out) throws IOException {
         if (out.getPassword() != null) {
-            return _encryptedWrap(out);
+            return OoxmlEncryption.wrapTarget(out);
         }
         if (!out.isFile()) return (SheetOutput<OutputStream>) out;
         final OutputStream raw = Files.newOutputStream(((File) out.getRaw()).toPath());
         return out.isNamed() ? SheetOutput.target(raw, out.getName()) : SheetOutput.target(raw);
-    }
-
-    /**
-     * Wraps an encrypted target — plain OOXML is streamed into an
-     * {@link EncryptedTempData} and encrypted on close.
-     */
-    private SheetOutput<OutputStream> _encryptedWrap(final SheetOutput<?> out) throws IOException {
-        final EncryptedTempData tempData = new EncryptedTempData();
-        final String password = out.getPassword();
-        final EncryptionSpec spec = out.getEncryption() != null
-                ? out.getEncryption() : EncryptionSpec.strong();
-        // FilterOutputStream's protected `out` field shadows the SheetOutput name below.
-        final SheetOutput<?> destination = out;
-        final OutputStream tempStream;
-        try {
-            tempStream = new java.io.FilterOutputStream(tempData.getOutputStream()) {
-                private boolean closed;
-                @Override
-                public void close() throws IOException {
-                    if (closed) return;
-                    closed = true;
-                    super.close();
-                    try {
-                        _encryptToTarget(tempData, destination, password, spec);
-                    } finally {
-                        tempData.dispose();
-                    }
-                }
-            };
-        } catch (IOException | RuntimeException e) {
-            tempData.dispose();
-            throw e;
-        }
-        return out.isNamed()
-                ? SheetOutput.target(tempStream, out.getName())
-                : SheetOutput.target(tempStream);
-    }
-
-    @SuppressWarnings("unchecked")
-    private void _encryptToTarget(final EncryptedTempData tempData, final SheetOutput<?> out,
-                                  final String password, final EncryptionSpec spec) throws IOException {
-        // File targets: write to a sibling temp, then atomic rename — partial bytes never reach the target.
-        final File finalTarget = out.isFile() ? ((SheetOutput<File>) out).getRaw() : null;
-        final File siblingTemp = finalTarget != null
-                ? new File(finalTarget.getAbsoluteFile().getParentFile(),
-                        finalTarget.getName() + ".enc-" + Long.toUnsignedString(System.nanoTime(), 36) + ".tmp")
-                : null;
-        final OutputStream target = (siblingTemp != null)
-                ? new FileOutputStream(siblingTemp)
-                : ((SheetOutput<OutputStream>) out).getRaw();
-        boolean writeFinalized = false;
-        IOException primary = null;
-        try {
-            try (InputStream plainIn = tempData.getInputStream();
-                 POIFSFileSystem fs = new POIFSFileSystem();
-                 OPCPackage opc = OPCPackage.open(plainIn)) {
-                final EncryptionInfo info = spec.toEncryptionInfo();
-                final Encryptor enc = Encryptor.getInstance(info);
-                try {
-                    enc.confirmPassword(password);
-                    // OPCPackage.save() only finishes the zip wrap, never closes;
-                    // explicit close commits EncryptionInfo / EncryptedPackage to the POIFS root.
-                    try (OutputStream encStream = enc.getDataStream(fs)) {
-                        opc.save(encStream);
-                    }
-                } catch (GeneralSecurityException e) {
-                    throw new IOException("Failed to encrypt spreadsheet output", e);
-                }
-                fs.writeFilesystem(target);
-                writeFinalized = true;
-            } catch (org.apache.poi.openxml4j.exceptions.InvalidFormatException e) {
-                throw new IOException("Failed to open temp data for encryption", e);
-            }
-        } catch (IOException e) {
-            primary = e;
-            throw e;
-        } finally {
-            if (siblingTemp != null) {
-                try {
-                    target.close();
-                } catch (IOException closeEx) {
-                    if (primary != null) primary.addSuppressed(closeEx);
-                    else throw closeEx;
-                }
-                if (writeFinalized) {
-                    try {
-                        Files.move(siblingTemp.toPath(), finalTarget.toPath(),
-                                java.nio.file.StandardCopyOption.ATOMIC_MOVE,
-                                java.nio.file.StandardCopyOption.REPLACE_EXISTING);
-                    } catch (java.nio.file.AtomicMoveNotSupportedException ex) {
-                        // Cross-filesystem — non-atomic, but partial state stays in sibling.
-                        Files.move(siblingTemp.toPath(), finalTarget.toPath(),
-                                java.nio.file.StandardCopyOption.REPLACE_EXISTING);
-                    }
-                } else {
-                    // Mid-write failure — delete sibling, leave target untouched.
-                    if (siblingTemp.exists() && !siblingTemp.delete() && log.isWarnEnabled()) {
-                        log.warn("Failed to delete partial encrypted sibling: {}", siblingTemp);
-                    }
-                }
-            }
-        }
     }
 
     /**

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SpreadsheetFactory.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SpreadsheetFactory.java
@@ -521,7 +521,7 @@ public final class SpreadsheetFactory extends JsonFactory {
         final EncryptedTempData tempData = new EncryptedTempData();
         final String password = out.getPassword();
         final EncryptionSpec spec = out.getEncryption() != null
-                ? out.getEncryption() : EncryptionSpec.balanced();
+                ? out.getEncryption() : EncryptionSpec.strong();
         // Captured locals — anonymous FilterOutputStream subclass shadows the
         // protected `out` field, so the SheetOutput must be referenced under a
         // distinct name to avoid the field shadowing.

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SpreadsheetFactory.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SpreadsheetFactory.java
@@ -348,19 +348,13 @@ public final class SpreadsheetFactory extends JsonFactory {
     }
 
     /**
-     * Decrypts an encrypted OOXML source to a POSIX owner-only temp file and
-     * returns a fresh {@link SheetInput} referencing it. The temp file is
-     * scheduled for deletion when the resulting {@link SheetParser} closes
-     * (resource-managed). Caller-owned {@link InputStream} sources are first
-     * spooled to disk to keep heap usage bounded for large encrypted files.
-     *
-     * <p>Throws {@link EncryptedDocumentException} when the password is wrong
-     * or the source is not actually encrypted.
+     * Decrypts an encrypted OOXML source to an owner-only temp file and
+     * returns a fresh {@link SheetInput} referencing it. The temp is cleaned
+     * when the resulting {@link SheetParser} closes.
      */
     @SuppressWarnings("unchecked")
     private SheetInput<?> _decryptToSheetInput(final SheetInput<?> src) throws IOException {
-        // F6: spool InputStream to disk before opening POIFS to avoid loading the
-        // entire encrypted file into memory.
+        // Spool InputStream to disk to bound heap usage.
         final File encryptedFile;
         final boolean spooledFromStream;
         if (src.isFile()) {
@@ -429,7 +423,7 @@ public final class SpreadsheetFactory extends JsonFactory {
         try {
             return new POIFSFileSystem(encryptedFile, true);
         } catch (org.apache.poi.poifs.filesystem.OfficeXmlFileException e) {
-            // F8: plain OOXML (zip) — POIFSFileSystem only opens OLE2 binary.
+            // Plain OOXML (zip) reaches here as OfficeXmlFileException — POIFSFileSystem only opens OLE2.
             throw new EncryptedDocumentException(
                     "Source is not an encrypted OOXML document (password was supplied"
                             + " but the file is a plain OOXML package): " + src);
@@ -511,20 +505,15 @@ public final class SpreadsheetFactory extends JsonFactory {
     }
 
     /**
-     * Wraps an encrypted target — the writer streams plain OOXML into an
-     * {@link EncryptedTempData} (AES-128-CBC with an in-memory random key, so
-     * even if the temp survives a crash the bytes on disk are unreadable). On
-     * close the temp is fed through {@link Encryptor} (agile, AES-256 + SHA-512)
-     * and the encrypted bytes land on the original target.
+     * Wraps an encrypted target — plain OOXML is streamed into an
+     * {@link EncryptedTempData} and encrypted on close.
      */
     private SheetOutput<OutputStream> _encryptedWrap(final SheetOutput<?> out) throws IOException {
         final EncryptedTempData tempData = new EncryptedTempData();
         final String password = out.getPassword();
         final EncryptionSpec spec = out.getEncryption() != null
                 ? out.getEncryption() : EncryptionSpec.strong();
-        // Captured locals — anonymous FilterOutputStream subclass shadows the
-        // protected `out` field, so the SheetOutput must be referenced under a
-        // distinct name to avoid the field shadowing.
+        // FilterOutputStream's protected `out` field shadows the SheetOutput name below.
         final SheetOutput<?> destination = out;
         final OutputStream tempStream;
         try {
@@ -554,11 +543,7 @@ public final class SpreadsheetFactory extends JsonFactory {
     @SuppressWarnings("unchecked")
     private void _encryptToTarget(final EncryptedTempData tempData, final SheetOutput<?> out,
                                   final String password, final EncryptionSpec spec) throws IOException {
-        // SEC-18: for File targets, write encrypted bytes into a sibling temp file
-        // and atomically rename onto the final target. Partial encrypted bytes
-        // never appear at the target path; mid-write failures leave the original
-        // target untouched. OutputStream targets cannot be made atomic by this
-        // library — the caller owns the stream and must wrap accordingly.
+        // File targets: write to a sibling temp, then atomic rename — partial bytes never reach the target.
         final File finalTarget = out.isFile() ? ((SheetOutput<File>) out).getRaw() : null;
         final File siblingTemp = finalTarget != null
                 ? new File(finalTarget.getAbsoluteFile().getParentFile(),
@@ -577,10 +562,8 @@ public final class SpreadsheetFactory extends JsonFactory {
                 final Encryptor enc = Encryptor.getInstance(info);
                 try {
                     enc.confirmPassword(password);
-                    // Explicit close on the cipher stream is critical: OPCPackage.save
-                    // only calls finish() on its ZipArchiveOutputStream wrap, never
-                    // close(), so AgileCipherOutputStream never commits its
-                    // EncryptionInfo / EncryptedPackage entries to the POIFS root.
+                    // OPCPackage.save() only finishes the zip wrap, never closes;
+                    // explicit close commits EncryptionInfo / EncryptedPackage to the POIFS root.
                     try (OutputStream encStream = enc.getDataStream(fs)) {
                         opc.save(encStream);
                     }
@@ -596,7 +579,6 @@ public final class SpreadsheetFactory extends JsonFactory {
             primary = e;
             throw e;
         } finally {
-            // F3: addSuppressed pattern — preserve primary IOException
             if (siblingTemp != null) {
                 try {
                     target.close();
@@ -610,13 +592,12 @@ public final class SpreadsheetFactory extends JsonFactory {
                                 java.nio.file.StandardCopyOption.ATOMIC_MOVE,
                                 java.nio.file.StandardCopyOption.REPLACE_EXISTING);
                     } catch (java.nio.file.AtomicMoveNotSupportedException ex) {
-                        // Cross-filesystem fallback — non-atomic but the partial
-                        // intermediate state is the sibling, not finalTarget.
+                        // Cross-filesystem — non-atomic, but partial state stays in sibling.
                         Files.move(siblingTemp.toPath(), finalTarget.toPath(),
                                 java.nio.file.StandardCopyOption.REPLACE_EXISTING);
                     }
                 } else {
-                    // F4: mid-write failure — delete sibling, leave finalTarget untouched.
+                    // Mid-write failure — delete sibling, leave target untouched.
                     if (siblingTemp.exists() && !siblingTemp.delete() && log.isWarnEnabled()) {
                         log.warn("Failed to delete partial encrypted sibling: {}", siblingTemp);
                     }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SpreadsheetFactory.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SpreadsheetFactory.java
@@ -12,13 +12,9 @@ import java.security.GeneralSecurityException;
 import org.apache.poi.EncryptedDocumentException;
 import org.apache.poi.openxml4j.opc.OPCPackage;
 import org.apache.poi.openxml4j.opc.PackagePart;
-import org.apache.poi.poifs.crypt.ChainingMode;
-import org.apache.poi.poifs.crypt.CipherAlgorithm;
 import org.apache.poi.poifs.crypt.Decryptor;
 import org.apache.poi.poifs.crypt.EncryptionInfo;
-import org.apache.poi.poifs.crypt.EncryptionMode;
 import org.apache.poi.poifs.crypt.Encryptor;
-import org.apache.poi.poifs.crypt.HashAlgorithm;
 import org.apache.poi.poifs.crypt.temp.EncryptedTempData;
 import org.apache.poi.poifs.filesystem.FileMagic;
 import org.apache.poi.poifs.filesystem.POIFSFileSystem;
@@ -524,6 +520,8 @@ public final class SpreadsheetFactory extends JsonFactory {
     private SheetOutput<OutputStream> _encryptedWrap(final SheetOutput<?> out) throws IOException {
         final EncryptedTempData tempData = new EncryptedTempData();
         final String password = out.getPassword();
+        final EncryptionSpec spec = out.getEncryption() != null
+                ? out.getEncryption() : EncryptionSpec.strong();
         // Captured locals — anonymous FilterOutputStream subclass shadows the
         // protected `out` field, so the SheetOutput must be referenced under a
         // distinct name to avoid the field shadowing.
@@ -538,7 +536,7 @@ public final class SpreadsheetFactory extends JsonFactory {
                     closed = true;
                     super.close();
                     try {
-                        _encryptToTarget(tempData, destination, password);
+                        _encryptToTarget(tempData, destination, password, spec);
                     } finally {
                         tempData.dispose();
                     }
@@ -555,7 +553,7 @@ public final class SpreadsheetFactory extends JsonFactory {
 
     @SuppressWarnings("unchecked")
     private void _encryptToTarget(final EncryptedTempData tempData, final SheetOutput<?> out,
-                                  final String password) throws IOException {
+                                  final String password, final EncryptionSpec spec) throws IOException {
         // SEC-18: for File targets, write encrypted bytes into a sibling temp file
         // and atomically rename onto the final target. Partial encrypted bytes
         // never appear at the target path; mid-write failures leave the original
@@ -575,12 +573,7 @@ public final class SpreadsheetFactory extends JsonFactory {
             try (InputStream plainIn = tempData.getInputStream();
                  POIFSFileSystem fs = new POIFSFileSystem();
                  OPCPackage opc = OPCPackage.open(plainIn)) {
-                // F5: explicit AES-256 + SHA-512 (modern strength); the default
-                // EncryptionInfo(agile) ctor pins AES-128. keyBits in bits,
-                // blockSize in bytes — AES uses a 16-byte block at every key
-                // size (CipherAlgorithm.aes256 declares blockSize=16).
-                final EncryptionInfo info = new EncryptionInfo(EncryptionMode.agile,
-                        CipherAlgorithm.aes256, HashAlgorithm.sha512, 256, 16, ChainingMode.cbc);
+                final EncryptionInfo info = spec.toPoiEncryptionInfo();
                 final Encryptor enc = Encryptor.getInstance(info);
                 try {
                     enc.confirmPassword(password);

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SpreadsheetFactory.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SpreadsheetFactory.java
@@ -7,8 +7,21 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 
+import java.security.GeneralSecurityException;
+
+import org.apache.poi.EncryptedDocumentException;
+import org.apache.poi.openxml4j.opc.OPCPackage;
 import org.apache.poi.openxml4j.opc.PackagePart;
+import org.apache.poi.poifs.crypt.ChainingMode;
+import org.apache.poi.poifs.crypt.CipherAlgorithm;
+import org.apache.poi.poifs.crypt.Decryptor;
+import org.apache.poi.poifs.crypt.EncryptionInfo;
+import org.apache.poi.poifs.crypt.EncryptionMode;
+import org.apache.poi.poifs.crypt.Encryptor;
+import org.apache.poi.poifs.crypt.HashAlgorithm;
+import org.apache.poi.poifs.crypt.temp.EncryptedTempData;
 import org.apache.poi.poifs.filesystem.FileMagic;
+import org.apache.poi.poifs.filesystem.POIFSFileSystem;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
@@ -168,7 +181,11 @@ public final class SpreadsheetFactory extends JsonFactory {
 
     @SuppressWarnings("unchecked")
     public SheetParser createParser(final SheetInput<?> src) throws IOException {
-        final SheetInput<?> source = _preferRawAsFile(src);
+        SheetInput<?> source = src;
+        if (src.getPassword() != null) {
+            source = _decryptToSheetInput(src);
+        }
+        source = _preferRawAsFile(source);
         final boolean resourceManaged = src != source;
         final IOContext ctxt = _createContext(_createContentReference(source), resourceManaged);
         final SheetReader reader;
@@ -334,6 +351,111 @@ public final class SpreadsheetFactory extends JsonFactory {
                 ? SheetInput.source(file, src.getName()) : SheetInput.source(file, src.getIndex());
     }
 
+    /**
+     * Decrypts an encrypted OOXML source to a POSIX owner-only temp file and
+     * returns a fresh {@link SheetInput} referencing it. The temp file is
+     * scheduled for deletion when the resulting {@link SheetParser} closes
+     * (resource-managed). Caller-owned {@link InputStream} sources are first
+     * spooled to disk to keep heap usage bounded for large encrypted files.
+     *
+     * <p>Throws {@link EncryptedDocumentException} when the password is wrong
+     * or the source is not actually encrypted.
+     */
+    @SuppressWarnings("unchecked")
+    private SheetInput<?> _decryptToSheetInput(final SheetInput<?> src) throws IOException {
+        // F6: spool InputStream to disk before opening POIFS to avoid loading the
+        // entire encrypted file into memory.
+        final File encryptedFile;
+        final boolean spooledFromStream;
+        if (src.isFile()) {
+            encryptedFile = ((SheetInput<File>) src).getRaw();
+            spooledFromStream = false;
+        } else {
+            encryptedFile = _spoolToSecureTempFile(
+                    ((SheetInput<InputStream>) src).getRaw(),
+                    "jackson-spreadsheet-encrypted-");
+            spooledFromStream = true;
+        }
+
+        File decrypted = null;
+        try (POIFSFileSystem fs = _openEncryptedPOIFS(encryptedFile, src)) {
+            final EncryptionInfo info;
+            try {
+                info = new EncryptionInfo(fs);
+            } catch (IOException e) {
+                throw new EncryptedDocumentException(
+                        "Source is not an encrypted OOXML document (password was supplied"
+                                + " but no EncryptionInfo entry found): " + src);
+            }
+            final Decryptor d = Decryptor.getInstance(info);
+            try {
+                if (!d.verifyPassword(src.getPassword())) {
+                    throw new EncryptedDocumentException(
+                            "Invalid password for encrypted spreadsheet source: " + src);
+                }
+            } catch (GeneralSecurityException e) {
+                throw new IOException("Failed to verify password for " + src, e);
+            }
+            decrypted = POICompat.createSecureTempFile(
+                    "jackson-spreadsheet-decrypted-", ".xlsx").toFile();
+            try (InputStream plain = d.getDataStream(fs);
+                 FileOutputStream out = new FileOutputStream(decrypted)) {
+                final byte[] buf = new byte[8192];
+                int n;
+                while ((n = plain.read(buf)) != -1) {
+                    out.write(buf, 0, n);
+                }
+            } catch (GeneralSecurityException e) {
+                throw new IOException("Failed to read decrypted data stream for " + src, e);
+            }
+        } catch (IOException | RuntimeException e) {
+            if (decrypted != null) {
+                try { POICompat.releaseTempFile(decrypted.toPath()); }
+                catch (IOException cleanup) { e.addSuppressed(cleanup); }
+            }
+            throw e;
+        } finally {
+            if (spooledFromStream) {
+                try { POICompat.releaseTempFile(encryptedFile.toPath()); }
+                catch (IOException ignore) { /* best effort */ }
+            }
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Decrypted encrypted source to temp file: {}", decrypted);
+        }
+        return src.isNamed()
+                ? SheetInput.source(decrypted, src.getName())
+                : SheetInput.source(decrypted, src.getIndex());
+    }
+
+    private POIFSFileSystem _openEncryptedPOIFS(final File encryptedFile, final SheetInput<?> src)
+            throws IOException {
+        try {
+            return new POIFSFileSystem(encryptedFile, true);
+        } catch (org.apache.poi.poifs.filesystem.OfficeXmlFileException e) {
+            // F8: plain OOXML (zip) — POIFSFileSystem only opens OLE2 binary.
+            throw new EncryptedDocumentException(
+                    "Source is not an encrypted OOXML document (password was supplied"
+                            + " but the file is a plain OOXML package): " + src);
+        }
+    }
+
+    private File _spoolToSecureTempFile(final InputStream in, final String prefix) throws IOException {
+        final File temp = POICompat.createSecureTempFile(prefix, ".tmp").toFile();
+        try (FileOutputStream out = new FileOutputStream(temp)) {
+            final byte[] buf = new byte[8192];
+            int n;
+            while ((n = in.read(buf)) != -1) {
+                out.write(buf, 0, n);
+            }
+        } catch (IOException e) {
+            try { POICompat.releaseTempFile(temp.toPath()); }
+            catch (IOException cleanup) { e.addSuppressed(cleanup); }
+            throw e;
+        }
+        return temp;
+    }
+
     /*
     /**********************************************************
     /* Factory methods used by factory for creating generator instances,
@@ -384,9 +506,110 @@ public final class SpreadsheetFactory extends JsonFactory {
     @SuppressWarnings("unchecked")
     private SheetOutput<OutputStream> _rawAsOutputStream(
             final SheetOutput<?> out) throws IOException {
+        if (out.getPassword() != null) {
+            return _encryptedWrap(out);
+        }
         if (!out.isFile()) return (SheetOutput<OutputStream>) out;
         final OutputStream raw = Files.newOutputStream(((File) out.getRaw()).toPath());
         return out.isNamed() ? SheetOutput.target(raw, out.getName()) : SheetOutput.target(raw);
+    }
+
+    /**
+     * Wraps an encrypted target — the writer streams plain OOXML into an
+     * {@link EncryptedTempData} (AES-128-CBC with an in-memory random key, so
+     * even if the temp survives a crash the bytes on disk are unreadable). On
+     * close the temp is fed through {@link Encryptor} (agile, AES-256 + SHA-512)
+     * and the encrypted bytes land on the original target.
+     */
+    private SheetOutput<OutputStream> _encryptedWrap(final SheetOutput<?> out) throws IOException {
+        final EncryptedTempData tempData = new EncryptedTempData();
+        final String password = out.getPassword();
+        // Captured locals — anonymous FilterOutputStream subclass shadows the
+        // protected `out` field, so the SheetOutput must be referenced under a
+        // distinct name to avoid the field shadowing.
+        final SheetOutput<?> destination = out;
+        final OutputStream tempStream;
+        try {
+            tempStream = new java.io.FilterOutputStream(tempData.getOutputStream()) {
+                private boolean closed;
+                @Override
+                public void close() throws IOException {
+                    if (closed) return;
+                    closed = true;
+                    super.close();
+                    try {
+                        _encryptToTarget(tempData, destination, password);
+                    } finally {
+                        tempData.dispose();
+                    }
+                }
+            };
+        } catch (IOException | RuntimeException e) {
+            tempData.dispose();
+            throw e;
+        }
+        return out.isNamed()
+                ? SheetOutput.target(tempStream, out.getName())
+                : SheetOutput.target(tempStream);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void _encryptToTarget(final EncryptedTempData tempData, final SheetOutput<?> out,
+                                  final String password) throws IOException {
+        final OutputStream target = out.isFile()
+                ? new FileOutputStream(((SheetOutput<File>) out).getRaw())
+                : ((SheetOutput<OutputStream>) out).getRaw();
+        boolean writeFinalized = false;
+        IOException primary = null;
+        try {
+            try (InputStream plainIn = tempData.getInputStream();
+                 POIFSFileSystem fs = new POIFSFileSystem();
+                 OPCPackage opc = OPCPackage.open(plainIn)) {
+                // F5: explicit AES-256 + SHA-512 (modern strength); the default
+                // EncryptionInfo(agile) ctor pins AES-128. keyBits in bits,
+                // blockSize in bytes — AES uses a 16-byte block at every key
+                // size (CipherAlgorithm.aes256 declares blockSize=16).
+                final EncryptionInfo info = new EncryptionInfo(EncryptionMode.agile,
+                        CipherAlgorithm.aes256, HashAlgorithm.sha512, 256, 16, ChainingMode.cbc);
+                final Encryptor enc = Encryptor.getInstance(info);
+                try {
+                    enc.confirmPassword(password);
+                    // Explicit close on the cipher stream is critical: OPCPackage.save
+                    // only calls finish() on its ZipArchiveOutputStream wrap, never
+                    // close(), so AgileCipherOutputStream never commits its
+                    // EncryptionInfo / EncryptedPackage entries to the POIFS root.
+                    try (OutputStream encStream = enc.getDataStream(fs)) {
+                        opc.save(encStream);
+                    }
+                } catch (GeneralSecurityException e) {
+                    throw new IOException("Failed to encrypt spreadsheet output", e);
+                }
+                fs.writeFilesystem(target);
+                writeFinalized = true;
+            } catch (org.apache.poi.openxml4j.exceptions.InvalidFormatException e) {
+                throw new IOException("Failed to open temp data for encryption", e);
+            }
+        } catch (IOException e) {
+            primary = e;
+            throw e;
+        } finally {
+            // F3: addSuppressed pattern — preserve primary IOException
+            if (out.isFile()) {
+                try {
+                    target.close();
+                } catch (IOException closeEx) {
+                    if (primary != null) primary.addSuppressed(closeEx);
+                    else throw closeEx;
+                }
+                // F4: mid-write failure — delete partial encrypted output
+                if (!writeFinalized) {
+                    final File partial = ((SheetOutput<File>) out).getRaw();
+                    if (partial.exists() && !partial.delete() && log.isWarnEnabled()) {
+                        log.warn("Failed to delete partial encrypted output: {}", partial);
+                    }
+                }
+            }
+        }
     }
 
     /**

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SpreadsheetFactory.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SpreadsheetFactory.java
@@ -556,8 +556,18 @@ public final class SpreadsheetFactory extends JsonFactory {
     @SuppressWarnings("unchecked")
     private void _encryptToTarget(final EncryptedTempData tempData, final SheetOutput<?> out,
                                   final String password) throws IOException {
-        final OutputStream target = out.isFile()
-                ? new FileOutputStream(((SheetOutput<File>) out).getRaw())
+        // SEC-18: for File targets, write encrypted bytes into a sibling temp file
+        // and atomically rename onto the final target. Partial encrypted bytes
+        // never appear at the target path; mid-write failures leave the original
+        // target untouched. OutputStream targets cannot be made atomic by this
+        // library — the caller owns the stream and must wrap accordingly.
+        final File finalTarget = out.isFile() ? ((SheetOutput<File>) out).getRaw() : null;
+        final File siblingTemp = finalTarget != null
+                ? new File(finalTarget.getAbsoluteFile().getParentFile(),
+                        finalTarget.getName() + ".enc-" + Long.toUnsignedString(System.nanoTime(), 36) + ".tmp")
+                : null;
+        final OutputStream target = (siblingTemp != null)
+                ? new FileOutputStream(siblingTemp)
                 : ((SheetOutput<OutputStream>) out).getRaw();
         boolean writeFinalized = false;
         IOException primary = null;
@@ -594,18 +604,28 @@ public final class SpreadsheetFactory extends JsonFactory {
             throw e;
         } finally {
             // F3: addSuppressed pattern — preserve primary IOException
-            if (out.isFile()) {
+            if (siblingTemp != null) {
                 try {
                     target.close();
                 } catch (IOException closeEx) {
                     if (primary != null) primary.addSuppressed(closeEx);
                     else throw closeEx;
                 }
-                // F4: mid-write failure — delete partial encrypted output
-                if (!writeFinalized) {
-                    final File partial = ((SheetOutput<File>) out).getRaw();
-                    if (partial.exists() && !partial.delete() && log.isWarnEnabled()) {
-                        log.warn("Failed to delete partial encrypted output: {}", partial);
+                if (writeFinalized) {
+                    try {
+                        Files.move(siblingTemp.toPath(), finalTarget.toPath(),
+                                java.nio.file.StandardCopyOption.ATOMIC_MOVE,
+                                java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+                    } catch (java.nio.file.AtomicMoveNotSupportedException ex) {
+                        // Cross-filesystem fallback — non-atomic but the partial
+                        // intermediate state is the sibling, not finalTarget.
+                        Files.move(siblingTemp.toPath(), finalTarget.toPath(),
+                                java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+                    }
+                } else {
+                    // F4: mid-write failure — delete sibling, leave finalTarget untouched.
+                    if (siblingTemp.exists() && !siblingTemp.delete() && log.isWarnEnabled()) {
+                        log.warn("Failed to delete partial encrypted sibling: {}", siblingTemp);
                     }
                 }
             }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SpreadsheetFactory.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/SpreadsheetFactory.java
@@ -521,7 +521,7 @@ public final class SpreadsheetFactory extends JsonFactory {
         final EncryptedTempData tempData = new EncryptedTempData();
         final String password = out.getPassword();
         final EncryptionSpec spec = out.getEncryption() != null
-                ? out.getEncryption() : EncryptionSpec.strong();
+                ? out.getEncryption() : EncryptionSpec.balanced();
         // Captured locals — anonymous FilterOutputStream subclass shadows the
         // protected `out` field, so the SheetOutput must be referenced under a
         // distinct name to avoid the field shadowing.
@@ -573,7 +573,7 @@ public final class SpreadsheetFactory extends JsonFactory {
             try (InputStream plainIn = tempData.getInputStream();
                  POIFSFileSystem fs = new POIFSFileSystem();
                  OPCPackage opc = OPCPackage.open(plainIn)) {
-                final EncryptionInfo info = spec.toPoiEncryptionInfo();
+                final EncryptionInfo info = spec.toEncryptionInfo();
                 final Encryptor enc = Encryptor.getInstance(info);
                 try {
                     enc.confirmPassword(password);

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetInput.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetInput.java
@@ -4,6 +4,8 @@ import java.io.File;
 import java.io.InputStream;
 import java.nio.file.Path;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import lombok.EqualsAndHashCode;
 
 import io.github.scndry.jackson.dataformat.spreadsheet.SheetContent;
@@ -118,14 +120,9 @@ public final class SheetInput<T> implements SheetContent<T> {
      * Returns a copy of this {@code SheetInput} with the given password for
      * OOXML file-level (agile) decryption. Pass {@code null} to clear.
      *
-     * <p>The decrypted plaintext is materialised in a POSIX owner-only temp
-     * file that is deleted when the resulting {@link SheetParser} closes;
-     * always close the parser (try-with-resources or {@code SheetMappingIterator})
-     * to release it promptly.
-     *
-     * <p>For {@code InputStream} sources, the caller still owns the stream;
-     * this library does not close it. Password verification reads the source
-     * before mapping, so a wrong password fails fast with
+     * <p>Decryption materialises plain OOXML in a POSIX 0600 temp file that is
+     * deleted on {@link SheetParser} close. {@code InputStream} sources are not
+     * closed by this library. A wrong password throws
      * {@link org.apache.poi.EncryptedDocumentException}.
      */
     public SheetInput<T> withPassword(final String password) {
@@ -140,6 +137,7 @@ public final class SheetInput<T> implements SheetContent<T> {
 
     public int getIndex() { return _index; }
 
+    @JsonIgnore
     public String getPassword() { return _password; }
 
     @Override

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetInput.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetInput.java
@@ -117,13 +117,8 @@ public final class SheetInput<T> implements SheetContent<T> {
     }
 
     /**
-     * Returns a copy of this {@code SheetInput} with the given password for
-     * OOXML file-level (agile) decryption. Pass {@code null} to clear.
-     *
-     * <p>Decryption materialises plain OOXML in a POSIX 0600 temp file that is
-     * deleted on {@link SheetParser} close. {@code InputStream} sources are not
-     * closed by this library. A wrong password throws
-     * {@link org.apache.poi.EncryptedDocumentException}.
+     * Returns a copy with the given password for OOXML file-level
+     * decryption. Pass {@code null} to clear.
      */
     public SheetInput<T> withPassword(final String password) {
         return new SheetInput<>(_raw, _name, _index, password);

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetInput.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetInput.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.io.InputStream;
 import java.nio.file.Path;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import lombok.EqualsAndHashCode;
 
 import io.github.scndry.jackson.dataformat.spreadsheet.SheetContent;
@@ -132,7 +130,6 @@ public final class SheetInput<T> implements SheetContent<T> {
 
     public int getIndex() { return _index; }
 
-    @JsonIgnore
     public String getPassword() { return _password; }
 
     @Override

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetInput.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetInput.java
@@ -25,17 +25,21 @@ public final class SheetInput<T> implements SheetContent<T> {
     private final T _raw;
     private final String _name;
     private final int _index;
+    private final String _password;
+
+    private SheetInput(final T raw, final String name, final int index, final String password) {
+        _raw = raw;
+        _name = name;
+        _index = index;
+        _password = password;
+    }
 
     private SheetInput(final T raw, final int index) {
-        _raw = raw;
-        _name = null;
-        _index = index;
+        this(raw, null, index, null);
     }
 
     private SheetInput(final T raw, final String name) {
-        _raw = raw;
-        _name = name;
-        _index = -1;
+        this(raw, name, -1, null);
     }
 
     /**
@@ -110,6 +114,24 @@ public final class SheetInput<T> implements SheetContent<T> {
         return new SheetInput<>(raw, sheetName);
     }
 
+    /**
+     * Returns a copy of this {@code SheetInput} with the given password for
+     * OOXML file-level (agile) decryption. Pass {@code null} to clear.
+     *
+     * <p>The decrypted plaintext is materialised in a POSIX owner-only temp
+     * file that is deleted when the resulting {@link SheetParser} closes;
+     * always close the parser (try-with-resources or {@code SheetMappingIterator})
+     * to release it promptly.
+     *
+     * <p>For {@code InputStream} sources, the caller still owns the stream;
+     * this library does not close it. Password verification reads the source
+     * before mapping, so a wrong password fails fast with
+     * {@link org.apache.poi.EncryptedDocumentException}.
+     */
+    public SheetInput<T> withPassword(final String password) {
+        return new SheetInput<>(_raw, _name, _index, password);
+    }
+
     @Override
     public T getRaw() { return _raw; }
 
@@ -118,9 +140,12 @@ public final class SheetInput<T> implements SheetContent<T> {
 
     public int getIndex() { return _index; }
 
+    public String getPassword() { return _password; }
+
     @Override
     public String toString() {
-        return "SheetInput(raw=" + _raw + ", name=" + _name + ", index=" + _index + ")";
+        return "SheetInput(raw=" + _raw + ", name=" + _name + ", index=" + _index
+                + ", password=" + (_password == null ? "null" : "***") + ")";
     }
 
 }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetInput.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/deser/SheetInput.java
@@ -7,6 +7,7 @@ import java.nio.file.Path;
 import lombok.EqualsAndHashCode;
 
 import io.github.scndry.jackson.dataformat.spreadsheet.SheetContent;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.Incubating;
 
 /**
  * Immutable descriptor for a spreadsheet read source. Wraps a
@@ -118,6 +119,7 @@ public final class SheetInput<T> implements SheetContent<T> {
      * Returns a copy with the given password for OOXML file-level
      * decryption. Pass {@code null} to clear.
      */
+    @Incubating
     public SheetInput<T> withPassword(final String password) {
         return new SheetInput<>(_raw, _name, _index, password);
     }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/EncryptOnCloseOutputStream.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/EncryptOnCloseOutputStream.java
@@ -1,0 +1,45 @@
+package io.github.scndry.jackson.dataformat.spreadsheet.poi.ooxml;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+
+import org.apache.poi.poifs.crypt.temp.EncryptedTempData;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.EncryptionSpec;
+import io.github.scndry.jackson.dataformat.spreadsheet.ser.SheetOutput;
+
+/**
+ * Streams plain OOXML bytes into an {@link EncryptedTempData} and, on
+ * close, encrypts them into the final {@link SheetOutput} destination.
+ */
+final class EncryptOnCloseOutputStream extends FilterOutputStream {
+
+    private final EncryptedTempData _tempData;
+    private final SheetOutput<?> _destination;
+    private final String _password;
+    private final EncryptionSpec _spec;
+    private boolean _closed;
+
+    EncryptOnCloseOutputStream(final EncryptedTempData tempData,
+                               final SheetOutput<?> destination,
+                               final String password,
+                               final EncryptionSpec spec) throws IOException {
+        super(tempData.getOutputStream());
+        _tempData = tempData;
+        _destination = destination;
+        _password = password;
+        _spec = spec;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (_closed) return;
+        _closed = true;
+        super.close();
+        try {
+            OoxmlEncryption.encryptToTarget(_tempData, _destination, _password, _spec);
+        } finally {
+            _tempData.dispose();
+        }
+    }
+}

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/OoxmlEncryption.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/poi/ooxml/OoxmlEncryption.java
@@ -1,0 +1,227 @@
+package io.github.scndry.jackson.dataformat.spreadsheet.poi.ooxml;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.security.GeneralSecurityException;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.poi.EncryptedDocumentException;
+import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
+import org.apache.poi.openxml4j.opc.OPCPackage;
+import org.apache.poi.poifs.crypt.Decryptor;
+import org.apache.poi.poifs.crypt.EncryptionInfo;
+import org.apache.poi.poifs.crypt.Encryptor;
+import org.apache.poi.poifs.crypt.temp.EncryptedTempData;
+import org.apache.poi.poifs.filesystem.OfficeXmlFileException;
+import org.apache.poi.poifs.filesystem.POIFSFileSystem;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.EncryptionSpec;
+import io.github.scndry.jackson.dataformat.spreadsheet.deser.SheetInput;
+import io.github.scndry.jackson.dataformat.spreadsheet.poi.POICompat;
+import io.github.scndry.jackson.dataformat.spreadsheet.ser.SheetOutput;
+
+/**
+ * OOXML password protection helpers for the read and write paths.
+ * Decrypts an encrypted source to an owner-only temp file before it
+ * re-enters the regular read pipeline, and wraps a write target so the
+ * plain OOXML output is encrypted into the final destination on close.
+ */
+@Slf4j
+public final class OoxmlEncryption {
+
+    private OoxmlEncryption() {
+    }
+
+    /**
+     * Decrypts an encrypted OOXML source to an owner-only temp file and
+     * returns a fresh {@link SheetInput} referencing it.
+     */
+    @SuppressWarnings("unchecked")
+    public static SheetInput<?> decrypt(final SheetInput<?> src) throws IOException {
+        final File encryptedFile;
+        final boolean spooledFromStream;
+        if (src.isFile()) {
+            encryptedFile = ((SheetInput<File>) src).getRaw();
+            spooledFromStream = false;
+        } else {
+            encryptedFile = _spoolToSecureTempFile(
+                    ((SheetInput<InputStream>) src).getRaw(),
+                    "jackson-spreadsheet-encrypted-");
+            spooledFromStream = true;
+        }
+
+        File decrypted = null;
+        try (POIFSFileSystem fs = _openEncryptedPOIFS(encryptedFile, src)) {
+            final EncryptionInfo info;
+            try {
+                info = new EncryptionInfo(fs);
+            } catch (IOException e) {
+                throw new EncryptedDocumentException(
+                        "Source is not an encrypted OOXML document (password was supplied"
+                                + " but no EncryptionInfo entry found): " + src);
+            } catch (IllegalArgumentException e) {
+                // POI throws this for XLS — keep the type, rewrap with a guide-oriented message.
+                throw new IllegalArgumentException(
+                        "Password protection is supported for OOXML (XLSX) sources only: " + src, e);
+            }
+            final Decryptor d = Decryptor.getInstance(info);
+            try {
+                if (!d.verifyPassword(src.getPassword())) {
+                    throw new EncryptedDocumentException(
+                            "Invalid password for encrypted spreadsheet source: " + src);
+                }
+            } catch (GeneralSecurityException e) {
+                throw new IOException("Failed to verify password for " + src, e);
+            }
+            decrypted = POICompat.createSecureTempFile(
+                    "jackson-spreadsheet-decrypted-", ".xlsx").toFile();
+            try (InputStream plain = d.getDataStream(fs);
+                 FileOutputStream out = new FileOutputStream(decrypted)) {
+                final byte[] buf = new byte[8192];
+                int n;
+                while ((n = plain.read(buf)) != -1) {
+                    out.write(buf, 0, n);
+                }
+            } catch (GeneralSecurityException e) {
+                throw new IOException("Failed to read decrypted data stream for " + src, e);
+            }
+        } catch (IOException | RuntimeException e) {
+            if (decrypted != null) {
+                try { POICompat.releaseTempFile(decrypted.toPath()); }
+                catch (IOException cleanup) { e.addSuppressed(cleanup); }
+            }
+            throw e;
+        } finally {
+            if (spooledFromStream) {
+                try { POICompat.releaseTempFile(encryptedFile.toPath()); }
+                catch (IOException ignore) { /* best effort */ }
+            }
+        }
+        if (log.isDebugEnabled()) {
+            log.debug("Decrypted encrypted source to temp file: {}", decrypted);
+        }
+        return src.isNamed()
+                ? SheetInput.source(decrypted, src.getName())
+                : SheetInput.source(decrypted, src.getIndex());
+    }
+
+    /**
+     * Wraps an encrypted target — plain OOXML is streamed into an
+     * {@link EncryptedTempData} and encrypted on close.
+     */
+    public static SheetOutput<OutputStream> wrapTarget(final SheetOutput<?> out) throws IOException {
+        final EncryptedTempData tempData = new EncryptedTempData();
+        final EncryptionSpec spec = out.getEncryption() != null
+                ? out.getEncryption() : EncryptionSpec.strong();
+        final OutputStream tempStream;
+        try {
+            tempStream = new EncryptOnCloseOutputStream(tempData, out, out.getPassword(), spec);
+        } catch (IOException | RuntimeException e) {
+            tempData.dispose();
+            throw e;
+        }
+        return out.isNamed()
+                ? SheetOutput.target(tempStream, out.getName())
+                : SheetOutput.target(tempStream);
+    }
+
+    @SuppressWarnings("unchecked")
+    static void encryptToTarget(final EncryptedTempData tempData, final SheetOutput<?> out,
+                                final String password, final EncryptionSpec spec) throws IOException {
+        // File targets: write to a sibling temp, then atomic rename — partial bytes never reach the target.
+        final File finalTarget = out.isFile() ? ((SheetOutput<File>) out).getRaw() : null;
+        final File siblingTemp = finalTarget != null
+                ? new File(finalTarget.getAbsoluteFile().getParentFile(),
+                        finalTarget.getName() + ".enc-" + Long.toUnsignedString(System.nanoTime(), 36) + ".tmp")
+                : null;
+        final OutputStream target = (siblingTemp != null)
+                ? Files.newOutputStream(siblingTemp.toPath())
+                : ((SheetOutput<OutputStream>) out).getRaw();
+        boolean writeFinalized = false;
+        IOException primary = null;
+        try {
+            try (InputStream plainIn = tempData.getInputStream();
+                 POIFSFileSystem fs = new POIFSFileSystem();
+                 OPCPackage opc = OPCPackage.open(plainIn)) {
+                final EncryptionInfo info = spec.toEncryptionInfo();
+                final Encryptor enc = Encryptor.getInstance(info);
+                try {
+                    enc.confirmPassword(password);
+                    // OPCPackage.save() only finishes the zip wrap, never closes;
+                    // explicit close commits EncryptionInfo / EncryptedPackage to the POIFS root.
+                    try (OutputStream encStream = enc.getDataStream(fs)) {
+                        opc.save(encStream);
+                    }
+                } catch (GeneralSecurityException e) {
+                    throw new IOException("Failed to encrypt spreadsheet output", e);
+                }
+                fs.writeFilesystem(target);
+                writeFinalized = true;
+            } catch (InvalidFormatException e) {
+                throw new IOException("Failed to open temp data for encryption", e);
+            }
+        } catch (IOException e) {
+            primary = e;
+            throw e;
+        } finally {
+            if (siblingTemp != null) {
+                try {
+                    target.close();
+                } catch (IOException closeEx) {
+                    if (primary != null) primary.addSuppressed(closeEx);
+                    else throw closeEx;
+                }
+                if (writeFinalized) {
+                    try {
+                        Files.move(siblingTemp.toPath(), finalTarget.toPath(),
+                                StandardCopyOption.ATOMIC_MOVE,
+                                StandardCopyOption.REPLACE_EXISTING);
+                    } catch (AtomicMoveNotSupportedException ex) {
+                        // Cross-filesystem — non-atomic, but partial state stays in sibling.
+                        Files.move(siblingTemp.toPath(), finalTarget.toPath(),
+                                StandardCopyOption.REPLACE_EXISTING);
+                    }
+                } else {
+                    // Mid-write failure — delete sibling, leave target untouched.
+                    if (siblingTemp.exists() && !siblingTemp.delete() && log.isWarnEnabled()) {
+                        log.warn("Failed to delete partial encrypted sibling: {}", siblingTemp);
+                    }
+                }
+            }
+        }
+    }
+
+    private static POIFSFileSystem _openEncryptedPOIFS(final File encryptedFile, final SheetInput<?> src)
+            throws IOException {
+        try {
+            return new POIFSFileSystem(encryptedFile, true);
+        } catch (OfficeXmlFileException e) {
+            // Plain OOXML (zip) reaches here as OfficeXmlFileException — POIFSFileSystem only opens OLE2.
+            throw new EncryptedDocumentException(
+                    "Source is not an encrypted OOXML document (password was supplied"
+                            + " but the file is a plain OOXML package): " + src);
+        }
+    }
+
+    private static File _spoolToSecureTempFile(final InputStream in, final String prefix) throws IOException {
+        final File temp = POICompat.createSecureTempFile(prefix, ".tmp").toFile();
+        try (FileOutputStream out = new FileOutputStream(temp)) {
+            final byte[] buf = new byte[8192];
+            int n;
+            while ((n = in.read(buf)) != -1) {
+                out.write(buf, 0, n);
+            }
+        } catch (IOException e) {
+            try { POICompat.releaseTempFile(temp.toPath()); }
+            catch (IOException cleanup) { e.addSuppressed(cleanup); }
+            throw e;
+        }
+        return temp;
+    }
+}

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/ser/SheetOutput.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/ser/SheetOutput.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.EqualsAndHashCode;
 import org.apache.poi.ss.util.WorkbookUtil;
 
+import io.github.scndry.jackson.dataformat.spreadsheet.EncryptionSpec;
 import io.github.scndry.jackson.dataformat.spreadsheet.SheetContent;
 
 /**
@@ -28,15 +29,18 @@ public final class SheetOutput<T> implements SheetContent<T> {
     private final T _raw;
     private final String _name;
     private final String _password;
+    private final EncryptionSpec _encryption;
 
-    private SheetOutput(final T raw, final String name, final String password) {
+    private SheetOutput(final T raw, final String name, final String password,
+                        final EncryptionSpec encryption) {
         _raw = raw;
         _name = name;
         _password = password;
+        _encryption = encryption;
     }
 
     private SheetOutput(final T raw, final String name) {
-        this(raw, name, null);
+        this(raw, name, null, null);
     }
 
     private static void _validateSheetName(final String name) {
@@ -103,18 +107,28 @@ public final class SheetOutput<T> implements SheetContent<T> {
     }
 
     /**
-     * Returns a copy of this {@code SheetOutput} with the given password for
-     * OOXML file-level encryption. Pass {@code null} to clear.
+     * Returns a copy with the given password for OOXML file-level encryption.
+     * Pass {@code null} to clear. When no {@link #withEncryption} is set,
+     * {@link EncryptionSpec#strong()} (agile AES-256 + SHA-512) is used.
      *
-     * <p>Encryption uses agile mode (AES-256 + SHA-512, PBKDF2 100K). For
-     * {@link java.io.File} targets the encrypted output is written to a
+     * <p>For {@link java.io.File} targets the encrypted output is written to a
      * sibling temp and atomically renamed onto the target on close, so
      * mid-write failures leave the original target untouched. For
-     * {@link java.io.OutputStream} targets the bytes are written directly
-     * and the stream is not closed by this library.
+     * {@link java.io.OutputStream} targets the bytes are written directly and
+     * the stream is not closed by this library.
      */
     public SheetOutput<T> withPassword(final String password) {
-        return new SheetOutput<>(_raw, _name, password);
+        return new SheetOutput<>(_raw, _name, password, _encryption);
+    }
+
+    /**
+     * Returns a copy with the given {@link EncryptionSpec} (strength /
+     * compatibility / cipher trade-off). Pass {@code null} to fall back to the
+     * default {@link EncryptionSpec#strong()}. Effective only when a password
+     * is also set.
+     */
+    public SheetOutput<T> withEncryption(final EncryptionSpec encryption) {
+        return new SheetOutput<>(_raw, _name, _password, encryption);
     }
 
     @Override
@@ -126,10 +140,14 @@ public final class SheetOutput<T> implements SheetContent<T> {
     @JsonIgnore
     public String getPassword() { return _password; }
 
+    @JsonIgnore
+    public EncryptionSpec getEncryption() { return _encryption; }
+
     @Override
     public String toString() {
         return "SheetOutput(raw=" + _raw + ", name=" + _name
-                + ", password=" + (_password == null ? "null" : "***") + ")";
+                + ", password=" + (_password == null ? "null" : "***")
+                + ", encryption=" + (_encryption == null ? "default" : _encryption) + ")";
     }
 
 }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/ser/SheetOutput.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/ser/SheetOutput.java
@@ -9,6 +9,7 @@ import org.apache.poi.ss.util.WorkbookUtil;
 
 import io.github.scndry.jackson.dataformat.spreadsheet.EncryptionSpec;
 import io.github.scndry.jackson.dataformat.spreadsheet.SheetContent;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.Incubating;
 
 /**
  * Immutable descriptor for a spreadsheet write target. Wraps a
@@ -108,6 +109,7 @@ public final class SheetOutput<T> implements SheetContent<T> {
      * Returns a copy with the given password for OOXML file-level encryption
      * using {@link EncryptionSpec#strong()}. Pass {@code null} to clear.
      */
+    @Incubating
     public SheetOutput<T> withPassword(final String password) {
         return new SheetOutput<>(_raw, _name, password, null);
     }
@@ -117,6 +119,7 @@ public final class SheetOutput<T> implements SheetContent<T> {
      * A {@code null} spec uses {@link EncryptionSpec#strong()}; a {@code null}
      * password clears both.
      */
+    @Incubating
     public SheetOutput<T> withPassword(final String password, final EncryptionSpec encryption) {
         return new SheetOutput<>(_raw, _name, password, password == null ? null : encryption);
     }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/ser/SheetOutput.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/ser/SheetOutput.java
@@ -108,8 +108,8 @@ public final class SheetOutput<T> implements SheetContent<T> {
 
     /**
      * Returns a copy with the given password for OOXML file-level encryption,
-     * using {@link EncryptionSpec#balanced()} (agile AES-128 + SHA-512 —
-     * matches Excel's native default). Pass {@code null} to clear.
+     * using {@link EncryptionSpec#strong()} (agile AES-256 + SHA-512). Pass
+     * {@code null} to clear.
      *
      * <p>For {@link java.io.File} targets the encrypted output is written to a
      * sibling temp and atomically renamed onto the target on close, so
@@ -124,7 +124,7 @@ public final class SheetOutput<T> implements SheetContent<T> {
     /**
      * Returns a copy with the given password and {@link EncryptionSpec}. The
      * spec selects the strength / compatibility / cipher trade-off. A
-     * {@code null} spec falls back to {@link EncryptionSpec#balanced()}. A
+     * {@code null} spec falls back to {@link EncryptionSpec#strong()}. A
      * {@code null} password clears both.
      */
     public SheetOutput<T> withPassword(final String password, final EncryptionSpec encryption) {

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/ser/SheetOutput.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/ser/SheetOutput.java
@@ -107,9 +107,9 @@ public final class SheetOutput<T> implements SheetContent<T> {
     }
 
     /**
-     * Returns a copy with the given password for OOXML file-level encryption.
-     * Pass {@code null} to clear. When no {@link #withEncryption} is set,
-     * {@link EncryptionSpec#strong()} (agile AES-256 + SHA-512) is used.
+     * Returns a copy with the given password for OOXML file-level encryption,
+     * using {@link EncryptionSpec#strong()} (agile AES-256 + SHA-512). Pass
+     * {@code null} to clear.
      *
      * <p>For {@link java.io.File} targets the encrypted output is written to a
      * sibling temp and atomically renamed onto the target on close, so
@@ -118,17 +118,17 @@ public final class SheetOutput<T> implements SheetContent<T> {
      * the stream is not closed by this library.
      */
     public SheetOutput<T> withPassword(final String password) {
-        return new SheetOutput<>(_raw, _name, password, _encryption);
+        return new SheetOutput<>(_raw, _name, password, null);
     }
 
     /**
-     * Returns a copy with the given {@link EncryptionSpec} (strength /
-     * compatibility / cipher trade-off). Pass {@code null} to fall back to the
-     * default {@link EncryptionSpec#strong()}. Effective only when a password
-     * is also set.
+     * Returns a copy with the given password and {@link EncryptionSpec}. The
+     * spec selects the strength / compatibility / cipher trade-off. A
+     * {@code null} spec falls back to {@link EncryptionSpec#strong()}. A
+     * {@code null} password clears both.
      */
-    public SheetOutput<T> withEncryption(final EncryptionSpec encryption) {
-        return new SheetOutput<>(_raw, _name, _password, encryption);
+    public SheetOutput<T> withPassword(final String password, final EncryptionSpec encryption) {
+        return new SheetOutput<>(_raw, _name, password, password == null ? null : encryption);
     }
 
     @Override

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/ser/SheetOutput.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/ser/SheetOutput.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.io.OutputStream;
 import java.nio.file.Path;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import lombok.EqualsAndHashCode;
 import org.apache.poi.ss.util.WorkbookUtil;
 
@@ -129,10 +127,8 @@ public final class SheetOutput<T> implements SheetContent<T> {
     @Override
     public String getName() { return _name; }
 
-    @JsonIgnore
     public String getPassword() { return _password; }
 
-    @JsonIgnore
     public EncryptionSpec getEncryption() { return _encryption; }
 
     @Override

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/ser/SheetOutput.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/ser/SheetOutput.java
@@ -4,6 +4,8 @@ import java.io.File;
 import java.io.OutputStream;
 import java.nio.file.Path;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import lombok.EqualsAndHashCode;
 import org.apache.poi.ss.util.WorkbookUtil;
 
@@ -104,12 +106,12 @@ public final class SheetOutput<T> implements SheetContent<T> {
      * Returns a copy of this {@code SheetOutput} with the given password for
      * OOXML file-level encryption. Pass {@code null} to clear.
      *
-     * <p>Encryption uses agile mode with AES-256 + SHA-512 (PBKDF2, 100K spin).
-     * The writer streams plain OOXML into an {@code EncryptedTempData}
-     * (AES-128-CBC, in-memory random key) so the intermediate bytes on disk
-     * cannot be decrypted even if the temp survives a crash. The encrypted
-     * output lands on the original target only after the generator closes;
-     * if the write fails mid-flight, the partial target file is deleted.
+     * <p>Encryption uses agile mode (AES-256 + SHA-512, PBKDF2 100K). For
+     * {@link java.io.File} targets the encrypted output is written to a
+     * sibling temp and atomically renamed onto the target on close, so
+     * mid-write failures leave the original target untouched. For
+     * {@link java.io.OutputStream} targets the bytes are written directly
+     * and the stream is not closed by this library.
      */
     public SheetOutput<T> withPassword(final String password) {
         return new SheetOutput<>(_raw, _name, password);
@@ -121,6 +123,7 @@ public final class SheetOutput<T> implements SheetContent<T> {
     @Override
     public String getName() { return _name; }
 
+    @JsonIgnore
     public String getPassword() { return _password; }
 
     @Override

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/ser/SheetOutput.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/ser/SheetOutput.java
@@ -107,25 +107,17 @@ public final class SheetOutput<T> implements SheetContent<T> {
     }
 
     /**
-     * Returns a copy with the given password for OOXML file-level encryption,
-     * using {@link EncryptionSpec#strong()} (agile AES-256 + SHA-512). Pass
-     * {@code null} to clear.
-     *
-     * <p>For {@link java.io.File} targets the encrypted output is written to a
-     * sibling temp and atomically renamed onto the target on close, so
-     * mid-write failures leave the original target untouched. For
-     * {@link java.io.OutputStream} targets the bytes are written directly and
-     * the stream is not closed by this library.
+     * Returns a copy with the given password for OOXML file-level encryption
+     * using {@link EncryptionSpec#strong()}. Pass {@code null} to clear.
      */
     public SheetOutput<T> withPassword(final String password) {
         return new SheetOutput<>(_raw, _name, password, null);
     }
 
     /**
-     * Returns a copy with the given password and {@link EncryptionSpec}. The
-     * spec selects the strength / compatibility / cipher trade-off. A
-     * {@code null} spec falls back to {@link EncryptionSpec#strong()}. A
-     * {@code null} password clears both.
+     * Returns a copy with the given password and {@link EncryptionSpec}.
+     * A {@code null} spec uses {@link EncryptionSpec#strong()}; a {@code null}
+     * password clears both.
      */
     public SheetOutput<T> withPassword(final String password, final EncryptionSpec encryption) {
         return new SheetOutput<>(_raw, _name, password, password == null ? null : encryption);

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/ser/SheetOutput.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/ser/SheetOutput.java
@@ -25,10 +25,16 @@ public final class SheetOutput<T> implements SheetContent<T> {
 
     private final T _raw;
     private final String _name;
+    private final String _password;
 
-    private SheetOutput(final T raw, final String name) {
+    private SheetOutput(final T raw, final String name, final String password) {
         _raw = raw;
         _name = name;
+        _password = password;
+    }
+
+    private SheetOutput(final T raw, final String name) {
+        this(raw, name, null);
     }
 
     private static void _validateSheetName(final String name) {
@@ -94,15 +100,33 @@ public final class SheetOutput<T> implements SheetContent<T> {
         return new SheetOutput<>(raw, sheetName);
     }
 
+    /**
+     * Returns a copy of this {@code SheetOutput} with the given password for
+     * OOXML file-level encryption. Pass {@code null} to clear.
+     *
+     * <p>Encryption uses agile mode with AES-256 + SHA-512 (PBKDF2, 100K spin).
+     * The writer streams plain OOXML into an {@code EncryptedTempData}
+     * (AES-128-CBC, in-memory random key) so the intermediate bytes on disk
+     * cannot be decrypted even if the temp survives a crash. The encrypted
+     * output lands on the original target only after the generator closes;
+     * if the write fails mid-flight, the partial target file is deleted.
+     */
+    public SheetOutput<T> withPassword(final String password) {
+        return new SheetOutput<>(_raw, _name, password);
+    }
+
     @Override
     public T getRaw() { return _raw; }
 
     @Override
     public String getName() { return _name; }
 
+    public String getPassword() { return _password; }
+
     @Override
     public String toString() {
-        return "SheetOutput(raw=" + _raw + ", name=" + _name + ")";
+        return "SheetOutput(raw=" + _raw + ", name=" + _name
+                + ", password=" + (_password == null ? "null" : "***") + ")";
     }
 
 }

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/ser/SheetOutput.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/ser/SheetOutput.java
@@ -108,8 +108,8 @@ public final class SheetOutput<T> implements SheetContent<T> {
 
     /**
      * Returns a copy with the given password for OOXML file-level encryption,
-     * using {@link EncryptionSpec#strong()} (agile AES-256 + SHA-512). Pass
-     * {@code null} to clear.
+     * using {@link EncryptionSpec#balanced()} (agile AES-128 + SHA-512 —
+     * matches Excel's native default). Pass {@code null} to clear.
      *
      * <p>For {@link java.io.File} targets the encrypted output is written to a
      * sibling temp and atomically renamed onto the target on close, so
@@ -124,7 +124,7 @@ public final class SheetOutput<T> implements SheetContent<T> {
     /**
      * Returns a copy with the given password and {@link EncryptionSpec}. The
      * spec selects the strength / compatibility / cipher trade-off. A
-     * {@code null} spec falls back to {@link EncryptionSpec#strong()}. A
+     * {@code null} spec falls back to {@link EncryptionSpec#balanced()}. A
      * {@code null} password clears both.
      */
     public SheetOutput<T> withPassword(final String password, final EncryptionSpec encryption) {

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/EncryptedRoundTripTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/EncryptedRoundTripTest.java
@@ -1,0 +1,102 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.poi.EncryptedDocumentException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+import io.github.scndry.jackson.dataformat.spreadsheet.deser.SheetInput;
+import io.github.scndry.jackson.dataformat.spreadsheet.ser.SheetOutput;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class EncryptedRoundTripTest {
+
+    @TempDir Path tempDir;
+
+    @DataGrid
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class Employee {
+        @DataColumn String name;
+        @DataColumn int salary;
+    }
+
+    @Test
+    void roundTrip_encryptedFile() throws Exception {
+        final File file = tempDir.resolve("encrypted.xlsx").toFile();
+        final List<Employee> input = Arrays.asList(
+                new Employee("Alice", 80000),
+                new Employee("Bob", 65000));
+
+        final SpreadsheetMapper mapper = new SpreadsheetMapper();
+        mapper.writeValue(
+                SheetOutput.target(file).withPassword("secret"),
+                input, Employee.class);
+
+        assertThat(file).exists();
+        assertThat(file.length()).isGreaterThan(0L);
+
+        final List<Employee> output = mapper.readValues(
+                SheetInput.source(file).withPassword("secret"),
+                Employee.class);
+        assertThat(output).isEqualTo(input);
+    }
+
+    @Test
+    void read_wrongPassword_throws() throws Exception {
+        final File file = tempDir.resolve("wrong-pwd.xlsx").toFile();
+        final SpreadsheetMapper mapper = new SpreadsheetMapper();
+        mapper.writeValue(
+                SheetOutput.target(file).withPassword("secret"),
+                Collections.singletonList(new Employee("A", 1)),
+                Employee.class);
+
+        assertThatThrownBy(() -> mapper.readValues(
+                SheetInput.source(file).withPassword("wrong"),
+                Employee.class))
+                .isInstanceOf(EncryptedDocumentException.class)
+                .hasMessageContaining("Invalid password");
+    }
+
+    @Test
+    void read_plainFile_withPassword_throws() throws Exception {
+        final File file = tempDir.resolve("plain.xlsx").toFile();
+        final SpreadsheetMapper mapper = new SpreadsheetMapper();
+        mapper.writeValue(file,
+                Collections.singletonList(new Employee("A", 1)),
+                Employee.class);
+
+        assertThatThrownBy(() -> mapper.readValues(
+                SheetInput.source(file).withPassword("secret"),
+                Employee.class))
+                .isInstanceOf(EncryptedDocumentException.class)
+                .hasMessageContaining("not an encrypted OOXML document");
+    }
+
+    @Test
+    void roundTrip_namedSheet() throws Exception {
+        final File file = tempDir.resolve("named.xlsx").toFile();
+        final List<Employee> input = Collections.singletonList(new Employee("Alice", 80000));
+
+        final SpreadsheetMapper mapper = new SpreadsheetMapper();
+        mapper.writeValue(
+                SheetOutput.target(file, "People").withPassword("secret"),
+                input, Employee.class);
+
+        final List<Employee> output = mapper.readValues(
+                SheetInput.source(file, "People").withPassword("secret"),
+                Employee.class);
+        assertThat(output).isEqualTo(input);
+    }
+}

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/EncryptedRoundTripTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/EncryptedRoundTripTest.java
@@ -1,6 +1,7 @@
 package io.github.scndry.jackson.dataformat.spreadsheet;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
@@ -13,6 +14,8 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.apache.poi.EncryptedDocumentException;
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -163,6 +166,67 @@ class EncryptedRoundTripTest {
                 SheetInput.source(file).withPassword("secret"),
                 Employee.class);
         assertThat(output).isEqualTo(input);
+    }
+
+    @Test
+    void roundTrip_sxssfEncrypted() throws Exception {
+        final File file = tempDir.resolve("sxssf.xlsx").toFile();
+        final List<Employee> input = SAMPLE;
+        final SpreadsheetMapper mapper = sxssfMapper();
+
+        mapper.writeValue(
+                SheetOutput.target(file).withPassword("secret"),
+                input, Employee.class);
+        final List<Employee> output = new SpreadsheetMapper().readValues(
+                SheetInput.source(file).withPassword("secret"),
+                Employee.class);
+        assertThat(output).isEqualTo(input);
+    }
+
+    @Test
+    void read_xlsFile_withPassword_throws() throws Exception {
+        final File file = makeXlsFile("plain.xls");
+        final SpreadsheetMapper mapper = new SpreadsheetMapper();
+
+        assertThatThrownBy(() -> mapper.readValues(
+                SheetInput.source(file).withPassword("secret"),
+                Employee.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("OOXML (XLSX) sources only");
+    }
+
+    @Test
+    void write_xlsTarget_withPassword_throws() throws Exception {
+        final File file = tempDir.resolve("out.xls").toFile();
+        final SpreadsheetMapper mapper = hssfMapper();
+
+        assertThatThrownBy(() -> mapper.writeValue(
+                SheetOutput.target(file).withPassword("secret"),
+                SAMPLE, Employee.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("OOXML (XLSX) targets only");
+    }
+
+    private File makeXlsFile(final String name) throws Exception {
+        final File file = tempDir.resolve(name).toFile();
+        try (HSSFWorkbook wb = new HSSFWorkbook();
+             FileOutputStream fos = new FileOutputStream(file)) {
+            wb.createSheet().createRow(0).createCell(0).setCellValue("x");
+            wb.write(fos);
+        }
+        return file;
+    }
+
+    private static SpreadsheetMapper hssfMapper() {
+        return new SpreadsheetMapper(
+                new SpreadsheetFactory(HSSFWorkbook::new,
+                        SpreadsheetFactory.DEFAULT_SHEET_PARSER_FEATURE_FLAGS));
+    }
+
+    private static SpreadsheetMapper sxssfMapper() {
+        return new SpreadsheetMapper(
+                new SpreadsheetFactory(SXSSFWorkbook::new,
+                        SpreadsheetFactory.DEFAULT_SHEET_PARSER_FEATURE_FLAGS));
     }
 
     private static SpreadsheetMapper poiMapper() {

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/EncryptedRoundTripTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/EncryptedRoundTripTest.java
@@ -1,6 +1,9 @@
 package io.github.scndry.jackson.dataformat.spreadsheet;
 
 import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
@@ -99,4 +102,76 @@ class EncryptedRoundTripTest {
                 Employee.class);
         assertThat(output).isEqualTo(input);
     }
+
+    @Test
+    void roundTrip_poiUserModel() throws Exception {
+        final File file = tempDir.resolve("poi-um.xlsx").toFile();
+        final List<Employee> input = SAMPLE;
+        final SpreadsheetMapper mapper = poiMapper();
+
+        mapper.writeValue(
+                SheetOutput.target(file).withPassword("secret"),
+                input, Employee.class);
+        final List<Employee> output = mapper.readValues(
+                SheetInput.source(file).withPassword("secret"),
+                Employee.class);
+        assertThat(output).isEqualTo(input);
+    }
+
+    @Test
+    void roundTrip_streamRaw() throws Exception {
+        final File file = tempDir.resolve("stream.xlsx").toFile();
+        final List<Employee> input = SAMPLE;
+        final SpreadsheetMapper mapper = new SpreadsheetMapper();
+
+        try (OutputStream out = Files.newOutputStream(file.toPath())) {
+            mapper.writeValue(
+                    SheetOutput.target(out).withPassword("secret"),
+                    input, Employee.class);
+        }
+        try (InputStream in = Files.newInputStream(file.toPath())) {
+            final List<Employee> output = mapper.readValues(
+                    SheetInput.source(in).withPassword("secret"),
+                    Employee.class);
+            assertThat(output).isEqualTo(input);
+        }
+    }
+
+    @Test
+    void crossPath_ssmlWriteEncrypt_poiReadDecrypt() throws Exception {
+        final File file = tempDir.resolve("cross-sw-pr.xlsx").toFile();
+        final List<Employee> input = SAMPLE;
+
+        new SpreadsheetMapper().writeValue(
+                SheetOutput.target(file).withPassword("secret"),
+                input, Employee.class);
+        final List<Employee> output = poiMapper().readValues(
+                SheetInput.source(file).withPassword("secret"),
+                Employee.class);
+        assertThat(output).isEqualTo(input);
+    }
+
+    @Test
+    void crossPath_poiWriteEncrypt_ssmlReadDecrypt() throws Exception {
+        final File file = tempDir.resolve("cross-pw-sr.xlsx").toFile();
+        final List<Employee> input = SAMPLE;
+
+        poiMapper().writeValue(
+                SheetOutput.target(file).withPassword("secret"),
+                input, Employee.class);
+        final List<Employee> output = new SpreadsheetMapper().readValues(
+                SheetInput.source(file).withPassword("secret"),
+                Employee.class);
+        assertThat(output).isEqualTo(input);
+    }
+
+    private static SpreadsheetMapper poiMapper() {
+        return SpreadsheetMapper.builder()
+                .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL)
+                .build();
+    }
+
+    private static final List<Employee> SAMPLE = Arrays.asList(
+            new Employee("Alice", 80000),
+            new Employee("Bob", 65000));
 }

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/EncryptionSpecTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/EncryptionSpecTest.java
@@ -1,0 +1,103 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataColumn;
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+import io.github.scndry.jackson.dataformat.spreadsheet.deser.SheetInput;
+import io.github.scndry.jackson.dataformat.spreadsheet.ser.SheetOutput;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class EncryptionSpecTest {
+
+    @TempDir Path tempDir;
+
+    @DataGrid
+    @Data @NoArgsConstructor @AllArgsConstructor
+    static class Row {
+        @DataColumn String name;
+        @DataColumn int qty;
+    }
+
+    private static final List<Row> SAMPLE = Arrays.asList(new Row("A", 1), new Row("B", 2));
+
+    private void _roundTrip(final EncryptionSpec spec, final String fileName) throws Exception {
+        final File file = tempDir.resolve(fileName).toFile();
+        final SpreadsheetMapper mapper = new SpreadsheetMapper();
+        mapper.writeValue(
+                SheetOutput.target(file).withPassword("secret").withEncryption(spec),
+                SAMPLE, Row.class);
+        final List<Row> back = mapper.readValues(
+                SheetInput.source(file).withPassword("secret"), Row.class);
+        assertThat(back).isEqualTo(SAMPLE);
+    }
+
+    @Test
+    void preset_strong_roundTrip() throws Exception {
+        _roundTrip(EncryptionSpec.strong(), "strong.xlsx");
+    }
+
+    @Test
+    void preset_balanced_roundTrip() throws Exception {
+        _roundTrip(EncryptionSpec.balanced(), "balanced.xlsx");
+    }
+
+    @Test
+    void preset_legacy_roundTrip() throws Exception {
+        _roundTrip(EncryptionSpec.legacy(), "legacy.xlsx");
+    }
+
+    @Test
+    void preset_fast_roundTrip() throws Exception {
+        _roundTrip(EncryptionSpec.fast(), "fast.xlsx");
+    }
+
+    @Test
+    void custom_aes192_sha384_roundTrip() throws Exception {
+        _roundTrip(EncryptionSpec.custom()
+                .cipher(EncryptionSpec.Cipher.AES_192)
+                .hash(EncryptionSpec.Hash.SHA_384)
+                .build(), "custom-aes192.xlsx");
+    }
+
+    @Test
+    void default_strong_whenNoExplicitSpec() throws Exception {
+        final File file = tempDir.resolve("default.xlsx").toFile();
+        final SpreadsheetMapper mapper = new SpreadsheetMapper();
+        // No withEncryption() → defaults to strong()
+        mapper.writeValue(
+                SheetOutput.target(file).withPassword("secret"),
+                SAMPLE, Row.class);
+        final List<Row> back = mapper.readValues(
+                SheetInput.source(file).withPassword("secret"), Row.class);
+        assertThat(back).isEqualTo(SAMPLE);
+    }
+
+    @Test
+    void custom_invalidCombo_aes256OnLegacy_throws() {
+        assertThatThrownBy(() -> EncryptionSpec.custom()
+                .compatibility(EncryptionSpec.Compatibility.EXCEL_2007_2010)
+                .cipher(EncryptionSpec.Cipher.AES_256)
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not support AES-256");
+    }
+
+    @Test
+    void custom_invalidKeyBits_throws() {
+        assertThatThrownBy(() -> EncryptionSpec.custom().keyBits(160))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("keyBits must be 128, 192, or 256");
+    }
+}

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/EncryptionSpecTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/EncryptionSpecTest.java
@@ -36,7 +36,7 @@ class EncryptionSpecTest {
         final File file = tempDir.resolve(fileName).toFile();
         final SpreadsheetMapper mapper = new SpreadsheetMapper();
         mapper.writeValue(
-                SheetOutput.target(file).withPassword("secret").withEncryption(spec),
+                SheetOutput.target(file).withPassword("secret", spec),
                 SAMPLE, Row.class);
         final List<Row> back = mapper.readValues(
                 SheetInput.source(file).withPassword("secret"), Row.class);

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/EncryptionSpecTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/EncryptionSpecTest.java
@@ -75,7 +75,7 @@ class EncryptionSpecTest {
     void default_strong_whenNoExplicitSpec() throws Exception {
         final File file = tempDir.resolve("default.xlsx").toFile();
         final SpreadsheetMapper mapper = new SpreadsheetMapper();
-        // No withEncryption() → defaults to strong()
+        // No spec arg → defaults to strong()
         mapper.writeValue(
                 SheetOutput.target(file).withPassword("secret"),
                 SAMPLE, Row.class);

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/PasswordLeakAuditTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/PasswordLeakAuditTest.java
@@ -11,9 +11,6 @@ import io.github.scndry.jackson.dataformat.spreadsheet.ser.SheetOutput;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * SEC-21 — Jackson serialize 의 password leak 검증.
- */
 class PasswordLeakAuditTest {
 
     private static final String SECRET = "MY_VERY_SECRET_PASSWORD";
@@ -23,8 +20,7 @@ class PasswordLeakAuditTest {
         final ObjectMapper m = new ObjectMapper();
         final SheetInput<File> in = SheetInput.source(new File("/tmp/x.xlsx")).withPassword(SECRET);
         final String json = m.writeValueAsString(in);
-        // SEC-21 fail 검출: password 가 JSON 에 포함되면 leak
-        assertThat(json).as("SheetInput JSON 에 password 가 포함 (SEC-21)").doesNotContain(SECRET);
+        assertThat(json).as("password leaked to SheetInput JSON").doesNotContain(SECRET);
     }
 
     @Test
@@ -32,7 +28,7 @@ class PasswordLeakAuditTest {
         final ObjectMapper m = new ObjectMapper();
         final SheetOutput<File> out = SheetOutput.target(new File("/tmp/y.xlsx")).withPassword(SECRET);
         final String json = m.writeValueAsString(out);
-        assertThat(json).as("SheetOutput JSON 에 password 가 포함 (SEC-21)").doesNotContain(SECRET);
+        assertThat(json).as("password leaked to SheetOutput JSON").doesNotContain(SECRET);
     }
 
     @Test

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/PasswordLeakAuditTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/PasswordLeakAuditTest.java
@@ -2,8 +2,6 @@ package io.github.scndry.jackson.dataformat.spreadsheet;
 
 import java.io.File;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.junit.jupiter.api.Test;
 
 import io.github.scndry.jackson.dataformat.spreadsheet.deser.SheetInput;
@@ -14,22 +12,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class PasswordLeakAuditTest {
 
     private static final String SECRET = "MY_VERY_SECRET_PASSWORD";
-
-    @Test
-    void sheetInput_objectMapper_writeValueAsString_password_leak() throws Exception {
-        final ObjectMapper m = new ObjectMapper();
-        final SheetInput<File> in = SheetInput.source(new File("/tmp/x.xlsx")).withPassword(SECRET);
-        final String json = m.writeValueAsString(in);
-        assertThat(json).as("password leaked to SheetInput JSON").doesNotContain(SECRET);
-    }
-
-    @Test
-    void sheetOutput_objectMapper_writeValueAsString_password_leak() throws Exception {
-        final ObjectMapper m = new ObjectMapper();
-        final SheetOutput<File> out = SheetOutput.target(new File("/tmp/y.xlsx")).withPassword(SECRET);
-        final String json = m.writeValueAsString(out);
-        assertThat(json).as("password leaked to SheetOutput JSON").doesNotContain(SECRET);
-    }
 
     @Test
     void sheetInput_toString_password_masked() {

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/PasswordLeakAuditTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/PasswordLeakAuditTest.java
@@ -1,0 +1,53 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import java.io.File;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.deser.SheetInput;
+import io.github.scndry.jackson.dataformat.spreadsheet.ser.SheetOutput;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * SEC-21 — Jackson serialize 의 password leak 검증.
+ */
+class PasswordLeakAuditTest {
+
+    private static final String SECRET = "MY_VERY_SECRET_PASSWORD";
+
+    @Test
+    void sheetInput_objectMapper_writeValueAsString_password_leak() throws Exception {
+        final ObjectMapper m = new ObjectMapper();
+        final SheetInput<File> in = SheetInput.source(new File("/tmp/x.xlsx")).withPassword(SECRET);
+        final String json = m.writeValueAsString(in);
+        // SEC-21 fail 검출: password 가 JSON 에 포함되면 leak
+        assertThat(json).as("SheetInput JSON 에 password 가 포함 (SEC-21)").doesNotContain(SECRET);
+    }
+
+    @Test
+    void sheetOutput_objectMapper_writeValueAsString_password_leak() throws Exception {
+        final ObjectMapper m = new ObjectMapper();
+        final SheetOutput<File> out = SheetOutput.target(new File("/tmp/y.xlsx")).withPassword(SECRET);
+        final String json = m.writeValueAsString(out);
+        assertThat(json).as("SheetOutput JSON 에 password 가 포함 (SEC-21)").doesNotContain(SECRET);
+    }
+
+    @Test
+    void sheetInput_toString_password_masked() {
+        final SheetInput<File> in = SheetInput.source(new File("/tmp/x.xlsx")).withPassword(SECRET);
+        final String s = in.toString();
+        assertThat(s).doesNotContain(SECRET);
+        assertThat(s).contains("password=***");
+    }
+
+    @Test
+    void sheetOutput_toString_password_masked() {
+        final SheetOutput<File> out = SheetOutput.target(new File("/tmp/y.xlsx")).withPassword(SECRET);
+        final String s = out.toString();
+        assertThat(s).doesNotContain(SECRET);
+        assertThat(s).contains("password=***");
+    }
+}


### PR DESCRIPTION
## Summary

- `SheetInput` / `SheetOutput` gain `withPassword(String)`; `SheetOutput.withPassword(String, EncryptionSpec)` lets the caller pick a preset. Read and write share the descriptor and round-trip through Jackson's standard `mapper.readValues` / `mapper.writeValue` surface.
- `EncryptionSpec` exposes four presets (`strong`, `balanced`, `legacy`, `fast`) plus a `custom()` builder. Default is `strong()` (AES-256 + SHA-512, agile). `EncryptionSpec` and the three `withPassword` overloads carry `@Incubating`.
- XLS targets are rejected. The write path probes `Workbook.getSpreadsheetVersion()` before any wrap; the read path catches POI's BIFF detection inside `EncryptionInfo` and re-throws with a guide-oriented message, preserving the POI error as the cause.
- Encryption flow lives in `OoxmlEncryption` (decrypt source, wrap target) and `EncryptOnCloseOutputStream` (encrypt-on-close, atomic sibling rename for file targets) under `poi.ooxml`. `SpreadsheetFactory` delegates the two entry points and drops the POI crypto imports.

## Design context

OOXML password protection is not a transparent byte cipher around the output stream — the wire format is a POIFS container with `EncryptionInfo` and `EncryptedPackage` entries written after the plain OOXML zip is fully assembled. The implementation spools plain OOXML into `EncryptedTempData` and finalises encryption on stream close, so the caller stays on the same `mapper.readValues` / `mapper.writeValue` surface that other Jackson formats use.

XLS is intentionally out of scope. POI's `HSSFWorkbook.setEncryptionMode` javadoc recommends OOXML over BIFF for real security, and the BIFF algorithm space (XOR / RC4 / CryptoAPI) is disjoint from `EncryptionSpec`'s AES/SHA presets.

## Test plan

- [x] `./gradlew test` — full suite passes (default POI 5.5.1 + Jackson 2.21.3).
- [x] `./gradlew test -PpoiVersion=4.1.1 -PjacksonVersion=2.14.0` — full suite passes.
- [x] `EncryptedRoundTripTest` covers file/stream raw round-trip, named-sheet round-trip, USE_POI_USER_MODEL round-trip, SXSSF round-trip (pins `SpreadsheetVersion.EXCEL2007` as the guard predicate so SXSSF is not rejected), SSML↔POI cross-path symmetry, wrong-password and plain-file rejection, XLS read/write rejection.
- [x] `EncryptionSpecTest` covers per-preset round-trip, `custom()` AES-192 + SHA-384 round-trip, default-when-no-spec round-trip, rejection of `EXCEL_2007_2010 + AES_256`, rejection of invalid `keyBits`.
- [x] `PasswordLeakAuditTest` covers `toString()` masking of the password on both `SheetInput` and `SheetOutput`.