### PR TITLE
Add GridConfigurer.protectSheet for sheet-level edit lock

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -279,7 +279,7 @@ The read path and the write path have different relationships with POI:
 | **XLSX write (default)** | Scaffold generation (`XSSFWorkbook.write()`) | StringBuilder streaming for worksheet + SST, zip entry copy for metadata |
 | **Non-streaming write** | `Workbook.write()`, `CellStyle`, `Font` | Schema-driven cell routing, merge logic |
 | **Styling** | `CellStyle` / `Font` API | `StylesBuilder` (fluent builder layer) |
-| **Sheet-level features** | `Sheet.createFreezePane`, `setAutoFilter`, `ConditionalFormatting` API | `GridConfigurer` (fluent builder layer) |
+| **Sheet-level features** | `Sheet.createFreezePane`, `setAutoFilter`, `protectSheet`, `ConditionalFormatting` API | `GridConfigurer` (fluent builder layer) |
 
 By default, both XLSX read and write paths bypass POI's User Model — the read path uses direct StAX parsing, the write path uses StringBuilder streaming with a POI scaffold for package metadata. Non-streaming paths (XLS, or XLSX with `USE_POI_USER_MODEL`) use POI's full User Model.
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -741,12 +741,13 @@ SpreadsheetMapper mapper = SpreadsheetMapper.builder()
     .gridConfigurer(new GridConfigurer()
         .freezePane(0, 1)
         .autoFilter()
+        .protectSheet("secret")
         .conditionalFormatting("score",
             greaterThanOrEqual(80).style("highlight")))
     .build();
 ```
 
-`freezePane(colSplit, rowSplit)` freezes the leftmost columns / topmost rows. `autoFilter()` enables the filter dropdown across all schema columns. Both work identically on streaming and `USE_POI_USER_MODEL` write paths.
+`freezePane(colSplit, rowSplit)` freezes the leftmost columns / topmost rows. `autoFilter()` enables the filter dropdown across all schema columns. `protectSheet(password)` enables sheet protection — for discouraging edits, not strong file-level encryption (see [File-Level Encryption](#file-level-encryption) for the latter). All three work identically on streaming and `USE_POI_USER_MODEL` write paths.
 
 ### Conditional Formatting
 
@@ -957,7 +958,7 @@ SpreadsheetMapper mapper = SpreadsheetMapper.builder()
 List<Row> rows = mapper.readValues(inputStream, Row.class);
 ```
 
-### Password Protection
+### File-Level Encryption
 
 OOXML files can be encrypted with a password. The same `withPassword` applies to both directions.
 
@@ -1009,7 +1010,7 @@ SpreadsheetMapper mapper = SpreadsheetMapper.builder()
     .build();
 ```
 
-This protects the temp file only — the output XLSX is not encrypted. For full-file XLSX encryption, see [Password Protection](#password-protection).
+This protects the temp file only — the output XLSX is not encrypted. For full-file XLSX encryption, see [File-Level Encryption](#file-level-encryption).
 
 Requires `com.h2database:h2` on the classpath:
 

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/grid/GridConfigurer.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/grid/GridConfigurer.java
@@ -17,8 +17,8 @@ import io.github.scndry.jackson.dataformat.spreadsheet.schema.Styles;
 import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.SpreadsheetSchemaImpl;
 
 /**
- * Configurer for sheet-level features: freeze pane, auto filter, and conditional formatting.
- * Conditional formatting rules reference style names declared in
+ * Configurer for sheet-level features: freeze pane, auto filter, conditional formatting,
+ * and sheet protection. Conditional formatting rules reference style names declared in
  * {@link io.github.scndry.jackson.dataformat.spreadsheet.schema.style.StylesBuilder}.
  */
 public final class GridConfigurer {
@@ -26,6 +26,7 @@ public final class GridConfigurer {
     private int _freezePaneColSplit = -1;
     private int _freezePaneRowSplit = -1;
     private boolean _autoFilter;
+    private String _protectSheetPassword;
     private final List<ColumnRule> _columnRules = new ArrayList<>();
 
     private static final class ColumnRule {
@@ -45,6 +46,12 @@ public final class GridConfigurer {
 
     public GridConfigurer autoFilter() {
         _autoFilter = true;
+        return this;
+    }
+
+    @Incubating
+    public GridConfigurer protectSheet(final String password) {
+        _protectSheetPassword = password;
         return this;
     }
 
@@ -93,6 +100,7 @@ public final class GridConfigurer {
             final SpreadsheetSchemaImpl schema, final int lastRow) {
         _applyFreezePane(sheet);
         _applyAutoFilter(sheet, schema, lastRow);
+        _applyProtectSheet(sheet);
         _applyConditionalFormattings(sheet, styles, schema, lastRow);
     }
 
@@ -113,6 +121,12 @@ public final class GridConfigurer {
                 ? sheet.getWorkbook().getSpreadsheetVersion().getMaxRows() - 1
                 : lastRow;
         sheet.setAutoFilter(new CellRangeAddress(firstRow, endRow, firstCol, lastCol));
+    }
+
+    private void _applyProtectSheet(final Sheet sheet) {
+        if (_protectSheetPassword != null) {
+            sheet.protectSheet(_protectSheetPassword);
+        }
     }
 
     private void _applyConditionalFormattings(final Sheet sheet, final Styles styles,

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/SheetProtectionTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/SheetProtectionTest.java
@@ -1,0 +1,160 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.grid.GridConfigurer;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.poi.openxml4j.opc.OPCPackage;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import static io.github.scndry.jackson.dataformat.spreadsheet.OpcXmlHelper.NS_SPREADSHEETML;
+import static io.github.scndry.jackson.dataformat.spreadsheet.OpcXmlHelper.parsePart;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SheetProtectionTest {
+
+    @TempDir File tempDir;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @DataGrid
+    static class Item {
+        private String name;
+        private int value;
+    }
+
+    @Test
+    void poiPathProtectSheet() throws Exception {
+        File file = new File(tempDir, "sp-poi.xlsx");
+        List<Item> data = Arrays.asList(new Item("A", 1), new Item("B", 2));
+
+        SpreadsheetMapper mapper = SpreadsheetMapper.builder()
+                .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL)
+                .gridConfigurer(new GridConfigurer().protectSheet("secret"))
+                .build();
+        mapper.writeValue(file, data, Item.class);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            assertThat(wb.getSheetAt(0).getProtect()).isTrue();
+        }
+    }
+
+    @Test
+    void ssmlPathProtectSheet() throws Exception {
+        File file = new File(tempDir, "sp-ssml.xlsx");
+        List<Item> data = Arrays.asList(new Item("A", 1), new Item("B", 2));
+
+        SpreadsheetMapper mapper = SpreadsheetMapper.builder()
+                .gridConfigurer(new GridConfigurer().protectSheet("secret"))
+                .build();
+        mapper.writeValue(file, data, Item.class);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            assertThat(wb.getSheetAt(0).getProtect()).isTrue();
+        }
+    }
+
+    @Test
+    void noProtectSheetByDefault() throws Exception {
+        File file = new File(tempDir, "sp-none.xlsx");
+        List<Item> data = Arrays.asList(new Item("A", 1));
+
+        new SpreadsheetMapper().writeValue(file, data, Item.class);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            assertThat(wb.getSheetAt(0).getProtect()).isFalse();
+        }
+    }
+
+    @Test
+    void dataIntegrityWithProtectSheet() throws Exception {
+        File file = new File(tempDir, "sp-roundtrip.xlsx");
+        List<Item> data = Arrays.asList(new Item("A", 1), new Item("B", 2));
+
+        SpreadsheetMapper mapper = SpreadsheetMapper.builder()
+                .gridConfigurer(new GridConfigurer().protectSheet("secret"))
+                .build();
+        mapper.writeValue(file, data, Item.class);
+
+        List<Item> read = new SpreadsheetMapper().readValues(file, Item.class);
+        assertThat(read).isEqualTo(data);
+    }
+
+    @Test
+    void nullPasswordClears() throws Exception {
+        File file = new File(tempDir, "sp-null.xlsx");
+        List<Item> data = Arrays.asList(new Item("A", 1));
+
+        SpreadsheetMapper mapper = SpreadsheetMapper.builder()
+                .gridConfigurer(new GridConfigurer().protectSheet("secret").protectSheet(null))
+                .build();
+        mapper.writeValue(file, data, Item.class);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            assertThat(wb.getSheetAt(0).getProtect()).isFalse();
+        }
+    }
+
+    @Test
+    void wrongPasswordRejected() throws Exception {
+        File file = new File(tempDir, "sp-validate.xlsx");
+        List<Item> data = Arrays.asList(new Item("A", 1));
+
+        SpreadsheetMapper mapper = SpreadsheetMapper.builder()
+                .gridConfigurer(new GridConfigurer().protectSheet("secret"))
+                .build();
+        mapper.writeValue(file, data, Item.class);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            XSSFSheet sheet = wb.getSheetAt(0);
+            assertThat(sheet.validateSheetPassword("secret")).isTrue();
+            assertThat(sheet.validateSheetPassword("wrong")).isFalse();
+        }
+    }
+
+    @Test
+    void domEquivalence() throws Exception {
+        File ssmlFile = new File(tempDir, "sp-dom-ssml.xlsx");
+        File poiFile = new File(tempDir, "sp-dom-poi.xlsx");
+        List<Item> data = Arrays.asList(new Item("A", 1), new Item("B", 2));
+
+        SpreadsheetMapper ssmlMapper = SpreadsheetMapper.builder()
+                .gridConfigurer(new GridConfigurer().protectSheet("secret"))
+                .build();
+        ssmlMapper.writeValue(ssmlFile, data, Item.class);
+
+        SpreadsheetMapper poiMapper = SpreadsheetMapper.builder()
+                .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL)
+                .gridConfigurer(new GridConfigurer().protectSheet("secret"))
+                .build();
+        poiMapper.writeValue(poiFile, data, Item.class);
+
+        try (OPCPackage expPkg = OPCPackage.open(poiFile);
+             OPCPackage actPkg = OPCPackage.open(ssmlFile)) {
+            Document expDoc = parsePart(expPkg, "/xl/worksheets/sheet1.xml");
+            Document actDoc = parsePart(actPkg, "/xl/worksheets/sheet1.xml");
+
+            NodeList expProt = expDoc.getElementsByTagNameNS(NS_SPREADSHEETML, "sheetProtection");
+            NodeList actProt = actDoc.getElementsByTagNameNS(NS_SPREADSHEETML, "sheetProtection");
+            assertThat(actProt.getLength())
+                    .as("sheetProtection element count")
+                    .isEqualTo(expProt.getLength());
+            for (int i = 0; i < expProt.getLength(); i++) {
+                assertThat(actProt.item(i).isEqualNode(expProt.item(i)))
+                        .as("sheetProtection[%d] DOM equality", i)
+                        .isTrue();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `GridConfigurer.protectSheet(String password)` — sheet-level edit lock via POI's `Sheet.protectSheet`. Locks the sheet plus objects and scenarios (POI's default for sheet protection).
- Works on both POI and SSML write paths without dedicated SSML emit code: the scaffold sheet's `protectSheet` call lands in the worksheet XML between `sheetData` and `protectedRanges` (xsd order), so SSML prefix/suffix split keeps it intact.
- For discouraging edits, not strong protection — POI's default is the legacy XOR password (~16-bit hash, Excel 2010 format). For strong file-level encryption use `SheetOutput.withPassword` (chapter renamed to "File-Level Encryption" in GUIDE).

## Test plan

- [x] `SheetProtectionTest` — 7 tests: POI/SSML write paths, default behaviour, round-trip data integrity, null password clears, wrong password rejected, POI vs SSML DOM equivalence of the emitted `<sheetProtection>` element
- [x] Full test suite — no regressions