### PR TITLE
Add GridConfigurer display options for sheet view rendering

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -279,7 +279,7 @@ The read path and the write path have different relationships with POI:
 | **XLSX write (default)** | Scaffold generation (`XSSFWorkbook.write()`) | StringBuilder streaming for worksheet + SST, zip entry copy for metadata |
 | **Non-streaming write** | `Workbook.write()`, `CellStyle`, `Font` | Schema-driven cell routing, merge logic |
 | **Styling** | `CellStyle` / `Font` API | `StylesBuilder` (fluent builder layer) |
-| **Sheet-level features** | `Sheet.createFreezePane`, `setAutoFilter`, `protectSheet`, `ConditionalFormatting` API | `GridConfigurer` (fluent builder layer) |
+| **Sheet-level features** | `Sheet.createFreezePane`, `setAutoFilter`, `protectSheet`, `setDisplayGridlines`, `setZoom`, `setRightToLeft`, `ConditionalFormatting` API | `GridConfigurer` (fluent builder layer) |
 
 By default, both XLSX read and write paths bypass POI's User Model — the read path uses direct StAX parsing, the write path uses StringBuilder streaming with a POI scaffold for package metadata. Non-streaming paths (XLS, or XLSX with `USE_POI_USER_MODEL`) use POI's full User Model.
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -742,12 +742,15 @@ SpreadsheetMapper mapper = SpreadsheetMapper.builder()
         .freezePane(0, 1)
         .autoFilter()
         .protectSheet("secret")
+        .displayGridlines(false)
+        .zoom(125)
+        .rightToLeft(true)
         .conditionalFormatting("score",
             greaterThanOrEqual(80).style("highlight")))
     .build();
 ```
 
-`freezePane(colSplit, rowSplit)` freezes the leftmost columns / topmost rows. `autoFilter()` enables the filter dropdown across all schema columns. `protectSheet(password)` enables sheet protection — for discouraging edits, not strong file-level encryption (see [File-Level Encryption](#file-level-encryption) for the latter). All three work identically on streaming and `USE_POI_USER_MODEL` write paths.
+`freezePane(colSplit, rowSplit)` freezes the leftmost columns / topmost rows. `autoFilter()` enables the filter dropdown across all schema columns. `protectSheet(password)` enables sheet protection — for discouraging edits, not strong file-level encryption (see [File-Level Encryption](#file-level-encryption) for the latter). `displayGridlines(boolean)`, `zoom(int percent)`, and `rightToLeft(boolean)` control sheet view rendering. All work identically on streaming and `USE_POI_USER_MODEL` write paths.
 
 ### Conditional Formatting
 

--- a/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/grid/GridConfigurer.java
+++ b/src/main/java/io/github/scndry/jackson/dataformat/spreadsheet/schema/grid/GridConfigurer.java
@@ -18,13 +18,17 @@ import io.github.scndry.jackson.dataformat.spreadsheet.schema.internal.Spreadshe
 
 /**
  * Configurer for sheet-level features: freeze pane, auto filter, conditional formatting,
- * and sheet protection. Conditional formatting rules reference style names declared in
+ * sheet protection, display gridlines, zoom, and right-to-left. Conditional formatting
+ * rules reference style names declared in
  * {@link io.github.scndry.jackson.dataformat.spreadsheet.schema.style.StylesBuilder}.
  */
 public final class GridConfigurer {
 
     private int _freezePaneColSplit = -1;
     private int _freezePaneRowSplit = -1;
+    private Boolean _displayGridlines;
+    private int _zoom = -1;
+    private Boolean _rightToLeft;
     private boolean _autoFilter;
     private String _protectSheetPassword;
     private final List<ColumnRule> _columnRules = new ArrayList<>();
@@ -41,6 +45,24 @@ public final class GridConfigurer {
     public GridConfigurer freezePane(final int colSplit, final int rowSplit) {
         _freezePaneColSplit = colSplit;
         _freezePaneRowSplit = rowSplit;
+        return this;
+    }
+
+    @Incubating
+    public GridConfigurer displayGridlines(final boolean show) {
+        _displayGridlines = show;
+        return this;
+    }
+
+    @Incubating
+    public GridConfigurer zoom(final int percent) {
+        _zoom = percent;
+        return this;
+    }
+
+    @Incubating
+    public GridConfigurer rightToLeft(final boolean value) {
+        _rightToLeft = value;
         return this;
     }
 
@@ -99,6 +121,9 @@ public final class GridConfigurer {
     public void apply(final Sheet sheet, final Styles styles,
             final SpreadsheetSchemaImpl schema, final int lastRow) {
         _applyFreezePane(sheet);
+        _applyDisplayGridlines(sheet);
+        _applyZoom(sheet);
+        _applyRightToLeft(sheet);
         _applyAutoFilter(sheet, schema, lastRow);
         _applyProtectSheet(sheet);
         _applyConditionalFormattings(sheet, styles, schema, lastRow);
@@ -109,6 +134,24 @@ public final class GridConfigurer {
             sheet.createFreezePane(
                     Math.max(_freezePaneColSplit, 0),
                     Math.max(_freezePaneRowSplit, 0));
+        }
+    }
+
+    private void _applyDisplayGridlines(final Sheet sheet) {
+        if (_displayGridlines != null) {
+            sheet.setDisplayGridlines(_displayGridlines);
+        }
+    }
+
+    private void _applyZoom(final Sheet sheet) {
+        if (_zoom > 0) {
+            sheet.setZoom(_zoom);
+        }
+    }
+
+    private void _applyRightToLeft(final Sheet sheet) {
+        if (_rightToLeft != null) {
+            sheet.setRightToLeft(_rightToLeft);
         }
     }
 

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/DisplayGridlinesTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/DisplayGridlinesTest.java
@@ -1,0 +1,127 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.grid.GridConfigurer;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.poi.openxml4j.opc.OPCPackage;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import static io.github.scndry.jackson.dataformat.spreadsheet.OpcXmlHelper.NS_SPREADSHEETML;
+import static io.github.scndry.jackson.dataformat.spreadsheet.OpcXmlHelper.parsePart;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DisplayGridlinesTest {
+
+    @TempDir File tempDir;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @DataGrid
+    static class Item {
+        private String name;
+        private int value;
+    }
+
+    @Test
+    void poiPathHideGridlines() throws Exception {
+        File file = new File(tempDir, "hg-poi.xlsx");
+        List<Item> data = Arrays.asList(new Item("A", 1), new Item("B", 2));
+
+        SpreadsheetMapper mapper = SpreadsheetMapper.builder()
+                .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL)
+                .gridConfigurer(new GridConfigurer().displayGridlines(false))
+                .build();
+        mapper.writeValue(file, data, Item.class);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            assertThat(wb.getSheetAt(0).isDisplayGridlines()).isFalse();
+        }
+    }
+
+    @Test
+    void ssmlPathHideGridlines() throws Exception {
+        File file = new File(tempDir, "hg-ssml.xlsx");
+        List<Item> data = Arrays.asList(new Item("A", 1), new Item("B", 2));
+
+        SpreadsheetMapper mapper = SpreadsheetMapper.builder()
+                .gridConfigurer(new GridConfigurer().displayGridlines(false))
+                .build();
+        mapper.writeValue(file, data, Item.class);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            assertThat(wb.getSheetAt(0).isDisplayGridlines()).isFalse();
+        }
+    }
+
+    @Test
+    void gridlinesShownByDefault() throws Exception {
+        File file = new File(tempDir, "hg-default.xlsx");
+        List<Item> data = Arrays.asList(new Item("A", 1));
+
+        new SpreadsheetMapper().writeValue(file, data, Item.class);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            assertThat(wb.getSheetAt(0).isDisplayGridlines()).isTrue();
+        }
+    }
+
+    @Test
+    void dataIntegrityWithHideGridlines() throws Exception {
+        File file = new File(tempDir, "hg-roundtrip.xlsx");
+        List<Item> data = Arrays.asList(new Item("A", 1), new Item("B", 2));
+
+        SpreadsheetMapper mapper = SpreadsheetMapper.builder()
+                .gridConfigurer(new GridConfigurer().displayGridlines(false))
+                .build();
+        mapper.writeValue(file, data, Item.class);
+
+        List<Item> read = new SpreadsheetMapper().readValues(file, Item.class);
+        assertThat(read).isEqualTo(data);
+    }
+
+    @Test
+    void domEquivalence() throws Exception {
+        File ssmlFile = new File(tempDir, "hg-dom-ssml.xlsx");
+        File poiFile = new File(tempDir, "hg-dom-poi.xlsx");
+        List<Item> data = Arrays.asList(new Item("A", 1), new Item("B", 2));
+
+        SpreadsheetMapper ssmlMapper = SpreadsheetMapper.builder()
+                .gridConfigurer(new GridConfigurer().displayGridlines(false))
+                .build();
+        ssmlMapper.writeValue(ssmlFile, data, Item.class);
+
+        SpreadsheetMapper poiMapper = SpreadsheetMapper.builder()
+                .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL)
+                .gridConfigurer(new GridConfigurer().displayGridlines(false))
+                .build();
+        poiMapper.writeValue(poiFile, data, Item.class);
+
+        try (OPCPackage expPkg = OPCPackage.open(poiFile);
+             OPCPackage actPkg = OPCPackage.open(ssmlFile)) {
+            Document expDoc = parsePart(expPkg, "/xl/worksheets/sheet1.xml");
+            Document actDoc = parsePart(actPkg, "/xl/worksheets/sheet1.xml");
+
+            NodeList expViews = expDoc.getElementsByTagNameNS(NS_SPREADSHEETML, "sheetView");
+            NodeList actViews = actDoc.getElementsByTagNameNS(NS_SPREADSHEETML, "sheetView");
+            assertThat(actViews.getLength())
+                    .as("sheetView element count")
+                    .isEqualTo(expViews.getLength());
+            for (int i = 0; i < expViews.getLength(); i++) {
+                assertThat(actViews.item(i).isEqualNode(expViews.item(i)))
+                        .as("sheetView[%d] DOM equality", i)
+                        .isTrue();
+            }
+        }
+    }
+}

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/RightToLeftTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/RightToLeftTest.java
@@ -1,0 +1,127 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.grid.GridConfigurer;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.poi.openxml4j.opc.OPCPackage;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import static io.github.scndry.jackson.dataformat.spreadsheet.OpcXmlHelper.NS_SPREADSHEETML;
+import static io.github.scndry.jackson.dataformat.spreadsheet.OpcXmlHelper.parsePart;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RightToLeftTest {
+
+    @TempDir File tempDir;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @DataGrid
+    static class Item {
+        private String name;
+        private int value;
+    }
+
+    @Test
+    void poiPathRightToLeft() throws Exception {
+        File file = new File(tempDir, "rtl-poi.xlsx");
+        List<Item> data = Arrays.asList(new Item("A", 1), new Item("B", 2));
+
+        SpreadsheetMapper mapper = SpreadsheetMapper.builder()
+                .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL)
+                .gridConfigurer(new GridConfigurer().rightToLeft(true))
+                .build();
+        mapper.writeValue(file, data, Item.class);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            assertThat(wb.getSheetAt(0).isRightToLeft()).isTrue();
+        }
+    }
+
+    @Test
+    void ssmlPathRightToLeft() throws Exception {
+        File file = new File(tempDir, "rtl-ssml.xlsx");
+        List<Item> data = Arrays.asList(new Item("A", 1), new Item("B", 2));
+
+        SpreadsheetMapper mapper = SpreadsheetMapper.builder()
+                .gridConfigurer(new GridConfigurer().rightToLeft(true))
+                .build();
+        mapper.writeValue(file, data, Item.class);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            assertThat(wb.getSheetAt(0).isRightToLeft()).isTrue();
+        }
+    }
+
+    @Test
+    void leftToRightByDefault() throws Exception {
+        File file = new File(tempDir, "rtl-default.xlsx");
+        List<Item> data = Arrays.asList(new Item("A", 1));
+
+        new SpreadsheetMapper().writeValue(file, data, Item.class);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            assertThat(wb.getSheetAt(0).isRightToLeft()).isFalse();
+        }
+    }
+
+    @Test
+    void dataIntegrityWithRightToLeft() throws Exception {
+        File file = new File(tempDir, "rtl-roundtrip.xlsx");
+        List<Item> data = Arrays.asList(new Item("A", 1), new Item("B", 2));
+
+        SpreadsheetMapper mapper = SpreadsheetMapper.builder()
+                .gridConfigurer(new GridConfigurer().rightToLeft(true))
+                .build();
+        mapper.writeValue(file, data, Item.class);
+
+        List<Item> read = new SpreadsheetMapper().readValues(file, Item.class);
+        assertThat(read).isEqualTo(data);
+    }
+
+    @Test
+    void domEquivalence() throws Exception {
+        File ssmlFile = new File(tempDir, "rtl-dom-ssml.xlsx");
+        File poiFile = new File(tempDir, "rtl-dom-poi.xlsx");
+        List<Item> data = Arrays.asList(new Item("A", 1), new Item("B", 2));
+
+        SpreadsheetMapper ssmlMapper = SpreadsheetMapper.builder()
+                .gridConfigurer(new GridConfigurer().rightToLeft(true))
+                .build();
+        ssmlMapper.writeValue(ssmlFile, data, Item.class);
+
+        SpreadsheetMapper poiMapper = SpreadsheetMapper.builder()
+                .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL)
+                .gridConfigurer(new GridConfigurer().rightToLeft(true))
+                .build();
+        poiMapper.writeValue(poiFile, data, Item.class);
+
+        try (OPCPackage expPkg = OPCPackage.open(poiFile);
+             OPCPackage actPkg = OPCPackage.open(ssmlFile)) {
+            Document expDoc = parsePart(expPkg, "/xl/worksheets/sheet1.xml");
+            Document actDoc = parsePart(actPkg, "/xl/worksheets/sheet1.xml");
+
+            NodeList expViews = expDoc.getElementsByTagNameNS(NS_SPREADSHEETML, "sheetView");
+            NodeList actViews = actDoc.getElementsByTagNameNS(NS_SPREADSHEETML, "sheetView");
+            assertThat(actViews.getLength())
+                    .as("sheetView element count")
+                    .isEqualTo(expViews.getLength());
+            for (int i = 0; i < expViews.getLength(); i++) {
+                assertThat(actViews.item(i).isEqualNode(expViews.item(i)))
+                        .as("sheetView[%d] DOM equality", i)
+                        .isTrue();
+            }
+        }
+    }
+}

--- a/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/ZoomTest.java
+++ b/src/test/java/io/github/scndry/jackson/dataformat/spreadsheet/ZoomTest.java
@@ -1,0 +1,139 @@
+package io.github.scndry.jackson.dataformat.spreadsheet;
+
+import io.github.scndry.jackson.dataformat.spreadsheet.annotation.DataGrid;
+import io.github.scndry.jackson.dataformat.spreadsheet.schema.grid.GridConfigurer;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.poi.openxml4j.opc.OPCPackage;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import static io.github.scndry.jackson.dataformat.spreadsheet.OpcXmlHelper.NS_SPREADSHEETML;
+import static io.github.scndry.jackson.dataformat.spreadsheet.OpcXmlHelper.parsePart;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ZoomTest {
+
+    @TempDir File tempDir;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @DataGrid
+    static class Item {
+        private String name;
+        private int value;
+    }
+
+    @Test
+    void poiPathZoom() throws Exception {
+        File file = new File(tempDir, "zm-poi.xlsx");
+        List<Item> data = Arrays.asList(new Item("A", 1), new Item("B", 2));
+
+        SpreadsheetMapper mapper = SpreadsheetMapper.builder()
+                .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL)
+                .gridConfigurer(new GridConfigurer().zoom(150))
+                .build();
+        mapper.writeValue(file, data, Item.class);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            XSSFSheet sheet = wb.getSheetAt(0);
+            assertThat(sheet.getCTWorksheet().getSheetViews().getSheetViewArray(0).getZoomScale())
+                    .isEqualTo(150);
+        }
+    }
+
+    @Test
+    void ssmlPathZoom() throws Exception {
+        File file = new File(tempDir, "zm-ssml.xlsx");
+        List<Item> data = Arrays.asList(new Item("A", 1), new Item("B", 2));
+
+        SpreadsheetMapper mapper = SpreadsheetMapper.builder()
+                .gridConfigurer(new GridConfigurer().zoom(150))
+                .build();
+        mapper.writeValue(file, data, Item.class);
+
+        try (XSSFWorkbook wb = new XSSFWorkbook(file)) {
+            XSSFSheet sheet = wb.getSheetAt(0);
+            assertThat(sheet.getCTWorksheet().getSheetViews().getSheetViewArray(0).getZoomScale())
+                    .isEqualTo(150);
+        }
+    }
+
+    @Test
+    void noZoomByDefault() throws Exception {
+        File file = new File(tempDir, "zm-default.xlsx");
+        List<Item> data = Arrays.asList(new Item("A", 1));
+
+        new SpreadsheetMapper().writeValue(file, data, Item.class);
+
+        try (OPCPackage pkg = OPCPackage.open(file)) {
+            Document doc = parsePart(pkg, "/xl/worksheets/sheet1.xml");
+            NodeList views = doc.getElementsByTagNameNS(NS_SPREADSHEETML, "sheetView");
+            assertThat(views.getLength()).isPositive();
+            Element view = (Element) views.item(0);
+            assertThat(view.getAttribute("zoomScale"))
+                    .as("zoomScale attribute absent by default")
+                    .isEmpty();
+        }
+    }
+
+    @Test
+    void dataIntegrityWithZoom() throws Exception {
+        File file = new File(tempDir, "zm-roundtrip.xlsx");
+        List<Item> data = Arrays.asList(new Item("A", 1), new Item("B", 2));
+
+        SpreadsheetMapper mapper = SpreadsheetMapper.builder()
+                .gridConfigurer(new GridConfigurer().zoom(125))
+                .build();
+        mapper.writeValue(file, data, Item.class);
+
+        List<Item> read = new SpreadsheetMapper().readValues(file, Item.class);
+        assertThat(read).isEqualTo(data);
+    }
+
+    @Test
+    void domEquivalence() throws Exception {
+        File ssmlFile = new File(tempDir, "zm-dom-ssml.xlsx");
+        File poiFile = new File(tempDir, "zm-dom-poi.xlsx");
+        List<Item> data = Arrays.asList(new Item("A", 1), new Item("B", 2));
+
+        SpreadsheetMapper ssmlMapper = SpreadsheetMapper.builder()
+                .gridConfigurer(new GridConfigurer().zoom(150))
+                .build();
+        ssmlMapper.writeValue(ssmlFile, data, Item.class);
+
+        SpreadsheetMapper poiMapper = SpreadsheetMapper.builder()
+                .enable(SpreadsheetFactory.Feature.USE_POI_USER_MODEL)
+                .gridConfigurer(new GridConfigurer().zoom(150))
+                .build();
+        poiMapper.writeValue(poiFile, data, Item.class);
+
+        try (OPCPackage expPkg = OPCPackage.open(poiFile);
+             OPCPackage actPkg = OPCPackage.open(ssmlFile)) {
+            Document expDoc = parsePart(expPkg, "/xl/worksheets/sheet1.xml");
+            Document actDoc = parsePart(actPkg, "/xl/worksheets/sheet1.xml");
+
+            NodeList expViews = expDoc.getElementsByTagNameNS(NS_SPREADSHEETML, "sheetView");
+            NodeList actViews = actDoc.getElementsByTagNameNS(NS_SPREADSHEETML, "sheetView");
+            assertThat(actViews.getLength())
+                    .as("sheetView element count")
+                    .isEqualTo(expViews.getLength());
+            for (int i = 0; i < expViews.getLength(); i++) {
+                assertThat(actViews.item(i).isEqualNode(expViews.item(i)))
+                        .as("sheetView[%d] DOM equality", i)
+                        .isTrue();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `GridConfigurer.displayGridlines(boolean show)`, `zoom(int percent)`, and `rightToLeft(boolean value)` — POI signature aligned.
- All three land in the worksheet XML `<sheetViews>` element. Works on both POI and SSML write paths through the existing scaffold serialize / prefix-suffix split — no dedicated SSML emit code.
- Boolean fields use nullable wrapper (`Boolean`) so unset (default) vs explicit-true/false are distinguishable.

## Test plan

- [x] `DisplayGridlinesTest` — 5 tests: POI/SSML write paths, default behaviour, round-trip data integrity, POI vs SSML DOM equivalence
- [x] `ZoomTest` — 5 tests: POI/SSML write paths, no zoom attribute by default, round-trip, DOM equivalence
- [x] `RightToLeftTest` — 5 tests: POI/SSML write paths, default left-to-right, round-trip, DOM equivalence
- [x] Full test suite — no regressions